### PR TITLE
Implement JSON unmarshaling for Any

### DIFF
--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -484,6 +484,7 @@ var unmarshalingTests = []struct {
 	{"BytesValue", Unmarshaler{}, `{"bytes":"d293"}`, &pb.KnownTypes{Bytes: &wpb.BytesValue{Value: []byte("wow")}}},
 	// `null` is also a permissible value. Let's just test one.
 	{"null DoubleValue", Unmarshaler{}, `{"dbl":null}`, &pb.KnownTypes{Dbl: &wpb.DoubleValue{}}},
+	{"Any with message", Unmarshaler{}, anySimpleJSON, anySimple},
 }
 
 func TestUnmarshaling(t *testing.T) {


### PR DESCRIPTION
The Any type has already support for marshalling, but the unmarshaling of it was left unimplemented.

This PR simply implements the clearly missing feature. I tired to stay as close as possible in terms of approach and coding style as similar code in this file.

We get the test almost for free.