### PR TITLE
Fix #270

### DIFF
--- a/descriptor/descriptor.go
+++ b/descriptor/descriptor.go
@@ -43,7 +43,7 @@ import (
 	"io/ioutil"
 
 	"github.com/golang/protobuf/proto"
-	protobuf "google.golang.org/genproto/protobuf"
+	protobuf "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
 // extractFile extracts a FileDescriptorProto from a gzip'd buffer.

--- a/descriptor/descriptor_test.go
+++ b/descriptor/descriptor_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/golang/protobuf/descriptor"
 	tpb "github.com/golang/protobuf/proto/testdata"
-	protobuf "google.golang.org/genproto/protobuf"
+	protobuf "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
 func TestMessage(t *testing.T) {


### PR DESCRIPTION
This changes the import path to import from github.com/golang
instead of google.golang.org

Fixes #270 