### PR TITLE
protoc-gen-go: add `url` flag to protobuf fields with json name

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1690,7 +1690,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		fieldName, fieldGetterName := ns[0], ns[1]
 		typename, wiretype := g.GoType(message, field)
 		jsonName := *field.Name
-		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
+		tag := fmt.Sprintf("protobuf:%s json:%q url:%q", g.goTag(message, field, wiretype), jsonName+",omitempty", jsonName+",omitempty")
 
 		fieldNames[field] = fieldName
 		fieldGetterNames[field] = fieldGetterName


### PR DESCRIPTION
Adds support for https://github.com/google/go-querystring

Need to look into tests.