### PR TITLE
Simplify

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -803,7 +803,7 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 				return fmt.Errorf("bad ListValue: %v", err)
 			}
 
-			target.Field(0).Set(reflect.ValueOf(make([]*stpb.Value, len(s), len(s))))
+			target.Field(0).Set(reflect.ValueOf(make([]*stpb.Value, len(s))))
 			for i, sv := range s {
 				if err := u.unmarshalValue(target.Field(0).Index(i), sv, prop); err != nil {
 					return err

--- a/proto/all_test.go
+++ b/proto/all_test.go
@@ -400,7 +400,7 @@ func TestRequiredBit(t *testing.T) {
 	err := o.Marshal(pb)
 	if err == nil {
 		t.Error("did not catch missing required fields")
-	} else if strings.Index(err.Error(), "Kind") < 0 {
+	} else if !strings.Contains(err.Error(), "Kind") {
 		t.Error("wrong error type:", err)
 	}
 }
@@ -1087,13 +1087,10 @@ func TestBigRepeated(t *testing.T) {
 		if pbd.Repeatedgroup[i] == nil { // TODO: more checking?
 			t.Error("pbd.Repeatedgroup bad")
 		}
-		var x uint64
-		x = uint64(pbd.F_Sint64Repeated[i])
-		if x != i {
+		if x := uint64(pbd.F_Sint64Repeated[i]); x != i {
 			t.Error("pbd.F_Sint64Repeated bad", x, i)
 		}
-		x = uint64(pbd.F_Sint32Repeated[i])
-		if x != i {
+		if x := uint64(pbd.F_Sint32Repeated[i]); x != i {
 			t.Error("pbd.F_Sint32Repeated bad", x, i)
 		}
 		s := fmt.Sprint(i)
@@ -1101,39 +1098,31 @@ func TestBigRepeated(t *testing.T) {
 		if pbd.F_StringRepeated[i] != s {
 			t.Error("pbd.F_Sint32Repeated bad", pbd.F_StringRepeated[i], i)
 		}
-		x = uint64(pbd.F_DoubleRepeated[i])
-		if x != i {
+		if x := uint64(pbd.F_DoubleRepeated[i]); x != i {
 			t.Error("pbd.F_DoubleRepeated bad", x, i)
 		}
-		x = uint64(pbd.F_FloatRepeated[i])
-		if x != i {
+		if x := uint64(pbd.F_FloatRepeated[i]); x != i {
 			t.Error("pbd.F_FloatRepeated bad", x, i)
 		}
-		x = pbd.F_Uint64Repeated[i]
-		if x != i {
+		if x := pbd.F_Uint64Repeated[i]; x != i {
 			t.Error("pbd.F_Uint64Repeated bad", x, i)
 		}
-		x = uint64(pbd.F_Uint32Repeated[i])
-		if x != i {
+		if x := uint64(pbd.F_Uint32Repeated[i]); x != i {
 			t.Error("pbd.F_Uint32Repeated bad", x, i)
 		}
-		x = pbd.F_Fixed64Repeated[i]
-		if x != i {
+		if x := pbd.F_Fixed64Repeated[i]; x != i {
 			t.Error("pbd.F_Fixed64Repeated bad", x, i)
 		}
-		x = uint64(pbd.F_Fixed32Repeated[i])
-		if x != i {
+		if x := uint64(pbd.F_Fixed32Repeated[i]); x != i {
 			t.Error("pbd.F_Fixed32Repeated bad", x, i)
 		}
-		x = uint64(pbd.F_Int64Repeated[i])
-		if x != i {
+		if x := uint64(pbd.F_Int64Repeated[i]); x != i {
 			t.Error("pbd.F_Int64Repeated bad", x, i)
 		}
-		x = uint64(pbd.F_Int32Repeated[i])
-		if x != i {
+		if x := uint64(pbd.F_Int32Repeated[i]); x != i {
 			t.Error("pbd.F_Int32Repeated bad", x, i)
 		}
-		if pbd.F_BoolRepeated[i] != (i%2 == 0) {
+		if x := pbd.F_BoolRepeated[i]; x != (i%2 == 0) {
 			t.Error("pbd.F_BoolRepeated bad", x, i)
 		}
 		if pbd.RepeatedField[i] == nil { // TODO: more checking?
@@ -1833,7 +1822,7 @@ func TestRequiredNotSetError(t *testing.T) {
 		o.DebugPrint("", bytes)
 		t.Fatalf("expected = %s", expected)
 	}
-	if strings.Index(err.Error(), "RequiredField.Label") < 0 {
+	if !strings.Contains(err.Error(), "RequiredField.Label") {
 		t.Errorf("marshal-1 wrong err msg: %v", err)
 	}
 	if !equal(bytes, expected, t) {
@@ -1849,7 +1838,7 @@ func TestRequiredNotSetError(t *testing.T) {
 		o.DebugPrint("", bytes)
 		t.Fatalf("string = %s", expected)
 	}
-	if strings.Index(err.Error(), "RequiredField.Label") < 0 && strings.Index(err.Error(), "RequiredField.{Unknown}") < 0 {
+	if !strings.Contains(err.Error(), "RequiredField.Label") && !strings.Contains(err.Error(), "RequiredField.{Unknown}") {
 		t.Errorf("unmarshal wrong err msg: %v", err)
 	}
 	bytes, err = Marshal(pbd)
@@ -1858,7 +1847,7 @@ func TestRequiredNotSetError(t *testing.T) {
 		o.DebugPrint("", bytes)
 		t.Fatalf("string = %s", expected)
 	}
-	if strings.Index(err.Error(), "RequiredField.Label") < 0 {
+	if !strings.Contains(err.Error(), "RequiredField.Label") {
 		t.Errorf("marshal-2 wrong err msg: %v", err)
 	}
 	if !equal(bytes, expected, t) {

--- a/proto/discard.go
+++ b/proto/discard.go
@@ -184,11 +184,9 @@ func (di *discardInfo) computeDiscardInfo() {
 				di := getDiscardInfo(tf)
 				dfi.discard = func(src pointer) {
 					sps := src.getPointerSlice()
-					if sps != nil {
-						for _, sp := range sps {
-							if !sp.isNil() {
-								di.discard(sp)
-							}
+					for _, sp := range sps {
+						if !sp.isNil() {
+							di.discard(sp)
 						}
 					}
 				}

--- a/proto/equal.go
+++ b/proto/equal.go
@@ -146,11 +146,7 @@ func equalStruct(v1, v2 reflect.Value) bool {
 
 	u1 := uf.Bytes()
 	u2 := v2.FieldByName("XXX_unrecognized").Bytes()
-	if !bytes.Equal(u1, u2) {
-		return false
-	}
-
-	return true
+	return bytes.Equal(u1, u2)
 }
 
 // v1 and v2 are known to have the same type.

--- a/proto/message_set.go
+++ b/proto/message_set.go
@@ -95,10 +95,7 @@ func (ms *messageSet) find(pb Message) *_MessageSet_Item {
 }
 
 func (ms *messageSet) Has(pb Message) bool {
-	if ms.find(pb) != nil {
-		return true
-	}
-	return false
+	return ms.find(pb) != nil
 }
 
 func (ms *messageSet) Unmarshal(pb Message) error {

--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -1176,7 +1176,7 @@ func sizeBoolValue(_ pointer, tagsize int) int {
 }
 func sizeBoolValueNoZero(ptr pointer, tagsize int) int {
 	v := *ptr.toBool()
-	if v == false {
+	if !v {
 		return 0
 	}
 	return 1 + tagsize

--- a/proto/table_merge.go
+++ b/proto/table_merge.go
@@ -125,7 +125,7 @@ func (mi *mergeInfo) merge(dst, src pointer) {
 			}
 			if fi.basicWidth > 0 {
 				switch {
-				case fi.basicWidth == 1 && *sfp.toBool() == false:
+				case fi.basicWidth == 1 && !*sfp.toBool():
 					continue
 				case fi.basicWidth == 4 && *sfp.toUint32() == 0:
 					continue
@@ -456,7 +456,7 @@ func (mi *mergeInfo) computeMergeInfo() {
 				}
 			default: // E.g., bool
 				mfi.merge = func(dst, src pointer) {
-					if v := *src.toBool(); v != false {
+					if v := *src.toBool(); v {
 						*dst.toBool() = v
 					}
 				}

--- a/proto/text.go
+++ b/proto/text.go
@@ -482,10 +482,7 @@ func writeRaw(w *textWriter, b []byte) error {
 		return err
 	}
 	w.unindent()
-	if err := w.WriteByte('>'); err != nil {
-		return err
-	}
-	return nil
+	return w.WriteByte('>')
 }
 
 // writeAny writes an arbitrary field.

--- a/proto/text_parser.go
+++ b/proto/text_parser.go
@@ -872,13 +872,9 @@ func (p *textParser) readAny(v reflect.Value, props *Properties) error {
 // UnmarshalText returns *RequiredNotSetError.
 func UnmarshalText(s string, pb Message) error {
 	if um, ok := pb.(encoding.TextUnmarshaler); ok {
-		err := um.UnmarshalText([]byte(s))
-		return err
+		return um.UnmarshalText([]byte(s))
 	}
 	pb.Reset()
 	v := reflect.ValueOf(pb)
-	if pe := newTextParser(s).readStruct(v.Elem(), ""); pe != nil {
-		return pe
-	}
-	return nil
+	return newTextParser(s).readStruct(v.Elem(), "")
 }

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -136,7 +136,7 @@ func (d *Descriptor) TypeName() []string {
 	for parent := d; parent != nil; parent = parent.parent {
 		n++
 	}
-	s := make([]string, n, n)
+	s := make([]string, n)
 	for parent := d; parent != nil; parent = parent.parent {
 		n--
 		s[n] = parent.GetName()


### PR DESCRIPTION
Found with honnef.co/go/tools/cmd/gosimple.

	proto/all_test.go:522:12: should use !strings.Contains(err.Error(), "Kind") instead (S1003)
	proto/all_test.go:1170:3: should merge variable declaration with assignment on next line (S1021)
	proto/all_test.go:1857:5: should use !strings.Contains(err.Error(), "RequiredField.Label") instead (S1003)
	proto/all_test.go:1873:5: should use !strings.Contains(err.Error(), "RequiredField.{Unknown}") instead (S1003)
	proto/all_test.go:1882:5: should use !strings.Contains(err.Error(), "RequiredField.Label") instead (S1003)
	proto/equal.go:149:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
	proto/message_set.go:97:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
	proto/properties.go:386:4: redundant break statement (S1023)
	proto/properties.go:434:4: redundant break statement (S1023)
	proto/properties.go:510:5: redundant break statement (S1023)
	proto/properties.go:520:5: redundant break statement (S1023)
	proto/properties.go:539:5: redundant break statement (S1023)
	proto/text.go:482:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
	proto/text_parser.go:891:2: 'if pe != nil { return pe }; return nil' can be simplified to 'return pe' (S1013)
	protoc-gen-go/generator/generator.go:137:22: should use make([]string, n) instead (S1019)