### PR TITLE
fix marshaling of any types to JSON when contained object has custom marshaling

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -127,7 +127,7 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 			// we are marshaling this object to an Any type
 			var js map[string]*json.RawMessage
 			if err = json.Unmarshal(b, &js); err != nil {
-				return fmt.Errorf("type %v produced invalid JSON: %v", reflect.TypeOf(v), err)
+				return fmt.Errorf("type %T produced invalid JSON: %v", v, err)
 			}
 			turl, err := json.Marshal(typeURL)
 			if err != nil {
@@ -670,7 +670,7 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 				}
 
 				if err := u.unmarshalValue(reflect.ValueOf(m).Elem(), *val, nil); err != nil {
-					return fmt.Errorf("can't unmarshal Any nested proto %v: %v", reflect.TypeOf(m), err)
+					return fmt.Errorf("can't unmarshal Any nested proto %T: %v", m, err)
 				}
 			} else {
 				delete(jsonFields, "@type")
@@ -680,13 +680,13 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 				}
 
 				if err = u.unmarshalValue(reflect.ValueOf(m).Elem(), nestedProto, nil); err != nil {
-					return fmt.Errorf("can't unmarshal Any nested proto %v: %v", reflect.TypeOf(m), err)
+					return fmt.Errorf("can't unmarshal Any nested proto %T: %v", m, err)
 				}
 			}
 
 			b, err := proto.Marshal(m)
 			if err != nil {
-				return fmt.Errorf("can't marshal proto %v into Any.Value: %v", reflect.TypeOf(m), err)
+				return fmt.Errorf("can't marshal proto %T into Any.Value: %v", m, err)
 			}
 			target.Field(1).SetBytes(b)
 

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -34,6 +34,7 @@ package jsonpb
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -43,6 +44,7 @@ import (
 
 	pb "github.com/golang/protobuf/jsonpb/jsonpb_test_proto"
 	proto3pb "github.com/golang/protobuf/proto/proto3_proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
 	durpb "github.com/golang/protobuf/ptypes/duration"
 	stpb "github.com/golang/protobuf/ptypes/struct"
@@ -454,6 +456,55 @@ func TestMarshalingWithJSONPBMarshaler(t *testing.T) {
 	}
 }
 
