### PR TITLE
grpc: generate idempotency level for service description

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -393,6 +393,7 @@ func (g *grpc) generateServerMethod(servName, fullServName string, method *pb.Me
 		g.P("info := &", grpcPkg, ".UnaryServerInfo{")
 		g.P("Server: srv,")
 		g.P("FullMethod: ", strconv.Quote(fmt.Sprintf("/%s/%s", fullServName, methName)), ",")
+		g.P("IdempotencyLevel: grpc.", method.GetOptions().GetIdempotencyLevel().String(), ",")
 		g.P("}")
 		g.P("handler := func(ctx ", contextPkg, ".Context, req interface{}) (interface{}, error) {")
 		g.P("return srv.(", servName, "Server).", methName, "(ctx, req.(*", inType, "))")


### PR DESCRIPTION
Protoc now supports an `idempotency_level` method option: https://github.com/google/protobuf/blob/9e745f7/src/google/protobuf/descriptor.proto#L630. The method option can be used to mark the idempotency of a gRPC method.

This change adds the idempotency level information to the generated service descriptions for use in e.g. gRPC server interceptors enforcing idempotency guarantees.