### PR TITLE
Add a `package` override parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ parameter list separated from the output directory by a colon:
 - `Mfoo/bar.proto=quux/shme` - declares that foo/bar.proto is
   associated with Go package quux/shme.  This is subject to the
   import_prefix parameter.
+- `package=mypackage` - an explicit package name that will override
+  `go_package` in the generated files.
 
 ## gRPC Support ##
 


### PR DESCRIPTION
The commandline flags allow overriding output location, package import
locations, and the default package name if none is declared. The
`package` flag allows forcing an explicit package name.

Context: we need to move Go code around to break import cycles. I'm
writing a go-protoc-wrapper that interprets `package` and `go_package`
as specifying full package path (like Java does), but that mangles the
declared package.