### PR TITLE
Document the grpc plugin usage for protoc

### DIFF
--- a/README
+++ b/README
@@ -146,3 +146,10 @@ To create and play with a Test object from the example package,
 		}
 		// etc.
 	}
+
+gRPC Support
+============
+
+To generate code from .protos with gRPC support, you'll need to explicitly enable the grpc plugin:
+
+    protoc --go_out=plugins=grpc:. path/to/thing.proto


### PR DESCRIPTION
This was a bit non-obvious until I ended up locating https://github.com/grpc/grpc-go/blob/master/codegen.sh

Calling this out directly in these docs I think will be helpful.