### PR TITLE
Update README to be Markdown formatted README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Go support for Protocol Buffers - Google's data interchange format
+# Go support for Protocol Buffers - Google's data interchange format
 Copyright 2010 The Go Authors.
 https://github.com/golang/protobuf
 
@@ -7,15 +7,26 @@ This package and the code it generates requires at least Go 1.4.
 This software implements Go bindings for protocol buffers.  For
 information about protocol buffers themselves, see
 	https://developers.google.com/protocol-buffers/
-To use this software, you must first install the standard C++
-implementation of protocol buffers from
-	https://developers.google.com/protocol-buffers/
+
+## Installation
+
+### Install the standard C++ implementation of protocol buffers
+
+To use this software, you must first install
+[the standard C++ implementation of protocol buffers](https://developers.google.com/protocol-buffers/),
+which provides the protocol compiler, `protoc`.
+
+### Install the Go compiler and tools
+
 And of course you must also install the Go compiler and tools from
 	https://golang.org/
+
 See
 	https://golang.org/doc/install
-for details or, if you are using gccgo, follow the instructions at
+for details or, if you are using `gccgo`, follow the instructions at
 	https://golang.org/doc/install/gccgo
+
+### Install the Go protobuf packages
 
 This software has two parts: a 'protocol compiler plugin' that
 generates Go source files that, once compiled, can access and manage
@@ -35,20 +46,24 @@ The simplest way is to run go get.
 	# Grab the code from the repository and install the proto package.
 	go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
 
-The compiler plugin, protoc-gen-go, will be installed in $GOBIN,
-defaulting to $GOPATH/bin.  It must be in your $PATH for the protocol
-compiler, protoc, to find it.
+The compiler plugin, `protoc-gen-go`, will be installed in $GOBIN`,
+defaulting to ``$GOPATH/bin`.  It must be in your `$PATH` for the protocol
+compiler, `protoc`, to find it.
+
+## Using protocol buffers with Go
 
 Once the software is installed, there are two steps to using it.
 First you must compile the protocol buffer definitions and then import
 them, with the support library, into your program.
 
-To compile the protocol buffer definition, run protoc with the --go_out
+To compile the protocol buffer definition, run `protoc` with the `--go_out`
 parameter set to the directory you want to output the Go code to.
 
+```shell
 	protoc --go_out=. *.proto
+```
 
-The generated files will be suffixed .pb.go.  See the Test code below
+The generated files will be suffixed `.pb.go`.  See the Test code below
 for an example using such a file.
 
 
@@ -56,33 +71,33 @@ The package comment for the proto library contains text describing
 the interface provided in Go for protocol buffers. Here is an edited
 version.
 
-==========
+----------
 
 The proto package converts data structures to and from the
 wire format of protocol buffers.  It works in concert with the
 Go source code generated for .proto files by the protocol compiler.
 
 A summary of the properties of the protocol buffer interface
-for a protocol buffer variable v:
+for a protocol buffer variable `v`:
 
-  - Names are turned from camel_case to CamelCase for export.
-  - There are no methods on v to set fields; just treat
+  - Names are turned from `camel_case` to `CamelCase` for export.
+  - There are no methods on `v` to set fields; just treat
   	them as structure fields.
   - There are getters that return a field's value if set,
 	and return the field's default value if unset.
-	The getters work even if the receiver is a nil message.
+	The getters work even if the receiver is a `nil` message.
   - The zero value for a struct is its correct initialization state.
 	All desired fields must be set before marshaling.
-  - A Reset() method will restore a protobuf struct to its zero state.
-  - Non-repeated fields are pointers to the values; nil means unset.
-	That is, optional or required field int32 f becomes F *int32.
+  - A `Reset()` method will restore a protobuf struct to its zero state.
+  - Non-repeated fields are pointers to the values; `nil` means unset.
+	That is, optional or required field `int32 f` becomes `F *int32`.
   - Repeated fields are slices.
   - Helper functions are available to aid the setting of fields.
 	Helpers for getting values are superseded by the
-	GetFoo methods and their use is deprecated.
+	`GetFoo` methods and their use is deprecated.
 		msg.Foo = proto.String("hello") // set field
   - Constants are defined to hold the default values of all fields that
-	have them.  They have the form Default_StructName_FieldName.
+	have them.  They have the form `Default_StructName_FieldName`.
 	Because the getter methods handle defaulted values,
 	direct use of these constants should be rare.
   - Enums are given type names and maps from names to values.
@@ -90,71 +105,74 @@ for a protocol buffer variable v:
 	a String method, and a Enum method to assist in message construction.
   - Nested groups and enums have type names prefixed with the name of
   	the surrounding message type.
-  - Extensions are given descriptor names that start with E_,
+  - Extensions are given descriptor names that start with `E_`,
 	followed by an underscore-delimited list of the nested messages
 	that contain it (if any) followed by the CamelCased name of the
-	extension field itself.  HasExtension, ClearExtension, GetExtension
-	and SetExtension are functions for manipulating extensions.
+	extension field itself.  `HasExtension`, `ClearExtension`, `GetExtension`
+	and `SetExtension` are functions for manipulating extensions.
   - Oneof field sets are given a single field in their message,
 	with distinguished wrapper types for each possible field value.
-  - Marshal and Unmarshal are functions to encode and decode the wire format.
+  - `Marshal` and `Unmarshal` are functions to encode and decode the wire format.
 
-Consider file test.proto, containing
+Consider file `test.proto`, containing
 
-	package example;
-	
-	enum FOO { X = 17; };
-	
-	message Test {
-	  required string label = 1;
-	  optional int32 type = 2 [default=77];
-	  repeated int64 reps = 3;
-	  optional group OptionalGroup = 4 {
-	    required string RequiredField = 5;
-	  }
+```protobuf
+package example;
+
+enum FOO { X = 17; };
+
+message Test {
+  required string label = 1;
+  optional int32 type = 2 [default=77];
+  repeated int64 reps = 3;
+  optional group OptionalGroup = 4 {
+    required string RequiredField = 5;
+  }
+}
+```
+
+To create and play with a `Test` object from the example package,
+
+```go
+package main
+
+import (
+	"log"
+
+	"github.com/golang/protobuf/proto"
+	"path/to/example"
+)
+
+func main() {
+	test := &example.Test {
+		Label: proto.String("hello"),
+		Type:  proto.Int32(17),
+		Optionalgroup: &example.Test_OptionalGroup {
+			RequiredField: proto.String("good bye"),
+		},
 	}
-
-To create and play with a Test object from the example package,
-
-	package main
-
-	import (
-		"log"
-
-		"github.com/golang/protobuf/proto"
-		"path/to/example"
-	)
-
-	func main() {
-		test := &example.Test {
-			Label: proto.String("hello"),
-			Type:  proto.Int32(17),
-			Optionalgroup: &example.Test_OptionalGroup {
-				RequiredField: proto.String("good bye"),
-			},
-		}
-		data, err := proto.Marshal(test)
-		if err != nil {
-			log.Fatal("marshaling error: ", err)
-		}
-		newTest := &example.Test{}
-		err = proto.Unmarshal(data, newTest)
-		if err != nil {
-			log.Fatal("unmarshaling error: ", err)
-		}
-		// Now test and newTest contain the same data.
-		if test.GetLabel() != newTest.GetLabel() {
-			log.Fatalf("data mismatch %q != %q", test.GetLabel(), newTest.GetLabel())
-		}
-		// etc.
+	data, err := proto.Marshal(test)
+	if err != nil {
+		log.Fatal("marshaling error: ", err)
 	}
+	newTest := &example.Test{}
+	err = proto.Unmarshal(data, newTest)
+	if err != nil {
+		log.Fatal("unmarshaling error: ", err)
+	}
+	// Now test and newTest contain the same data.
+	if test.GetLabel() != newTest.GetLabel() {
+		log.Fatalf("data mismatch %q != %q", test.GetLabel(), newTest.GetLabel())
+	}
+	// etc.
+}
+```
 
+## gRPC Support
 
-gRPC Support
-============
 If a proto file specifies RPC services, protoc-gen-go can be instructed to
-generate code compatible with gRPC (http://www.grpc.io/). To do this, pass
-the `plugins` parameter to protoc-gen-go; the usual way is to insert it into
-the --go_out argument to protoc:
+generate code compatible with [gRPC](http://www.grpc.io/). To do this, pass
+the `plugins` parameter to `protoc-gen-go`; the usual way is to insert it into
+the `--go_out` argument to `protoc`:
 
 	protoc --go_out=plugins=grpc:. *.proto


### PR DESCRIPTION
I missed the installation of the C++ protocol buffer compiler step when
I first started. This is because with the plain-text formatting it was
hard to read, so I skipped to the line "to install this code." By adding
headings, it should make this mistake less common.

I also added quotes to enable
[syntax
highlighting](https://help.github.com/articles/github-flavored-markdown/#syntax-highlighting),
but tried to keep edits to a minimum.