### PR TITLE
Allow "make test" to run with Bourne shell.

### DIFF
--- a/protoc-gen-go/testdata/Makefile
+++ b/protoc-gen-go/testdata/Makefile
@@ -58,7 +58,7 @@ testbuild:	regenerate
 
 regenerate:
 	# Invoke protoc once to generate three independent .pb.go files in the same package.
-	protoc --go_out=. multi/multi{1,2,3}.proto
+	protoc --go_out=. multi/multi1.proto multi/multi2.proto multi/multi3.proto
 
 #extension_test:	extension_test.$O
 #	$(LD) -L. -o $@ $<


### PR DESCRIPTION
"make install; make test" did not work out of the box on Ubuntu 16.04. Removing the bashism from protoc-gen-go/testdata/Makefile allows "make test" to run with a PASS result.