### PR TITLE
protoc-gen-go: fix issue with self-import check

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -650,6 +650,11 @@ func (g *Generator) DefaultPackageName(obj Object) string {
 	if pkg == g.packageName {
 		return ""
 	}
+
+	if obj.File().GetOptions().GetGoPackage() == g.file.GetOptions().GetGoPackage() {
+		return ""
+	}
+
 	return pkg + "."
 }
 
@@ -1329,6 +1334,11 @@ func (g *Generator) generateImports() {
 		if fd.PackageName() == g.packageName {
 			continue
 		}
+
+		if fd.GetOptions().GetGoPackage() == g.file.GetOptions().GetGoPackage() {
+			continue
+		}
+
 		filename := fd.goFileName()
 		// By default, import path is the dirname of the Go filename.
 		importPath := path.Dir(filename)
@@ -1348,6 +1358,7 @@ func (g *Generator) generateImports() {
 		if _, ok := g.usedPackages[pname]; !ok {
 			pname = "_"
 		}
+
 		g.P("import ", pname, " ", strconv.Quote(importPath))
 	}
 	g.P()


### PR DESCRIPTION
Previously the go generator only checked to ensure that original package name is not self-imported. When the  option is used, this check does not cover the option-defined package. This change adds in that check to ensure that the go generator doesn't self import in addition to avoiding prepending package names to types in the generated go code for those same option-defined packages