### PR TITLE
Add means to insert version information

### DIFF
--- a/protoc-gen-go/main.go
+++ b/protoc-gen-go/main.go
@@ -49,6 +49,9 @@
 package main
 
 import (
+	"encoding/base64"
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -56,7 +59,23 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/generator"
 )
 
+var (
+	versionBase64 = "dmVyc2lvbi1ub3Qtc2V0" // version-not-set
+	version, _    = base64.StdEncoding.DecodeString(versionBase64)
+)
+
+var (
+	versionShort = flag.Bool("v", false, "Show version details (same as --version).")
+	versionLong  = flag.Bool("version", false, "Show version details (same as -v).")
+)
+
 func main() {
+	flag.Parse()
+	if *versionShort || *versionLong {
+		fmt.Printf("%v: %v\n", os.Args[0], string(version))
+		os.Exit(0)
+	}
+
 	// Begin by allocating a generator. The request and response structures are stored there
 	// so we can do error handling easily - the response structure contains the field to
 	// report failure.


### PR DESCRIPTION
Using ideas from [this thread](https://groups.google.com/forum/#!searchin/golang-nuts/binary$20commit/golang-nuts/Sx3-hgfjZdc/Eiuj6iSfiEYJ)

Particularly useful in CI environments, ensuring developers have the correct version of tools installed etc. Not least because we want to be very clear what version of `protoc-gen-go` we are running vs the 'underlying' [`protoc`](https://github.com/google/protobuf)

```
$ cd $GOPATH/src/github.com/golang/protobuf/protoc-gen-go
$ go build -ldflags "-X main.versionBase64=$(echo -n 'commit 5fc2294' | base64)"
$ ./protoc-gen-go -v
./protoc-gen-go: commit 5fc2294e655b78ed8a02082d37808d46c17d7e64
```