### PR TITLE
proto: resuse buffers in proto

### DIFF
--- a/proto/encode.go
+++ b/proto/encode.go
@@ -232,6 +232,7 @@ func Marshal(pb Message) ([]byte, error) {
 	if m, ok := pb.(Marshaler); ok {
 		return m.Marshal()
 	}
+
 	p := NewBuffer(nil)
 	err := p.Marshal(pb)
 	if p.buf == nil && err == nil {
@@ -748,8 +749,13 @@ func (o *Buffer) enc_slice_packed_int32(p *Properties, base structPointer) error
 	if l == 0 {
 		return ErrNil
 	}
-	// TODO: Reuse a Buffer.
-	buf := NewBuffer(nil)
+
+	buf := bufPool.Get().(*Buffer)
+	defer func() {
+		buf.Reset()
+		bufPool.Put(buf)
+	}()
+
 	for i := 0; i < l; i++ {
 		x := int32(s.Index(i)) // permit sign extension to use full 64-bit range
 		p.valEnc(buf, uint64(x))
@@ -817,8 +823,13 @@ func (o *Buffer) enc_slice_packed_uint32(p *Properties, base structPointer) erro
 	if l == 0 {
 		return ErrNil
 	}
-	// TODO: Reuse a Buffer.
-	buf := NewBuffer(nil)
+
+	buf := bufPool.Get().(*Buffer)
+	defer func() {
+		buf.Reset()
+		bufPool.Put(buf)
+	}()
+
 	for i := 0; i < l; i++ {
 		p.valEnc(buf, uint64(s.Index(i)))
 	}
@@ -880,8 +891,13 @@ func (o *Buffer) enc_slice_packed_int64(p *Properties, base structPointer) error
 	if l == 0 {
 		return ErrNil
 	}
-	// TODO: Reuse a Buffer.
-	buf := NewBuffer(nil)
+
+	buf := bufPool.Get().(*Buffer)
+	defer func() {
+		buf.Reset()
+		bufPool.Put(buf)
+	}()
+
 	for i := 0; i < l; i++ {
 		p.valEnc(buf, s.Index(i))
 	}

--- a/proto/extensions.go
+++ b/proto/extensions.go
@@ -439,7 +439,13 @@ func defaultExtensionValue(extension *ExtensionDesc) (interface{}, error) {
 
 // decodeExtension decodes an extension encoded in b.
 func decodeExtension(b []byte, extension *ExtensionDesc) (interface{}, error) {
-	o := NewBuffer(b)
+	o := bufPool.Get().(*Buffer)
+	o.SetBuf(b)
+	defer func() {
+		o.Reset()
+		bufPool.Put(o)
+	}()
+
 
 	t := reflect.TypeOf(extension.ExtensionType)
 

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -296,6 +296,11 @@ type Stats struct {
 const collectStats = false
 
 var stats Stats
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		return &Buffer{}
+	},
+}
 
 // GetStats returns a copy of the global Stats structure.
 func GetStats() Stats { return stats }

--- a/proto/text.go
+++ b/proto/text.go
@@ -609,7 +609,14 @@ func writeUnknownStruct(w *textWriter, data []byte) (err error) {
 			return err
 		}
 	}
-	b := NewBuffer(data)
+
+	b := bufPool.Get().(*Buffer)
+	b.SetBuf(data)
+	defer func() {
+		b.Reset()
+		bufPool.Put(b)
+	}()
+
 	for b.index < len(b.buf) {
 		x, err := b.DecodeVarint()
 		if err != nil {


### PR DESCRIPTION
Completed some TODOs that wanted to reuse buffers. Included the sync.Pool struct to tackle task. I've only replaced buffers where they are used for encoding/decoding byte streams