### PR TITLE
Update timestamp.pb.go with helper functions

### DIFF
--- a/ptypes/timestamp/timestamp.pb.go
+++ b/ptypes/timestamp/timestamp.pb.go
@@ -101,6 +101,22 @@ func (*Timestamp) ProtoMessage()               {}
 func (*Timestamp) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 func (*Timestamp) XXX_WellKnownType() string   { return "Timestamp" }
 
+// GetSeconds returns the seconds of the Timestamp structure
+func (m *Timestamp) GetSeconds() int64 {
+	if m != nil {
+		return m.Seconds
+	}
+	return 0
+}
+
+// GetNanos returns the nanos of the Timestamp structure
+func (m *Timestamp) GetNanos() int32 {
+	if m != nil {
+		return m.Nanos
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*Timestamp)(nil), "google.protobuf.Timestamp")
 }


### PR DESCRIPTION
This is a proposed fix for the timestamp file. Without this, the latest version of `protoc-gen-go` generates "broken" code that gives the following compile time error :
```
$ go run *go
# github.com/17twenty/protobuf/go
/Users/nickg/go/src/github.com/17twenty/protobuf/go/Common.pb.go:24: (*timestamp.Timestamp)(m).GetSeconds undefined (type *timestamp.Timestamp has no field or method GetSeconds)
/Users/nickg/go/src/github.com/17twenty/protobuf/go/Common.pb.go:27: (*timestamp.Timestamp)(m).GetNanos undefined (type *timestamp.Timestamp has no field or method GetNanos)
```

This appears in dependant projects that use:

```
import public "google/protobuf/timestamp.proto";
```

An alternative fix, would be to remove references to those functions in the generated foo.pb.go code