### PR TITLE
add lenient option for parsing json

### DIFF
--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -471,3 +471,31 @@ func TestUnmarshalingBadInput(t *testing.T) {
 		}
 	}
 }
+
+var unmarshalingExtraFields = []struct {
+	desc string
+	in   string
+	pb   proto.Message
+}{
+	{"an unknown field", `{"oBoo1": true}`, new(pb.Simple)},
+}
+
+func TestUnmarshalingExtraFields(t *testing.T) {
+	for _, tt := range unmarshalingExtraFields {
+		unmarshaler := &Unmarshaler{Lenient: false}
+		err := unmarshaler.UnmarshalString(tt.in, tt.pb)
+		if err == nil {
+			t.Errorf("an error was expected when parsing %q instead of an object: %v", tt.desc, err)
+		}
+	}
+}
+
+func TestUnmarshalingExtraFieldsOkIfLenient(t *testing.T) {
+	for _, tt := range unmarshalingExtraFields {
+		unmarshaler := &Unmarshaler{Lenient: true}
+		err := unmarshaler.UnmarshalString(tt.in, tt.pb)
+		if err != nil {
+			t.Errorf("an error was not expected when parsing %q instead of an object: %v", tt.desc, err)
+		}
+	}
+}


### PR DESCRIPTION
This adds an option to make JSON parsing lenient.  For context: https://github.com/google/protobuf/issues/1389

I noticed there was no unmarshaler object for adding options, so I added one of those as well.  I left the old functions around for backwards compatibility.  I'm new to go, so not sure if reusing function names as method names is a nice practice or not?

If this looks like it's going in the right direction, I'll also add the missing doc and comments.