### PR TITLE
Convert JSON 0/1 bools to protobuf bools

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -516,6 +516,10 @@ type Unmarshaler struct {
 	// Whether to allow messages to contain unknown fields, as opposed to
 	// failing to unmarshal.
 	AllowUnknownFields bool
+
+	// Whether or not we should try to convert json 0/1 integer bools to
+	// protobuf bools.
+	ConvertBools bool
 }
 
 // UnmarshalNext unmarshals the next protocol buffer from a JSON object stream.
@@ -780,6 +784,18 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 		inputValue = inputValue[1 : len(inputValue)-1]
 	}
 
+	// If target type is bool and the value is 1 or 0, assume it was supposed to be a bool
+	if u.ConvertBools && targetType == reflect.TypeOf(true) {
+		// Use ascii values of 1 and 0 for efficiency
+		switch inputValue[0] {
+		case 49:
+			val := strconv.AppendBool([]byte{}, true)
+			return json.Unmarshal(val, target.Addr().Interface())
+		case 48:
+			val := strconv.AppendBool([]byte{}, false)
+			return json.Unmarshal(val, target.Addr().Interface())
+		}
+	}
 	// Use the encoding/json for parsing other value types.
 	return json.Unmarshal(inputValue, target.Addr().Interface())
 }


### PR DESCRIPTION
Many json messages use 0/1 values for booleans, specifically older
versions of openrtb messages. Other than this difference the json
and protobuf objects align perfectly. A setting to allow the
Unmarshaler to detect and convert these fields would be very useful
for integrating with systems using json openrtb messages while
using the current protobuf version internally.