### PR TITLE
Fix Make targets

### DIFF
--- a/protoc-gen-go/descriptor/Makefile
+++ b/protoc-gen-go/descriptor/Makefile
@@ -33,10 +33,10 @@
 # at src/google/protobuf/descriptor.proto
 regenerate:
 	echo WARNING! THIS RULE IS PROBABLY NOT RIGHT FOR YOUR INSTALLATION
-	cd $(HOME)/src/protobuf/src && \
-	protoc --go_out=. ./google/protobuf/descriptor.proto && \
-	sed -i 's,^package google_protobuf,package descriptor,' google/protobuf/descriptor.pb.go && \
-	cp ./google/protobuf/descriptor.pb.go $(GOPATH)/src/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go
+	protoc --go_out=. -I$(HOME)/src/protobuf/src $(HOME)/src/protobuf/src/google/protobuf/descriptor.proto && \
+		sed 's,^package google_protobuf,package descriptor,' google/protobuf/descriptor.pb.go > \
+		$(GOPATH)/src/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go && \
+		rm -f google/protobuf/descriptor.pb.go
 
 restore:
 	cp descriptor.pb.golden descriptor.pb.go

--- a/protoc-gen-go/plugin/Makefile
+++ b/protoc-gen-go/plugin/Makefile
@@ -34,10 +34,9 @@
 # Also we need to fix an import.
 regenerate:
 	echo WARNING! THIS RULE IS PROBABLY NOT RIGHT FOR YOUR INSTALLATION
-	cd $(HOME)/src/protobuf/src && \
 	protoc --go_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor:. \
-	  ./google/protobuf/compiler/plugin.proto && \
-	cat ./google/protobuf/compiler/plugin.pb.go > $(GOPATH)/src/github.com/golang/protobuf/protoc-gen-go/plugin/plugin.pb.go
+		-I$(HOME)/src/protobuf/src $(HOME)/src/protobuf/src/google/protobuf/compiler/plugin.proto && \
+		mv google/protobuf/compiler/plugin.pb.go $(GOPATH)/src/github.com/golang/protobuf/protoc-gen-go/plugin
 
 restore:
 	cp plugin.pb.golden plugin.pb.go

--- a/protoc-gen-go/testdata/Makefile
+++ b/protoc-gen-go/testdata/Makefile
@@ -46,15 +46,15 @@ golden:
 
 nuke:	clean
 
-testbuild:	buildprotos
+testbuild:	regenerate
 	go test
 
-buildprotos:
+regenerate:
 	# Invoke protoc once to generate three independent .pb.go files in the same package.
 	protoc --go_out=. multi/multi{1,2,3}.proto
 
 #extension_test:	extension_test.$O
-#	$(LD) -L. -o $@ $< 
+#	$(LD) -L. -o $@ $<
 
 #multi.a: multi3.pb.$O multi2.pb.$O multi1.pb.$O
 #	rm -f multi.a


### PR DESCRIPTION
This PR fixes the make targets by:
- Updating `protoc-gen-go/testdata regenerate`
- Making the `sed` invocation BSD `sed` friendly

It also regenerates the descriptor and plugin protos from google/protobuf at v3.0.0-alpha-3.1.