### PR TITLE
simplify size_struct

### DIFF
--- a/proto/encode.go
+++ b/proto/encode.go
@@ -1276,8 +1276,7 @@ func (o *Buffer) enc_struct(prop *StructProperties, base structPointer) error {
 }
 
 func size_struct(prop *StructProperties, base structPointer) (n int) {
-	for _, i := range prop.order {
-		p := prop.Prop[i]
+	for _, p := range prop.Prop {
 		if p.size != nil {
 			n += p.size(p, base)
 		}


### PR DESCRIPTION
size_struct currently iterates through properties in order.
When computing the size, the order is unnecessary.

benchmark                 old ns/op     new ns/op     delta
BenchmarkSize-12          6620          6394          -3.41%
BenchmarkSizeBytes-12     608           529           -12.99%