### PR TITLE
Update package name to 'main'

### DIFF
--- a/protoc-gen-go/doc.go
+++ b/protoc-gen-go/doc.go
@@ -48,4 +48,4 @@
 		https://developers.google.com/protocol-buffers/
 
 */
-package documentation
+package main


### PR DESCRIPTION
I see no benefit in having another package name. I found this trying to build the package without go build and just with go tool compile
