### PR TITLE
Add package_comments parameter to enable or disable generated package comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ parameter list separated from the output directory by a colon:
   rightmost slash is ignored.
 - `plugins=plugin1+plugin2` - specifies the list of sub-plugins to
   load. The only plugin in this repo is `grpc`.
+- `package_comments=false` - will disable package comments in the generated go files
 - `Mfoo/bar.proto=quux/shme` - declares that foo/bar.proto is
   associated with Go package quux/shme.  This is subject to the
   import_prefix parameter.

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -510,16 +510,17 @@ type Generator struct {
 
 	Pkg map[string]string // The names under which we import support packages
 
-	packageName      string                     // What we're calling ourselves.
-	allFiles         []*FileDescriptor          // All files in the tree
-	allFilesByName   map[string]*FileDescriptor // All files by filename.
-	genFiles         []*FileDescriptor          // Those files we will generate output for.
-	file             *FileDescriptor            // The file we are compiling now.
-	usedPackages     map[string]bool            // Names of packages used in current file.
-	typeNameToObject map[string]Object          // Key is a fully-qualified name in input syntax.
-	init             []string                   // Lines to emit in the init function.
-	indent           string
-	writeOutput      bool
+	packageName            string                     // What we're calling ourselves.
+	allFiles               []*FileDescriptor          // All files in the tree
+	allFilesByName         map[string]*FileDescriptor // All files by filename.
+	genFiles               []*FileDescriptor          // Those files we will generate output for.
+	file                   *FileDescriptor            // The file we are compiling now.
+	usedPackages           map[string]bool            // Names of packages used in current file.
+	typeNameToObject       map[string]Object          // Key is a fully-qualified name in input syntax.
+	init                   []string                   // Lines to emit in the init function.
+	indent                 string
+	writeOutput            bool
+	disablePackageComments bool
 }
 
 // New creates a new generator and allocates the request and response protobufs.
@@ -568,6 +569,12 @@ func (g *Generator) CommandLineParameters(parameter string) {
 			g.PackageImportPath = v
 		case "plugins":
 			pluginList = v
+		case "package_comments":
+			packageComments, err := strconv.ParseBool(v)
+			if err != nil {
+				g.Error(err, "expected bool for package_comments")
+			}
+			g.disablePackageComments = !packageComments
 		default:
 			if len(k) > 0 && k[0] == 'M' {
 				g.ImportMap[k[1:]] = v
@@ -1186,7 +1193,7 @@ func (g *Generator) generateHeader() {
 
 	name := g.file.PackageName()
 
-	if g.file.index == 0 {
+	if g.file.index == 0 && !g.disablePackageComments {
 		// Generate package docs for the first file in the package.
 		g.P("/*")
 		g.P("Package ", name, " is a generated protocol buffer package.")


### PR DESCRIPTION
This adds a parameter to enable or disable package comments. A lot of the time, a go package will have generated protobuf code along side it, and the generated package comments will override any other package comments in godoc. Whether or not this is a good design decision is a good debate heh, but that's a separate issue - a lot of users do this (including myself half the time).

By default, package comments will be turned on. To disable:

```
# assuming foo.proto in your current directory
protoc --go_out=package_comments=false:. foo.proto
```