### PR TITLE
Update to standard library context package.

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -53,7 +53,7 @@ const generatedCodeVersion = 4
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.
 const (
-	contextPkgPath = "golang.org/x/net/context"
+	contextPkgPath = "context"
 	grpcPkgPath    = "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Go 1.7 added context to the standard library.  With Go 1.8 coming soon here is a PR to switch from `golang.org/x/net/context` to `context.