### PR TITLE
Adding repeated field data population example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ To create and play with a Test object from the example package,
 		test := &example.Test {
 			Label: proto.String("hello"),
 			Type:  proto.Int32(17),
+			Reps:  []int64{1, 2, 3},
 			Optionalgroup: &example.Test_OptionalGroup {
 				RequiredField: proto.String("good bye"),
 			},

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -235,6 +235,7 @@ To create and play with a Test object:
 		test := &pb.Test{
 			Label: proto.String("hello"),
 			Type:  proto.Int32(17),
+			Reps:  []int64{1, 2, 3},
 			Optionalgroup: &pb.Test_OptionalGroup{
 				RequiredField: proto.String("good bye"),
 			},


### PR DESCRIPTION
Data population for the 'repeated' field rule was not previously described in the code example. This addition also aids in highlighting the purpose of the proto field helper functions; to return pointers values. At first glance I interpreted them as type wrappers and couldn't understand why I couldn't set Reps to "[]proto.Int64{...}".