### PR TITLE
Never use `go_package` to munge the output filename

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -316,15 +316,6 @@ func (d *FileDescriptor) goFileName() string {
 	}
 	name += ".pb.go"
 
-	// Does the file have a "go_package" option?
-	// If it does, it may override the filename.
-	if impPath, _, ok := d.goPackageOption(); ok && impPath != "" {
-		// Replace the existing dirname with the declared import path.
-		_, name = path.Split(name)
-		name = path.Join(impPath, name)
-		return name
-	}
-
 	return name
 }
 
@@ -1327,11 +1318,15 @@ func (g *Generator) generateImports() {
 			continue
 		}
 		filename := fd.goFileName()
-		// By default, import path is the dirname of the Go filename.
+		// By default, import path is the dirname of the Go filename. If an explicit
+		// mapping or a go_package declaration is available, use that instead.
 		importPath := path.Dir(filename)
 		if substitution, ok := g.ImportMap[s]; ok {
 			importPath = substitution
+		} else if impPath, _, ok := fd.goPackageOption(); ok && impPath != "" {
+			importPath = impPath
 		}
+
 		importPath = g.ImportPrefix + importPath
 		// Skip weak imports.
 		if g.weak(int32(i)) {


### PR DESCRIPTION
The `go_package` option is useful in defining how the generated files
can be imported. But the existing implementation also changes the
output filename based on it, causing some weird results if you are
running `protoc` from the project root, which is a common operation.

Let me illustrate with an example.

Imagine you're sitting in `$GOPATH/src/github.com/colinmarc/myproject.`
From there, you have the following directory structure:

    foo/
      something.go
      foo.proto
    bar/
      baz/
        baz.proto

foo.proto declares the following:

    option go_package = "github.com/colinmarc/myproject/foo";

and baz.proto wants to import it:

    import "foo/foo.proto";

Now you run `protoc --go_out=. -I. foo/foo.proto`, and the same for
the other file. It works, but the generated files end up in a totally
weird place! Your directory structure now looks like this:

    foo/
      something.go
      foo.proto
    bar/baz/
      baz.proto
    github.com/
      colinmarc/
        myproject/
          foo/
            foo.pb.go
          bar/
            baz/
              baz.pb.go

Which is not useful at all. So you try a few different things. First,
you change the `go_package` declaration in foo.proto, to:

    option go_package = "foo"

Again, everything compiles fine, and this time the generated files
in the right place. But the imports in `baz.pb.go` are broken:

    import "foo"

Which again, is not a thing that makes any sense in go.

Said another way, the `go_package` option is useful if it munges either
the imports *or* the filepath, but not both.

I can't really think of a useful situation for having the generated
file end up in a different place from the .proto file; so this just
removes that functionality altogether. If you generate a file in
the wrong package, the go compiler will fail and tell you that you
have two packages in the same directory - which is exactly what would
happen if you declared the wrong package in a go source file instead
of a protobuf source file.