### PR TITLE
issue 196 ptypes/regen.sh

### DIFF
--- a/ptypes/regen.sh
+++ b/ptypes/regen.sh
@@ -3,12 +3,19 @@
 # To run this you will need protoc and goprotobuf installed;
 # see https://github.com/golang/protobuf for instructions.
 # You also need Go and Git installed.
+#
+# This is a complete rewrite of the original regen.sh in order to address #196
+# and reduce the reliance on external tools (which might behave differently
+# from system to system) to the bare minimum.
 
+# Set here to make sure it gets acknowledged even
+# in the weirdest of circumstances
 set -Ee
 
 PKG=github.com/golang/protobuf/ptypes
 UPSTREAM=https://github.com/google/protobuf
 UPSTREAM_SUBDIR=src/google/protobuf
+
 
 function die() {
   echo 1>&2 $*
@@ -16,60 +23,57 @@ function die() {
 }
 
 # Sanity check that the right tools are accessible.
-for tool in go git protoc protoc-gen-go; do
+for tool in go git protoc protoc-gen-go find; do
   q=$(which $tool) || die "didn't find $tool"
   echo 1>&2 "$tool: $q"
 done
 
 # Can be use for tests of regen2.sh
-tmpdir=/tmp/upstream
-#tmpdir=$(mktemp -d -t regen-wkt.XXXXXX)
-#git clone -q $UPSTREAM $tmpdir
-#trap 'rm -rf $tmpdir' EXIT
+#tmpdir=/tmp/upstream
+tmpdir=$(mktemp -d -t regen-wkt.XXXXXX)
+git clone $UPSTREAM $tmpdir
+trap 'rm -rf $tmpdir' EXIT
 
 # Jump to the working directory
+# It has to be $GOPATH/src/$PKG, because
+# * that is where the sources are supposed to be
+# * protoc will not find the data necessary to import
+# TODO: this is arguable. Maybe we should just have a basepath.
 pushd $GOPATH/src/$PKG &>/dev/null
+# Jump back to the original directory
+trap 'popd &>/dev/null' EXIT
 
 # Pass 1: sanitizing
-for F in $(find . -name '*.proto'); do
+for F in $(find . -type f -name '*.proto'); do
 
-  inst=$(find $tmpdir/$UPSTREAM_SUBDIR -name $(basename $F) -and -not -path "*/testdata/*"  -print)
-  if [ $(echo "$inst" | wc -l) -ne 1 ] ; then
-    die "Did not find exactly one instance of '$F' in '$tmpdir/$UPSTREAM_SUBDIR'!"
+  count=$(find $tmpdir/$UPSTREAM_SUBDIR \
+    -type f -name $(expr "$F" : '.*/\(.*\.proto\)') \
+    -and -not -path "*/testdata/*" | wc -l)
+
+  if [ $count -ne 1 ] ; then
+    die "Did not find exactly one instance of '$F' in '$tmpdir/$UPSTREAM_SUBDIR', found $count!"
   fi
 
 done
 
-# Pass 2: copy and modify
+# Pass 2: copy the protofiles to their according location
 # We are sure the upstream is in valid state as per pass 1
+# Upstream now has the go_package option set, so no need for
+# mangling with names any more
 for F in $(find . -name '*.proto'); do
-  shortname=$(expr "$F" : '.*/\(.*\)\.proto')
-
-  echo $shortname
-  fn="$tmpdir/$UPSTREAM_SUBDIR/$shortname.proto"
-  echo $fn
-
-  # Unfortunately "package struct" doesn't work.
-  # Handle the special case here instead of passing all files through sed
-  # a second time
-  if [ $shortname == "struct" ] ; then
-    shortname="structpb"
+  cp  "$tmpdir/$UPSTREAM_SUBDIR/$(expr "$F" : '.*/\(.*.proto\)')" $F
+  if [ $? -ne 0 ];then
+    die "Error while copying $F"
   fi
-
-  # Upstream now seems to have the go_package option
-  # We just ensure it is correctly named
-  sed -e "s@^\(option go_package\).*=.*@\1 = \"$PKG/$shortname\";@" "$fn" > $F
 done
 
 # Compile
-for dir in $(find . -name '*.proto' -exec dirname {} \; | sort -u); do
+for dir in $(find -type f -name *.proto -exec dirname {} \; | sort -u); do
   echo -en "* $dir... " 1>&2
-  protoc --go_out=. $dir/*.proto
+  protoc --go_out=$GOPATH/src $dir/*.proto
   if [ $? -ne 0 ]; then
     die "Error creating output files"
   fi
   echo "...Success!" 1>&2
 done
 
-# Jump back to the original directory
-popd &>/dev/null

--- a/ptypes/regen.sh
+++ b/ptypes/regen.sh
@@ -68,7 +68,7 @@ for F in $(find . -name '*.proto'); do
 done
 
 # Compile
-for dir in $(find -type f -name *.proto -exec dirname {} \; | sort -u); do
+for dir in $(find . -type f -name *.proto -exec dirname {} \; | sort -u); do
   echo -en "* $dir... " 1>&2
   protoc --go_out=$GOPATH/src $dir/*.proto
   if [ $? -ne 0 ]; then

--- a/ptypes/regen.sh
+++ b/ptypes/regen.sh
@@ -12,9 +12,9 @@
 # in the weirdest of circumstances
 set -Ee
 
-PKG=github.com/golang/protobuf/ptypes
-UPSTREAM=https://github.com/google/protobuf
-UPSTREAM_SUBDIR=src/google/protobuf
+PKG=${PTYPES_REGEN_PKG:-github.com/golang/protobuf/ptypes}
+UPSTREAM=${PTYPES_REGEN_UPSTREAM:-https://github.com/google/protobuf}
+UPSTREAM_SUBDIR=${PTYPES_REGEN_UPSTREAM_SUBDIR:-src/google/protobuf}
 
 
 function die() {


### PR DESCRIPTION
I have changed the regen.sh script as per issue #196. Only later I found out about #144. I took the comments made there into account, where feasible.

Tests were run on Linux (CentOS 6.7, go1.6.2 linux/amd64) and OS X(10.11.5 "El Capitan", go1.6.2 darwin/amd64).
# Overview of changes
- The unused `PROTO_FILES`variable was removed
- `PKG`,`UPSTREAM` and `UPSTREAM_SUBDIR` can now be configured by setting the respective `PTYPES_REGEN_*` environment variable. If they are not set or empty, the current values are used as a default.
- `find` was added to the tool sanitation
- `git clone` is not silent any more to give proper feedback
- the `basedir` lookup was simplified to the static `$GOPATH/src/$PKG`
- Upstream now provides `option go_package`, so the mangling of package names became unnecessary , hence it was removed
- The output directory of `protoc` was set to `$GOPATH/src`, as full package paths are generated now.
- Enhanced portability
  -  Instead of using the `declare` statement, which caused portability problems on OS X, the search for `.proto` files is done again for the second pass, again using `find`. Since we are sure that the environment is sane as of pass 1 not dying, we can do this and it is more portable and reasonably cheap.
  - The dependency on sed was removed entirely, as it is a good candidate for portability problems. The unproblematic `expr` or shell substitution patterns are used instead, where necessary.
  - There still is some reliance on GNU coreutils and findutils, but those are known to be unproblematic
