### PR TITLE
Work around gccgo bug (see golang.org/issue/15738)

### DIFF
--- a/proto/message_set_test.go
+++ b/proto/message_set_test.go
@@ -29,6 +29,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// This package having both internal and external tests triggers a surprising
+// bug in gccgo (see https://github.com/golang/go/issues/15738), so don't
+// compile the internal tests with gccgo:
+// +build !gccgo
+
 package proto
 
 import (

--- a/proto/size2_test.go
+++ b/proto/size2_test.go
@@ -29,6 +29,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// This package having both internal and external tests triggers a surprising
+// bug in gccgo (see https://github.com/golang/go/issues/15738), so don't
+// compile the internal tests with gccgo:
+// +build !gccgo
+
 package proto
 
 import (


### PR DESCRIPTION
github.com/golang/protobuf/proto having both internal and external tests
triggers a surprising bug in gccgo. As the bug only affects tests, it seems
reasonable to workaround it by not compiling the internal tests with gccgo.
