### PR TITLE
JSON unmarshaler returns UnknownFieldError error

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -510,6 +510,20 @@ func (m *Marshaler) marshalValue(out *errWriter, prop *proto.Properties, v refle
 	return out.err
 }
 
+// UnknownFieldError is an error if an unknown field was encountered
+// during unmarshaling.
+type UnknownFieldError struct {
+	// Field is the name of the JSON field.
+	Field string
+
+	// TargetType is the type attempted unmarshaled.
+	TargetType reflect.Type
+}
+
+func (u UnknownFieldError) Error() string {
+	return fmt.Sprintf("unknown field %q in %v", u.Field, u.TargetType)
+}
+
 // Unmarshaler is a configurable object for converting from a JSON
 // representation to a protocol buffer object.
 type Unmarshaler struct {
@@ -701,7 +715,10 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 				f = fname
 				break
 			}
-			return fmt.Errorf("unknown field %q in %v", f, targetType)
+			return UnknownFieldError{
+				Field:      f,
+				TargetType: targetType,
+			}
 		}
 		return nil
 	}

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -504,6 +504,29 @@ func TestUnmarshaling(t *testing.T) {
 	}
 }
 
+func TestUnmarshalDisallowingUnknownField(t *testing.T) {
+	u := Unmarshaler{AllowUnknownFields: false}
+	err := u.Unmarshal(strings.NewReader(`{"unknown": "foo"}`), simpleObject)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+		return
+	}
+	fieldErr, ok := err.(UnknownFieldError)
+	if !ok {
+		t.Errorf("expected error to be UnknownFieldError, got %T", fieldErr)
+		return
+	}
+	if fieldErr.Field != "unknown" {
+		t.Errorf("expected field to be %q, got %q", "unknown", fieldErr.Field)
+		return
+	}
+	if fieldErr.TargetType.Name() != reflect.TypeOf(*simpleObject).Name() {
+		t.Errorf("expected target type to be %T, got %T",
+			reflect.TypeOf(*simpleObject), fieldErr.TargetType)
+		return
+	}
+}
+
 func TestUnmarshalNext(t *testing.T) {
 	// We only need to check against a few, not all of them.
 	tests := unmarshalingTests[:5]


### PR DESCRIPTION
This makes the JSON unmarshaler return a new error struct, UnknownFieldError, for unknown fields, when `AllowUnknownFields` is `false`. This is necessary in order for callers to be able to hide Go internals in APIs. Previously, the error of `Unmarshal` would be an error string such as:

```go
unknown field "glorp" in proto.Mutation
```

This leaks the type `proto.Mutation` to clients, which should not need to see such internals when they are consuming a pure-JSON HTTP API.

There are other instances of `fmt.Errorf` being used, but this is the main one that leaks.