### PR TITLE
Add Travis configuration to ensure this builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+
+install:
+  - export GOPATH="$HOME/gopath"
+  - mkdir -p "$GOPATH/src/github.com/golang"
+  - mv "$TRAVIS_BUILD_DIR" "$GOPATH/src/github.com/golang/protobuf"
+  - go get -v -t -d github.com/golang/protobuf/...
+
+script:
+  - go test -v github.com/golang/protobuf/...


### PR DESCRIPTION
This should help catch changes where we break support for older versions, such as https://github.com/golang/protobuf/issues/146.

Based loosely on https://github.com/golang/oauth2/blob/master/.travis.yml.

In a conversation with the folks from the google/protobuf over https://github.com/google/protobuf/pull/1316, they would prefer if I move the Go protobuf sample to this repo, so having a Travis config in place can help make sure those are tested, too.