### PR TITLE
protoc-gen-go: avoid importing own package

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1266,6 +1266,11 @@ func (g *Generator) generateImports() {
 			importPath = substitution
 		}
 		importPath = g.ImportPrefix + importPath
+		// If we know the import path for our own file, and if that
+		// matches the import path for this dependency, skip.
+		if g.PackageImportPath != "" && g.PackageImportPath == importPath {
+			continue
+		}
 		// Skip weak imports.
 		if g.weak(int32(i)) {
 			g.P("// skipping weak import ", fd.PackageName(), " ", strconv.Quote(importPath))


### PR DESCRIPTION
Normally, protoc-gen-go recommends certain conventions to avoid
cyclic imports between generated go files.  Some of these are
documented in:
https://github.com/golang/protobuf/issues/67

This change adds one more mechanism to avoid cycles: if protoc-gen-go
was invoked with import_path parameter set, then it will not generate
import statements for any packages with identical import_path.

This ends up being a simple way of avoiding cycles when all other
options are hard to implement.  For example, the codebase that I'm
working with has 100s of proto files shared between code written in
4 different languages including go.  It's difficult for us to pass
all proto files in a directory to protoc.  Other alternatives
documented in the above issue are even more complex for us to adopt.

In contrast, import_path is easy to set.