### PR TITLE
jsonpb: marshal int64 and uint64 values without quotes

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -499,14 +499,7 @@ func (m *Marshaler) marshalValue(out *errWriter, prop *proto.Properties, v refle
 	if err != nil {
 		return err
 	}
-	needToQuote := string(b[0]) != `"` && (v.Kind() == reflect.Int64 || v.Kind() == reflect.Uint64)
-	if needToQuote {
-		out.write(`"`)
-	}
 	out.write(string(b))
-	if needToQuote {
-		out.write(`"`)
-	}
 	return out.err
 }
 

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -74,11 +74,11 @@ var (
 	simpleObjectJSON = `{` +
 		`"oBool":true,` +
 		`"oInt32":-32,` +
-		`"oInt64":"-6400000000",` +
+		`"oInt64":-6400000000,` +
 		`"oUint32":32,` +
-		`"oUint64":"6400000000",` +
+		`"oUint64":6400000000,` +
 		`"oSint32":-13,` +
-		`"oSint64":"-2600000000",` +
+		`"oSint64":-2600000000,` +
 		`"oFloat":3.14,` +
 		`"oDouble":6.02214179e+23,` +
 		`"oString":"hello \"there\"",` +
@@ -88,11 +88,11 @@ var (
 	simpleObjectPrettyJSON = `{
   "oBool": true,
   "oInt32": -32,
-  "oInt64": "-6400000000",
+  "oInt64": -6400000000,
   "oUint32": 32,
-  "oUint64": "6400000000",
+  "oUint64": 6400000000,
   "oSint32": -13,
-  "oSint64": "-2600000000",
+  "oSint64": -2600000000,
   "oFloat": 3.14,
   "oDouble": 6.02214179e+23,
   "oString": "hello \"there\"",
@@ -116,11 +116,11 @@ var (
 	repeatsObjectJSON = `{` +
 		`"rBool":[true,false,true],` +
 		`"rInt32":[-3,-4,-5],` +
-		`"rInt64":["-123456789","-987654321"],` +
+		`"rInt64":[-123456789,-987654321],` +
 		`"rUint32":[1,2,3],` +
-		`"rUint64":["6789012345","3456789012"],` +
+		`"rUint64":[6789012345,3456789012],` +
 		`"rSint32":[-1,-2,-3],` +
-		`"rSint64":["-6789012345","-3456789012"],` +
+		`"rSint64":[-6789012345,-3456789012],` +
 		`"rFloat":[3.14,6.28],` +
 		`"rDouble":[2.99792458e+28,6.62606957e-34],` +
 		`"rString":["happy","days"],` +
@@ -139,8 +139,8 @@ var (
     -5
   ],
   "rInt64": [
-    "-123456789",
-    "-987654321"
+    -123456789,
+    -987654321
   ],
   "rUint32": [
     1,
@@ -148,8 +148,8 @@ var (
     3
   ],
   "rUint64": [
-    "6789012345",
-    "3456789012"
+    6789012345,
+    3456789012
   ],
   "rSint32": [
     -1,
@@ -157,8 +157,8 @@ var (
     -3
   ],
   "rSint64": [
-    "-6789012345",
-    "-3456789012"
+    -6789012345,
+    -3456789012
   ],
   "rFloat": [
     3.14,
@@ -194,7 +194,7 @@ var (
 	complexObjectJSON = `{"color":"GREEN",` +
 		`"rColor":["RED","GREEN","BLUE"],` +
 		`"simple":{"oInt32":-32},` +
-		`"rSimple":[{"oInt32":-32},{"oInt64":"25"}],` +
+		`"rSimple":[{"oInt32":-32},{"oInt64":25}],` +
 		`"repeats":{"rString":["roses","red"]},` +
 		`"rRepeats":[{"rString":["roses","red"]},{"rString":["violets","blue"]}]` +
 		`}`
@@ -214,7 +214,7 @@ var (
       "oInt32": -32
     },
     {
-      "oInt64": "25"
+      "oInt64": 25
     }
   ],
   "repeats": {
@@ -394,8 +394,8 @@ var marshalingTests = []struct {
 
 	{"DoubleValue", marshaler, &pb.KnownTypes{Dbl: &wpb.DoubleValue{Value: 1.2}}, `{"dbl":1.2}`},
 	{"FloatValue", marshaler, &pb.KnownTypes{Flt: &wpb.FloatValue{Value: 1.2}}, `{"flt":1.2}`},
-	{"Int64Value", marshaler, &pb.KnownTypes{I64: &wpb.Int64Value{Value: -3}}, `{"i64":"-3"}`},
-	{"UInt64Value", marshaler, &pb.KnownTypes{U64: &wpb.UInt64Value{Value: 3}}, `{"u64":"3"}`},
+	{"Int64Value", marshaler, &pb.KnownTypes{I64: &wpb.Int64Value{Value: -3}}, `{"i64":-3}`},
+	{"UInt64Value", marshaler, &pb.KnownTypes{U64: &wpb.UInt64Value{Value: 3}}, `{"u64":3}`},
 	{"Int32Value", marshaler, &pb.KnownTypes{I32: &wpb.Int32Value{Value: -4}}, `{"i32":-4}`},
 	{"UInt32Value", marshaler, &pb.KnownTypes{U32: &wpb.UInt32Value{Value: 4}}, `{"u32":4}`},
 	{"BoolValue", marshaler, &pb.KnownTypes{Bool: &wpb.BoolValue{Value: true}}, `{"bool":true}`},


### PR DESCRIPTION
Hello.
Sometimes it is inconvenient to parse decimal values with quotes.
I don't see cases it is need.