### PR TITLE
Emit empty array in JsonPB if EmitDefaults is enabled

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -180,7 +180,7 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 
 		// IsNil will panic on most value kinds.
 		switch value.Kind() {
-		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr:
 			if value.IsNil() {
 				continue
 			}
@@ -188,6 +188,10 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 
 		if !m.EmitDefaults {
 			switch value.Kind() {
+			case reflect.Slice:
+				if value.IsNil() {
+					continue
+				}
 			case reflect.Bool:
 				if !value.Bool() {
 					continue


### PR DESCRIPTION
Forces an empty-valued array field to be serialized if `EmitDefaults` is set to `true`. 

Mirrors Java's protobuf to JSON implementation when `includingDefaultValueFields` is enabled. 
