### PR TITLE
Add TimestampNow and TimestampFormat funcs

### DIFF
--- a/ptypes/timestamp.go
+++ b/ptypes/timestamp.go
@@ -85,8 +85,7 @@ func validateTimestamp(ts *tspb.Timestamp) error {
 // locale. This may or may not be a meaningful time; many invalid Timestamps
 // do map to valid time.Times.
 //
-// A nil Timestamp returns an error. The first return value in that case is
-// undefined.
+// A nil Timestamp returns the UNIX epoch time (not Go's empty time).
 func Timestamp(ts *tspb.Timestamp) (time.Time, error) {
 	// Don't return the zero value on error, because corresponds to a valid
 	// timestamp. Instead return whatever time.Unix gives us.
@@ -117,9 +116,25 @@ func TimestampProto(t time.Time) (*tspb.Timestamp, error) {
 // TimestampString returns the RFC 3339 string for valid Timestamps. For invalid
 // Timestamps, it returns an error message in parentheses.
 func TimestampString(ts *tspb.Timestamp) string {
+	return TimestampFormat(ts, time.RFC3339Nano)
+}
+
+// TimestampFormat returns a string representation of a timestamp.
+// Format strings follow the same conventions as in Go's "time" package.
+// For invalid timestamps, this returns an error message in parentheses.
+func TimestampFormat(ts *tspb.Timestamp, format string) string {
 	t, err := Timestamp(ts)
 	if err != nil {
 		return fmt.Sprintf("(%v)", err)
 	}
-	return t.Format(time.RFC3339Nano)
+	return t.Format(format)
+}
+
+// TimestampNow returns a Timestamp with the current date and time.
+func TimestampNow() *tspb.Timestamp {
+	ts, err := TimestampProto(time.Now())
+	if err != nil {
+		panic("timestampVerify failed for built-in time.Now()")
+	}
+	return ts
 }

--- a/ptypes/timestamp_test.go
+++ b/ptypes/timestamp_test.go
@@ -133,6 +133,35 @@ func TestTimestampString(t *testing.T) {
 	}
 }
 
+func TestTimestampFormat(t *testing.T) {
+	now := time.Now().UTC()
+	for _, test := range []struct {
+		format string
+		want   string
+	}{
+		{time.ANSIC, now.Format(time.ANSIC)},
+		{time.UnixDate, now.Format(time.UnixDate)},
+		{time.StampMilli, now.Format(time.StampMilli)},
+	} {
+		ts, err := TimestampProto(now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := TimestampFormat(ts, test.format); got != test.want {
+			t.Errorf("TimestampFormat(%v, %q) = %q, want %q", ts, test.format, got, test.want)
+		}
+	}
+}
+
+func TestTimestampNow(t *testing.T) {
+	now := time.Now()
+	nowts := TimestampNow()
+
+	if now.Unix() > nowts.Seconds {
+		t.Errorf("TimestampNow() returned timestamp older than time.Now()")
+	}
+}
+
 func utcDate(year, month, day int) time.Time {
 	return time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
 }


### PR DESCRIPTION
This adds two timestamp functions to the pytpe library. TimestampNow()
returns a protobuf Timestamp with the current time. TimestampFormat()
takes a Go time format string and formats a protobuf Timestamp
accordingly. With TimestampFormat here, TimestampString() was refactored
to use that function.

Additionally, one documentation fix was made to the Timestamp()
function.
