### PR TITLE
Append comma to wire type name in String()

### DIFF
--- a/proto/properties.go
+++ b/proto/properties.go
@@ -216,7 +216,7 @@ type Properties struct {
 // String formats the properties in the protobuf struct field tag style.
 func (p *Properties) String() string {
 	s := p.Wire
-	s = ","
+	s += ","
 	s += strconv.Itoa(p.Tag)
 	if p.Required {
 		s += ",req"


### PR DESCRIPTION
Although String only seems to be used only in debugging, it is probably helpful to see the `p.Wire` property in the String representation. If not, maybe get rid of the assignment. 