### PR TITLE
add EOF() method to proto.Buffer

### DIFF
--- a/proto/decode.go
+++ b/proto/decode.go
@@ -464,7 +464,7 @@ func (o *Buffer) unmarshalType(st reflect.Type, prop *StructProperties, is_group
 	required, reqFields := prop.reqCount, uint64(0)
 
 	var err error
-	for err == nil && o.index < len(o.buf) {
+	for err == nil && !o.EOF() {
 		oi := o.index
 		var u uint64
 		u, err = o.DecodeVarint()

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -344,6 +344,11 @@ func (p *Buffer) SetBuf(s []byte) {
 // Bytes returns the contents of the Buffer.
 func (p *Buffer) Bytes() []byte { return p.buf }
 
+// EOF returns true when there is no more data to read and decode.
+func (p *Buffer) EOF() bool {
+	return p.index >= len(p.buf)
+}
+
 /*
  * Helper routines for simplifying the creation of optional fields of basic type.
  */

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -349,6 +349,18 @@ func (p *Buffer) EOF() bool {
 	return p.index >= len(p.buf)
 }
 
+// ReaderIndex returns the current offset in Buffer for reading. Calls to the
+// various Decode* methods will read and decode data starting at this index in
+// the Buffer's underlying byte slice.
+func (p *Buffer) ReaderIndex() int { return p.index }
+
+// SetReaderIndex changes the current offset in Buffer for reading to the
+// given value. Subsequent calls to Decode* methods will read and decode data
+// starting at this index in the Buffer's underlying byte slice.
+func (p *Buffer) SetReaderIndex(index int) {
+	p.index = index
+}
+
 /*
  * Helper routines for simplifying the creation of optional fields of basic type.
  */


### PR DESCRIPTION
The `Buffer` type has a wide API that is very useful for writing my own message marshaller. However, what is does *not* have is a way to check whether EOF has been reached. The various `Decode*` methods return `io.ErrUnexpectedEOF` when they reach EOF, but that's not sufficient. For example, when reading the next tag+value pair, there was no way to distinguish end-of-message (e.g. no bytes left) from a malformed message (e.g. try to read next varint and/or field contents and reach EOF in the middle).

This small change seems inline with the spirit of this type since much of its API is exported. With it, it is possible to write a function that unmarshals a message and properly distinguishes end-of-message from an erroneous/unexpected EOF.