### PR TITLE
add bson note after json comment, "xx, omitempty"

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1543,7 +1543,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		usedNames[fieldName] = true
 		typename, wiretype := g.GoType(message, field)
 		jsonName := *field.Name
-		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
+		tag := fmt.Sprintf("protobuf:%s json:%q bson:%q", g.goTag(message, field, wiretype), jsonName+",omitempty", jsonName+",omitempty")
 
 		if *field.Type == descriptor.FieldDescriptorProto_TYPE_MESSAGE {
 			desc := g.ObjectNamed(field.GetTypeName())


### PR DESCRIPTION
bson is widely used in golang communicate with mongodb, for example protobuf escape _id to Xid, but in mongodb `_id` is the primary key, so it need to add bson comment for column definition. 
So I suggest adding `bson` note for struct define, it benefit users using mongo, without any bad effect on others.