### PR TITLE
generator: use consistent ModTime across go1.7 and go1.8

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -49,6 +49,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -2607,6 +2608,7 @@ func (g *Generator) generateFileDescriptor(file *FileDescriptor) {
 
 	var buf bytes.Buffer
 	w, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	w.Header.ModTime = time.Unix(0, 1) // consistent, non-zero val for time
 	w.Write(b)
 	w.Close()
 	b = buf.Bytes()


### PR DESCRIPTION
without this change, protos generated by golang 1.7 and golang 1.8 differ because gzip on golang 1.7 uses "nonsense" values for ModTime when it's a zeroval (see golang 1.8 changelog w/ respect to gzip changes)

xref https://github.com/gogo/protobuf/pull/303