### PR TITLE
Change JSON generation to lowerCamelCase

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1665,7 +1665,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		ns := allocNames(base, "Get"+base)
 		fieldName, fieldGetterName := ns[0], ns[1]
 		typename, wiretype := g.GoType(message, field)
-		jsonName := *field.Name
+		jsonName := LowerCamelCase(*field.Name)
 		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
 
 		fieldNames[field] = fieldName
@@ -2410,9 +2410,28 @@ func isASCIILower(c byte) bool {
 	return 'a' <= c && c <= 'z'
 }
 
+// Is c an ASCII upper-case letter?
+func isASCIIUpper(c byte) bool {
+	return 'A' <= c && c <= 'Z'
+}
+
 // Is c an ASCII digit?
 func isASCIIDigit(c byte) bool {
 	return '0' <= c && c <= '9'
+}
+
+// LowerCamelCase(s) returns CamelCase(s), but with the first character forced to lower-case.
+// This is used by JSON field names in protobuf3 JSON encoding, for example.
+func LowerCamelCase(s string) string {
+	s = CamelCase(s)
+	if len(s) > 0 {
+		c := s[0]
+		if isASCIIUpper(c) {
+			c ^= ' ' // Make it a lower-case letter.
+			s = string(c) + s[1:]
+		}
+	}
+	return s
 }
 
 // CamelCase returns the CamelCased name.

--- a/protoc-gen-go/generator/name_test.go
+++ b/protoc-gen-go/generator/name_test.go
@@ -54,3 +54,23 @@ func TestCamelCase(t *testing.T) {
 		}
 	}
 }
+
+func TestLowerCamelCase(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"one", "one"},
+		{"one_two", "oneTwo"},
+		{"_my_field_name_2", "xMyFieldName_2"},
+		{"Something_Capped", "something_Capped"},
+		{"my_Name", "my_Name"},
+		{"OneTwo", "oneTwo"},
+		{"_", "x"},
+		{"_a_", "xA_"},
+	}
+	for _, tc := range tests {
+		if got := LowerCamelCase(tc.in); got != tc.want {
+			t.Errorf("LowerCamelCase(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
According to the proto3 specs, JSON fields are generated using
lowerCamelCase, not UpperCamelCase.

Change the generator to do this.