### PR TITLE
Unmarshal a value which implements JSONPBUnmarshaler

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -673,7 +673,8 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 	if targetType.Kind() == reflect.Ptr {
 		// If input value is "null" and target is a pointer type, then the field should be treated as not set
 		// UNLESS the target is structpb.Value, in which case it should be set to structpb.NullValue.
-		if string(inputValue) == "null" && targetType != reflect.TypeOf(&stpb.Value{}) {
+		_, isJSONPBUnmarshaler := target.Interface().(JSONPBUnmarshaler)
+		if string(inputValue) == "null" && targetType != reflect.TypeOf(&stpb.Value{}) && !isJSONPBUnmarshaler {
 			return nil
 		}
 		target.Set(reflect.New(targetType.Elem()))


### PR DESCRIPTION
Hi, our test cases are failed by #394 .  
We defined a struct which implements interface `JSONPBUnmarshaler`, and use it as a field in another message, for example:
```protobuf
message MyString {
  bool null = 1;
  string value = 2;
}
message Request {
  MyString name = 1;
}
```
`MyString` implements `JSONPBUnmarshaler `.

Before #394 , everything works fine.  
After #394 , if input json is `{"name": null}`, func `UnmarshalJSONPB` on `MyString` is not executed. Because it will return earlier:
```go
if string(inputValue) == "null" && targetType != reflect.TypeOf(&stpb.Value{}) {
	return nil   // <---returned here
}
```
