### PR TITLE
Return registered nil Message

### DIFF
--- a/proto/properties.go
+++ b/proto/properties.go
@@ -826,8 +826,9 @@ func EnumValueMap(enumType string) map[string]int32 {
 // A registry of all linked message types.
 // The string is a fully-qualified proto name ("pkg.Message").
 var (
-	protoTypes    = make(map[string]reflect.Type)
-	revProtoTypes = make(map[reflect.Type]string)
+	protoTypes         = make(map[string]reflect.Type)
+	revProtoTypes      = make(map[reflect.Type]string)
+	registeredMessages = make(map[string]Message)
 )
 
 // RegisterType is called from generated code and maps from the fully qualified
@@ -841,6 +842,7 @@ func RegisterType(x Message, name string) {
 	t := reflect.TypeOf(x)
 	protoTypes[name] = t
 	revProtoTypes[t] = name
+	registeredMessages[name] = x
 }
 
 // MessageName returns the fully-qualified proto name for the given message type.
@@ -856,6 +858,9 @@ func MessageName(x Message) string {
 
 // MessageType returns the message type (pointer to struct) for a named message.
 func MessageType(name string) reflect.Type { return protoTypes[name] }
+
+// MessageRegistered returns the registered nil-value message (pointer to struct) for a named message.
+func MessageRegistered(name string) Message { return registeredMessages[name] }
 
 // A registry of all linked proto files.
 var (


### PR DESCRIPTION
### What this PR do
1, Make a map:  
`registeredMessages = make(map[string]Message)`
2, Store registered Message:
`registeredMessages[name] = x`
3, Return this Message by name:
`func MessageRegistered(name string) Message { return registeredMessages[name] }`
### Why
To lookup field options of request struct in a "google.golang.org/grpc.UnaryInterceptor", I have to:
1, With "req interface{}" as input, find the TypeName using reflection.
2, With TypeName, call MessageRegistered() to get a proto.Message.
3, With a proto.Message, call 
`_, md = descriptor.ForMessage( protoMessage.(descriptor.Message)  )`
`opt, err := proto.GetExtension(md.GetField()[0].Options, E_SomeOption)`
to get option value.

This PR adds the func to be used in step 2.