### PR TITLE
protoc-gen-go: update Makefiles for protobuf 3.3.0

### DIFF
--- a/protoc-gen-go/descriptor/Makefile
+++ b/protoc-gen-go/descriptor/Makefile
@@ -32,8 +32,5 @@
 # Not stored here, but descriptor.proto is in https://github.com/google/protobuf/
 # at src/google/protobuf/descriptor.proto
 regenerate:
-	echo WARNING! THIS RULE IS PROBABLY NOT RIGHT FOR YOUR INSTALLATION
-	protoc --go_out=. -I$(HOME)/src/protobuf/src $(HOME)/src/protobuf/src/google/protobuf/descriptor.proto && \
-		sed 's,^package google_protobuf,package descriptor,' google/protobuf/descriptor.pb.go > \
-		$(GOPATH)/src/github.com/golang/protobuf/protoc-gen-go/descriptor/descriptor.pb.go && \
-		rm -f google/protobuf/descriptor.pb.go
+	@echo WARNING! THIS RULE IS PROBABLY NOT RIGHT FOR YOUR INSTALLATION
+	protoc --go_out=../../../../.. -I$(HOME)/src/protobuf/include $(HOME)/src/protobuf/include/google/protobuf/descriptor.proto

--- a/protoc-gen-go/plugin/Makefile
+++ b/protoc-gen-go/plugin/Makefile
@@ -33,10 +33,9 @@
 # at src/google/protobuf/compiler/plugin.proto
 # Also we need to fix an import.
 regenerate:
-	echo WARNING! THIS RULE IS PROBABLY NOT RIGHT FOR YOUR INSTALLATION
-	protoc --go_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor:. \
-		-I$(HOME)/src/protobuf/src $(HOME)/src/protobuf/src/google/protobuf/compiler/plugin.proto && \
-		mv google/protobuf/compiler/plugin.pb.go $(GOPATH)/src/github.com/golang/protobuf/protoc-gen-go/plugin
+	@echo WARNING! THIS RULE IS PROBABLY NOT RIGHT FOR YOUR INSTALLATION
+	protoc --go_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor:../../../../.. \
+		-I$(HOME)/src/protobuf/include $(HOME)/src/protobuf/include/google/protobuf/compiler/plugin.proto
 
 restore:
 	cp plugin.pb.golden plugin.pb.go


### PR DESCRIPTION
Instead of using checked out source, this now works with a binary
release.  Descriptor now has the go_package option set, so we no longer
need to move the files around.