### PR TITLE
Revert "Update to standard library context package."

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -53,7 +53,7 @@ const generatedCodeVersion = 4
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.
 const (
-	contextPkgPath = "context"
+	contextPkgPath = "golang.org/x/net/context"
 	grpcPkgPath    = "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
Reverts golang/protobuf#275

This is causing breakages for users. Will investigate more in-depth tomorrow.