### PR TITLE
support custom JSON (de)serialization by delegating to message if it implements json.Marshaler/json.Unmarshaler

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -553,9 +553,6 @@ func (u *Unmarshaler) UnmarshalNext(dec *json.Decoder, pb proto.Message) error {
 	if err := dec.Decode(&inputValue); err != nil {
 		return err
 	}
-	if jsu, ok := pb.(JSONPBUnmarshaler); ok {
-		return jsu.UnmarshalJSONPB(u, []byte(inputValue))
-	}
 	return u.unmarshalValue(reflect.ValueOf(pb).Elem(), inputValue, nil)
 }
 
@@ -597,6 +594,10 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 	if targetType.Kind() == reflect.Ptr {
 		target.Set(reflect.New(targetType.Elem()))
 		return u.unmarshalValue(target.Elem(), inputValue, prop)
+	}
+
+	if jsu, ok := target.Addr().Interface().(JSONPBUnmarshaler); ok {
+		return jsu.UnmarshalJSONPB(u, []byte(inputValue))
 	}
 
 	// Handle well-known types.

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -441,13 +441,13 @@ func TestMarshaling(t *testing.T) {
 
 func TestMarshalingWithJSONPBMarshaler(t *testing.T) {
 	rawJson := `{ "foo": "bar", "baz": [0, 1, 2, 3] }`
-	msg := notGeneratedMessage{rawJson: rawJson}
+	msg := dynamicMessage{rawJson: rawJson}
 	str, err := new(Marshaler).MarshalToString(&msg)
 	if err != nil {
 		t.Errorf("an unexpected error occurred when marshalling JSONPBMarshaler: %v", err)
 	}
 	if str != rawJson {
-		t.Errorf("Marshalling JSON produced incorrect output\nExpected: %s\nGot: %s", rawJson, str)
+		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, rawJson)
 	}
 }
 
@@ -650,38 +650,38 @@ func TestUnmarshalingBadInput(t *testing.T) {
 
 func TestUnmarshalWithJSONPBUnmarshaler(t *testing.T) {
 	rawJson := `{ "foo": "bar", "baz": [0, 1, 2, 3] }`
-	var msg notGeneratedMessage
+	var msg dynamicMessage
 	err := Unmarshal(strings.NewReader(rawJson), &msg)
 	if err != nil {
 		t.Errorf("an unexpected error occurred when parsing into JSONPBUnmarshaler: %v", err)
 	}
 	if msg.rawJson != rawJson {
-		t.Errorf("message contents not set correctly after unmarshalling JSON\nExpected: %s\nGot: %s", rawJson, msg.rawJson)
+		t.Errorf("message contents not set correctly after unmarshalling JSON: got %s, wanted %s", msg.rawJson, rawJson)
 	}
 }
 
-// Implements protobuf.Message but is not a normal generated message type. Provides
-// implementations of JSONPBMarshaler and JSONPBUnmarshaler for JSON support.
-type notGeneratedMessage struct {
+// dynamicMessage implements protobuf.Message but is not a normal generated message type.
+// It provides implementations of JSONPBMarshaler and JSONPBUnmarshaler for JSON support.
+type dynamicMessage struct {
 	rawJson string
 }
 
-func (m *notGeneratedMessage) Reset() {
+func (m *dynamicMessage) Reset() {
 	m.rawJson = "{}"
 }
 
-func (m *notGeneratedMessage) String() string {
+func (m *dynamicMessage) String() string {
 	return m.rawJson
 }
 
-func (m *notGeneratedMessage) ProtoMessage() {
+func (m *dynamicMessage) ProtoMessage() {
 }
 
-func (m *notGeneratedMessage) MarshalJSONPB(jm *Marshaler) ([]byte, error) {
+func (m *dynamicMessage) MarshalJSONPB(jm *Marshaler) ([]byte, error) {
 	return []byte(m.rawJson), nil
 }
 
-func (m *notGeneratedMessage) UnmarshalJSONPB(jum *Unmarshaler, json []byte) error {
+func (m *dynamicMessage) UnmarshalJSONPB(jum *Unmarshaler, json []byte) error {
 	m.rawJson = string(json)
 	return nil
 }


### PR DESCRIPTION
This is achieved by delegating to the message if it implements `json.Marshaler` or `json.Unmarshaler`.

FWIW, this could simplify how the well-known types are handled (e.g. no need to special-case them in this package).

Both the binary and text encodings support the same concept, where a message can implement a particular interface (`proto.Marshaler`/`proto.Unmarshaler`, `encoding.TextMarshaler`/`encoding.TextUnmarshaler`) to customize serialization/de-serialization. This just extends that same concept to JSON encoding/decoding.