### PR TITLE
Make ExtensionDescs not error on empty protos

### DIFF
--- a/proto/extensions.go
+++ b/proto/extensions.go
@@ -500,6 +500,9 @@ func ExtensionDescs(pb Message) ([]*ExtensionDesc, error) {
 	registeredExtensions := RegisteredExtensions(pb)
 
 	emap, mu := epb.extensionsRead()
+	if emap == nil {
+		return nil, nil
+	}
 	mu.Lock()
 	defer mu.Unlock()
 	extensions := make([]*ExtensionDesc, 0, len(emap))

--- a/proto/extensions_test.go
+++ b/proto/extensions_test.go
@@ -101,6 +101,14 @@ func TestExtensionDescsWithMissingExtensions(t *testing.T) {
 	}
 }
 
+func TestExtensionDescsWithEmptyProto(t *testing.T) {
+	msg := &pb.MyMessage{Count: proto.Int32(0)}
+	_, err := proto.ExtensionDescs(msg)
+	if err != nil {
+		t.Fatalf("proto.ExtensionDescs: got error %v", err)
+	}
+}
+
 type ExtensionDescSlice []*proto.ExtensionDesc
 
 func (s ExtensionDescSlice) Len() int           { return len(s) }


### PR DESCRIPTION
When called on a Message with nil XXX_InternalExtensions.p,
ExtensionDescs should not try to lock the nil Mutex returned from
extensionsRead().