### PR TITLE
jsonpb: fixing unmarshaling enum from int

### DIFF
--- a/proto/lib.go
+++ b/proto/lib.go
@@ -421,14 +421,14 @@ func EnumName(m map[int32]string, v int32) string {
 // value, it returns an int32 that can be cast to the enum type by the caller.
 //
 // The function can deal with both JSON representations, numeric and symbolic.
-func UnmarshalJSONEnum(m map[string]int32, data []byte, enumName string) (int32, error) {
+func UnmarshalJSONEnum(names map[int32]string, values map[string]int32, data []byte, enumName string) (int32, error) {
 	if data[0] == '"' {
 		// New style: enums are strings.
 		var repr string
 		if err := json.Unmarshal(data, &repr); err != nil {
 			return -1, err
 		}
-		val, ok := m[repr]
+		val, ok := values[repr]
 		if !ok {
 			return 0, fmt.Errorf("unrecognized enum %s value %q", enumName, repr)
 		}
@@ -438,6 +438,9 @@ func UnmarshalJSONEnum(m map[string]int32, data []byte, enumName string) (int32,
 	var val int32
 	if err := json.Unmarshal(data, &val); err != nil {
 		return 0, fmt.Errorf("cannot unmarshal %#q into enum %s", data, enumName)
+	}
+	if _, ok := names[val]; !ok {
+		return 0, fmt.Errorf("unrecognized enum %s key %d", enumName, val)
 	}
 	return val, nil
 }

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -127,7 +127,7 @@ func (x FieldDescriptorProto_Type) String() string {
 	return proto.EnumName(FieldDescriptorProto_Type_name, int32(x))
 }
 func (x *FieldDescriptorProto_Type) UnmarshalJSON(data []byte) error {
-	value, err := proto.UnmarshalJSONEnum(FieldDescriptorProto_Type_value, data, "FieldDescriptorProto_Type")
+	value, err := proto.UnmarshalJSONEnum(FieldDescriptorProto_Type_name, FieldDescriptorProto_Type_value, data, "FieldDescriptorProto_Type")
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (x FieldDescriptorProto_Label) String() string {
 	return proto.EnumName(FieldDescriptorProto_Label_name, int32(x))
 }
 func (x *FieldDescriptorProto_Label) UnmarshalJSON(data []byte) error {
-	value, err := proto.UnmarshalJSONEnum(FieldDescriptorProto_Label_value, data, "FieldDescriptorProto_Label")
+	value, err := proto.UnmarshalJSONEnum(FieldDescriptorProto_Label_name, FieldDescriptorProto_Label_value, data, "FieldDescriptorProto_Label")
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func (x FileOptions_OptimizeMode) String() string {
 	return proto.EnumName(FileOptions_OptimizeMode_name, int32(x))
 }
 func (x *FileOptions_OptimizeMode) UnmarshalJSON(data []byte) error {
-	value, err := proto.UnmarshalJSONEnum(FileOptions_OptimizeMode_value, data, "FileOptions_OptimizeMode")
+	value, err := proto.UnmarshalJSONEnum(FileOptions_OptimizeMode_name, FileOptions_OptimizeMode_value, data, "FileOptions_OptimizeMode")
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func (x FieldOptions_CType) String() string {
 	return proto.EnumName(FieldOptions_CType_name, int32(x))
 }
 func (x *FieldOptions_CType) UnmarshalJSON(data []byte) error {
-	value, err := proto.UnmarshalJSONEnum(FieldOptions_CType_value, data, "FieldOptions_CType")
+	value, err := proto.UnmarshalJSONEnum(FieldOptions_CType_name, FieldOptions_CType_value, data, "FieldOptions_CType")
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func (x FieldOptions_JSType) String() string {
 	return proto.EnumName(FieldOptions_JSType_name, int32(x))
 }
 func (x *FieldOptions_JSType) UnmarshalJSON(data []byte) error {
-	value, err := proto.UnmarshalJSONEnum(FieldOptions_JSType_value, data, "FieldOptions_JSType")
+	value, err := proto.UnmarshalJSONEnum(FieldOptions_JSType_name, FieldOptions_JSType_value, data, "FieldOptions_JSType")
 	if err != nil {
 		return err
 	}

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1453,7 +1453,7 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 	if !enum.proto3() {
 		g.P("func (x *", ccTypeName, ") UnmarshalJSON(data []byte) error {")
 		g.In()
-		g.P("value, err := ", g.Pkg["proto"], ".UnmarshalJSONEnum(", ccTypeName, `_value, data, "`, ccTypeName, `")`)
+		g.P("value, err := ", g.Pkg["proto"], ".UnmarshalJSONEnum(", ccTypeName, "_name, ", ccTypeName, `_value, data, "`, ccTypeName, `")`)
 		g.P("if err != nil {")
 		g.In()
 		g.P("return err")


### PR DESCRIPTION
Now it's unsafe, you can easily write any value and it will swallow.
