### PR TITLE
Remove unncessary conversions

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -753,7 +753,7 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 			if err != nil {
 				return fmt.Errorf("bad Timestamp: %v", err)
 			}
-			target.Field(0).SetInt(int64(t.Unix()))
+			target.Field(0).SetInt(t.Unix())
 			target.Field(1).SetInt(int64(t.Nanosecond()))
 			return nil
 		case "Struct":

--- a/proto/encode.go
+++ b/proto/encode.go
@@ -174,11 +174,11 @@ func sizeFixed32(x uint64) int {
 // This is the format used for the sint64 protocol buffer type.
 func (p *Buffer) EncodeZigzag64(x uint64) error {
 	// use signed number to get arithmetic right shift.
-	return p.EncodeVarint(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+	return p.EncodeVarint((x << 1) ^ uint64((int64(x) >> 63)))
 }
 
 func sizeZigzag64(x uint64) int {
-	return sizeVarint(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+	return sizeVarint((x << 1) ^ uint64((int64(x) >> 63)))
 }
 
 // EncodeZigzag32 writes a zigzag-encoded 32-bit integer

--- a/proto/text_parser.go
+++ b/proto/text_parser.go
@@ -865,7 +865,7 @@ func (p *textParser) readAny(v reflect.Value, props *Properties) error {
 		return p.readStruct(fv, terminator)
 	case reflect.Uint32:
 		if x, err := strconv.ParseUint(tok.value, 0, 32); err == nil {
-			fv.SetUint(uint64(x))
+			fv.SetUint(x)
 			return nil
 		}
 	case reflect.Uint64:


### PR DESCRIPTION
Found with github.com/mdempsky/unconvert.

	/Users/tamird/src/go/src/github.com/golang/protobuf/jsonpb/jsonpb.go:625:32: unnecessary conversion
	/Users/tamird/src/go/src/github.com/golang/protobuf/proto/encode.go:177:30: unnecessary conversion
	/Users/tamird/src/go/src/github.com/golang/protobuf/proto/encode.go:181:26: unnecessary conversion
	/Users/tamird/src/go/src/github.com/golang/protobuf/proto/text_parser.go:868:21: unnecessary conversion