+func TestMarshalingToAnyWithJSONPBMarshaler(t *testing.T) {
+	msg := dynamicMessage{rawJson: `{ "foo": "bar", "baz": [0, 1, 2, 3] }`}
+	a, err := ptypes.MarshalAny(&msg)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling to Any: %v", err)
+	}
+	str, err := new(Marshaler).MarshalToString(a)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling Any to JSON: %v", err)
+	}
+	// after custom marshaling, it's round-tripped through JSON decoding/encoding already,
+	// so the keys are sorted, whitespace is compacted, and "@type" key has been added
+	expected := `{"@type":"type.googleapis.com/` + dynamicMessageName +`","baz":[0,1,2,3],"foo":"bar"}`
+	if str != expected {
+		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
+	}
+}
+
+func TestMarshalingToAnyWithJSONPBMarshalerCustomJSON(t *testing.T) {
+	// first try will fail because we're producing invalid JSON object
+	var msg proto.Message = &dynamicMessage{rawJson: `"fubar"`}
+	a, err := ptypes.MarshalAny(msg)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling to Any: %v", err)
+	}
+	str, err := new(Marshaler).MarshalToString(a)
+	if err == nil || !strings.Contains(err.Error(), "illegally produced JSON that is not an object") {
+		t.Errorf(`expected error message "illegally produced JSON that is not an object" but instead got %v`, err)
+	}
+
+	// now we try, but with custom marshaling that allows non-object JSON type
+	msg = &dynamicMessageCustomJson{dynamicMessage{rawJson: `"fubar"`}}
+	a, err = ptypes.MarshalAny(msg)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling to Any: %v", err)
+	}
+	str, err = new(Marshaler).MarshalToString(a)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling Any to JSON: %v", err)
+	}
+
+	// after custom marshaling, it's round-tripped through JSON decoding/encoding already,
+	// so the keys are sorted, whitespace is compacted, and "@type" key has been added
+	expected := `{"@type":"type.googleapis.com/` + dynamicMessageCustomJsonName +`","value":"fubar"}`
+	if str != expected {
+		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
+	}
+}
+
 var unmarshalingTests = []struct {
 	desc        string
 	unmarshaler Unmarshaler
@@ -654,13 +705,60 @@ func TestUnmarshalingBadInput(t *testing.T) {
 func TestUnmarshalWithJSONPBUnmarshaler(t *testing.T) {
 	rawJson := `{ "foo": "bar", "baz": [0, 1, 2, 3] }`
 	var msg dynamicMessage
-	err := Unmarshal(strings.NewReader(rawJson), &msg)
-	if err != nil {
+	if err := Unmarshal(strings.NewReader(rawJson), &msg); err != nil {
 		t.Errorf("an unexpected error occurred when parsing into JSONPBUnmarshaler: %v", err)
 	}
 	if msg.rawJson != rawJson {
 		t.Errorf("message contents not set correctly after unmarshalling JSON: got %s, wanted %s", msg.rawJson, rawJson)
 	}
+}
+
+func TestUnmarshalAnyWithJSONPBUnmarshaler(t *testing.T) {
+	rawJson := `{ "@type": "blah.com/` + dynamicMessageName + `", "foo": "bar", "baz": [0, 1, 2, 3] }`
+	var a anypb.Any
+	if err := Unmarshal(strings.NewReader(rawJson), &a); err != nil {
+		t.Errorf("an unexpected error occurred when parsing into JSONPBUnmarshaler: %v", err)
+	}
+	var msg ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(&a, &msg); err != nil {
+		t.Errorf("an unexpected error occurred when parsing from Any type: %v", err)
+	}
+	dm := msg.Message.(*dynamicMessage)
+	// when it gets to the custom unmarshal, it's round-tripped through JSON decoding/encoding
+	// already, so the keys are sorted, whitespace is compacted, and "@type" key has been removed
+	expected := `{"baz":[0,1,2,3],"foo":"bar"}`
+	if dm.rawJson != expected {
+		t.Errorf("message contents not set correctly after unmarshalling JSON: got %s, wanted %s", dm.rawJson, expected)
+	}
+}
+
+func TestUnmarshalAnyWithJSONPBUnmarshalerCustomJSON(t *testing.T) {
+	// with custom JSON, we unmarshal contents at "value" key instead of whole JSON object
+	rawJson := `{ "@type": "blah.com/` + dynamicMessageCustomJsonName + `", "value": "fubar"}`
+	var a anypb.Any
+	if err := Unmarshal(strings.NewReader(rawJson), &a); err != nil {
+		t.Errorf("an unexpected error occurred when parsing into JSONPBUnmarshaler: %v", err)
+	}
+	var msg ptypes.DynamicAny
+	if err := ptypes.UnmarshalAny(&a, &msg); err != nil {
+		t.Errorf("an unexpected error occurred when parsing from Any type: %v", err)
+	}
+	dm := msg.Message.(*dynamicMessageCustomJson)
+	// when it gets to the custom unmarshal, it's round-tripped through JSON decoding/encoding
+	// already, so the keys are sorted, whitespace is compacted, and "@type" key has been removed
+	if dm.rawJson != `"fubar"` {
+		t.Errorf("message contents not set correctly after unmarshalling JSON: got %s, wanted %s", dm.rawJson, `"fubar"`)
+	}
+}
+
+const (
+	dynamicMessageName = "google.protobuf.jsonpb.testing.dynamicMessage"
+	dynamicMessageCustomJsonName = "google.protobuf.jsonpb.testing.dynamicMessageCustomJson"
+)
+func init() {
+	// we register the custom types below so that we can use them in Any types
+	proto.RegisterType((*dynamicMessage)(nil), dynamicMessageName)
+	proto.RegisterType((*dynamicMessageCustomJson)(nil), dynamicMessageCustomJsonName)
 }
 
 // dynamicMessage implements protobuf.Message but is not a normal generated message type.
@@ -684,7 +782,45 @@ func (m *dynamicMessage) MarshalJSONPB(jm *Marshaler) ([]byte, error) {
 	return []byte(m.rawJson), nil
 }
 
-func (m *dynamicMessage) UnmarshalJSONPB(jum *Unmarshaler, json []byte) error {
-	m.rawJson = string(json)
+func (m *dynamicMessage) UnmarshalJSONPB(jum *Unmarshaler, js []byte) error {
+	m.rawJson = string(js)
 	return nil
+}
+
+func (m *dynamicMessage) Marshal() ([]byte, error) {
+	var b proto.Buffer
+	// tag #1, wire type length-delimited
+	if err := b.EncodeVarint(uint64((1 << 3) | proto.WireBytes)); err != nil {
+		return nil, err
+	}
+	if err := b.EncodeRawBytes([]byte(m.rawJson)); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func (m *dynamicMessage) Unmarshal(b []byte) error {
+	// really dumb unmarshalling, just for test
+	buf := proto.NewBuffer(b)
+	if tagAndWire, err := buf.DecodeVarint(); err != nil {
+		return err
+	} else if tagAndWire != uint64((1 << 3) | proto.WireBytes) {
+		return fmt.Errorf("Unknown tag/wire type: %x", tagAndWire)
+	}
+	if bb, err := buf.DecodeRawBytes(true); err != nil {
+		return err
+	} else {
+		m.rawJson = string(bb)
+	}
+	return nil
+}
+
+// dynamicMessageCustomJson is the same as dynamicMessage except it also provides
+// XXX_CustomJSON method, for marshaling to non-object JSON types.
+type dynamicMessageCustomJson struct {
+	dynamicMessage
+}
+
+func (m *dynamicMessageCustomJson) XXX_CustomJSON() bool {
+	return true
 }


### PR DESCRIPTION
This should address #360 

I included support for the custom message type to marshal itself into JSON types other than object. So it's a little more flexible than the solution @cybrcodr suggested in #360.

Also fixed a potential nil-dereference panic if an Any type was unmarshaled from bad JSON that had a null type:
```json
{ "@type": null, "key": "value" }
```