### PR TITLE
Fix generated import statements

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -541,10 +541,6 @@ func RegisterUniquePackageName(pkg string, f *FileDescriptor) string {
 	// Convert dots to underscores before finding a unique alias.
 	pkg = strings.Map(badToUnderscore, pkg)
 
-	for i, orig := 1, pkg; pkgNamesInUse[pkg]; i++ {
-		// It's a duplicate; must rename.
-		pkg = orig + strconv.Itoa(i)
-	}
 	// Install it.
 	pkgNamesInUse[pkg] = true
 	if f != nil {
@@ -1149,13 +1145,25 @@ func (g *Generator) generateImports() {
 	if !g.file.proto3 {
 		g.P("import " + g.Pkg["math"] + ` "math"`)
 	}
+
+	// Track imported packages
+	imported := make(map[string]bool)
+
 	for i, s := range g.file.Dependency {
 		fd := g.fileByName(s)
 		// Do not import our own package.
 		if fd.PackageName() == g.packageName {
 			continue
 		}
-		filename := goFileName(s)
+
+		// Skip duplicated imports
+		if imported[fd.PackageName()] {
+			continue
+		}
+		imported[fd.PackageName()] = true
+
+		// Import the package name, rather than the file name
+		filename := goFileDir(s)
 		if substitution, ok := g.ImportMap[s]; ok {
 			filename = substitution
 		}
@@ -2000,6 +2008,11 @@ func goFileName(name string) string {
 		name = name[0 : len(name)-len(ext)]
 	}
 	return name + ".pb.go"
+}
+
+// Given a .proto file name, return the directory
+func goFileDir(name string) string {
+	return path.Dir(name)
 }
 
 // Is this field optional?


### PR DESCRIPTION
(via @mattoddie)

As described in #8 and #10 the import statements written to the generated `.pb.go` files don't seem to work as expected, which results in import statements trying to import files ending in `.pb` rather than the package - eg. `import foo "foo/foo.pb"` rather than `import foo "foo"`.

I'm uncertain if this is due to incorrect usage on my part, as our import statements are usually fully qualified import paths, such as:
`import "github.com/<org>/<repo>/proto/common/common.proto";`
which I would expect to generate an import statement of:
`import common "github.com/<org>/<repo>/proto/common"`
_not_:
`import common "github.com/<org>/<repo>/proto/common/common.pb"`

This patch determines the directory that the proto file exists in, and uses that for the import, rather than stripping off `.go` from the filename. It also stops duplicate imports being given unique names, by incrementing each, so we can just import the package.