### PR TITLE
Simplify the installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use this software, you must:
   for details or, if you are using gccgo, follow the instructions at
 	https://golang.org/doc/install/gccgo
 - Grab the code from the repository and install the proto package.
-  The simplest way is to run `go get -u github.com/golang/protobuf/{proto,protoc-gen-go}`.
+  The simplest way is to run `go get -u github.com/golang/protobuf/protoc-gen-go`.
   The compiler plugin, protoc-gen-go, will be installed in $GOBIN,
   defaulting to $GOPATH/bin.  It must be in your $PATH for the protocol
   compiler, protoc, to find it.


### PR DESCRIPTION
The curlies in the go get argument is very unknown, I have
witnessed a few users parsing the argument to run the following
commands indiviually rather than copy/pasting the instruction:

$ go get -u github.com/golang/protobuf/protoc-gen-go
$ go get -u github.com/golang/protobuf/proto

go get the protoc-gen-go to simplify this step.