### PR TITLE
Respect json_name option in go json tags

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1783,6 +1783,9 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		fieldName, fieldGetterName := ns[0], ns[1]
 		typename, wiretype := g.GoType(message, field)
 		jsonName := *field.Name
+		if json := field.GetJsonName(); json != "" {
+			jsonName = json
+		}
 		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
 
 		fieldNames[field] = fieldName


### PR DESCRIPTION
```
message Foo {
    int64 Bar = 1 [json_name="b"];
}
```

Fixes a bug when the .proto file above doesn't respect "json_name" option and generates:

```
type Foo struct {
    Bar int64 `protobuf:"varint,1,opt,name=Bar,json=b,proto3" json:"Bar,omitempty"`
}
```

instead of:

```
type Foo struct {
    Bar int64 `protobuf:"varint,1,opt,name=Bar,json=b,proto3" json:"b,omitempty"`
}
```