### PR TITLE
jsonpb: add benchmarks

### DIFF
--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -36,6 +36,7 @@ import (
 	"encoding/json"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -520,6 +521,44 @@ func TestUnmarshalingBadInput(t *testing.T) {
 		err := UnmarshalString(tt.in, tt.pb)
 		if err == nil {
 			t.Errorf("an error was expected when parsing %q instead of an object", tt.desc)
+		}
+	}
+}
+
+func BenchmarkSimpleMarshalPB(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, err := marshaler.MarshalToString(simpleObject)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSimpleMarshalJSON(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, err := json.Marshal(simpleObject)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkSimpleUnmarshalPB(b *testing.B) {
+	var so pb.Simple
+	for n := 0; n < b.N; n++ {
+		err := Unmarshal(strings.NewReader(simpleObjectJSON), &so)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSimpleUnmarshalJSON(b *testing.B) {
+	var so pb.Simple
+	payload := []byte(simpleObjectJSON)
+	for n := 0; n < b.N; n++ {
+		err := json.Unmarshal(payload, &so)
+		if err != nil {
+			b.Fatal(err)
 		}
 	}
 }


### PR DESCRIPTION
Running on my late-2012 MacBook, `jsonpb` is 4x - 10x slower than `encoding/json`.

```
$ go test -bench=. -benchmem
BenchmarkSimpleMarshalPB-4         30000         41738 ns/op        8064 B/op        145 allocs/op
BenchmarkSimpleMarshalJSON-4      300000          4903 ns/op         632 B/op          5 allocs/op
BenchmarkSimpleUnmarshalPB-4       30000         49350 ns/op        6695 B/op        113 allocs/op
BenchmarkSimpleUnmarshalJSON-4    100000         16748 ns/op        1312 B/op         68 allocs/op
```

I don't think this needs to be fixed right now, but I do think it's a good idea to have the benchmarks in the codebase.
