### PR TITLE
handle grpc services with no package declaration

### DIFF
--- a/protoc-gen-go/internal/grpc/grpc.go
+++ b/protoc-gen-go/internal/grpc/grpc.go
@@ -134,7 +134,12 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	path := fmt.Sprintf("6,%d", index) // 6 means service.
 
 	origServName := service.GetName()
-	fullServName := file.GetPackage() + "." + origServName
+	var fullServName string
+	if file.GetPackage() == "" {
+		fullServName = origServName
+	} else {
+		fullServName = file.GetPackage() + "." + origServName
+	}
 	servName := generator.CamelCase(origServName)
 
 	g.P()


### PR DESCRIPTION
If a protobuf file for a GRPC service definition has no `package name` declaration, the service name currently generated is `.{{ServiceName}}`.

Clients in other languages seem to expect package-less services to be named ``{{ServiceName}}``.

For instance, in the NodeJS client: https://github.com/grpc/grpc/blob/8bbc4e0ac98901ca83b0f71791fba04ffbd84401/src/node/src/common.js#L92-L96