### PR TITLE
JSONPb check enum int values

### DIFF
--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -245,13 +245,6 @@ var (
  "color": 2
 }`
 
-	colorListPrettyJSON = `{
-  "color": 1000,
-  "rColor": [
-    "RED"
-  ]
-}`
-
 	nummyPrettyJSON = `{
   "nummy": {
     "1": 2,
@@ -354,8 +347,6 @@ var marshalingTests = []struct {
 		&pb.Widget{Color: pb.Widget_BLUE.Enum()}, `{"color":"BLUE"}`},
 	{"enum-value pretty object", Marshaler{EnumsAsInts: true, Indent: " "},
 		&pb.Widget{Color: pb.Widget_BLUE.Enum()}, colorPrettyJSON},
-	{"unknown enum value object", marshalerAllOptions,
-		&pb.Widget{Color: pb.Widget_Color(1000).Enum(), RColor: []pb.Widget_Color{pb.Widget_RED}}, colorListPrettyJSON},
 	{"repeated proto3 enum", Marshaler{},
 		&proto3pb.Message{RFunny: []proto3pb.Message_Humour{
 			proto3pb.Message_PUNS,
@@ -510,10 +501,6 @@ var unmarshalingTests = []struct {
 	{"unknown field with allowed option", Unmarshaler{AllowUnknownFields: true}, `{"unknown": "foo"}`, new(pb.Simple)},
 	{"proto3 enum string", Unmarshaler{}, `{"hilarity":"PUNS"}`, &proto3pb.Message{Hilarity: proto3pb.Message_PUNS}},
 	{"proto3 enum value", Unmarshaler{}, `{"hilarity":1}`, &proto3pb.Message{Hilarity: proto3pb.Message_PUNS}},
-	{"unknown enum value object",
-		Unmarshaler{},
-		"{\n  \"color\": 1000,\n  \"r_color\": [\n    \"RED\"\n  ]\n}",
-		&pb.Widget{Color: pb.Widget_Color(1000).Enum(), RColor: []pb.Widget_Color{pb.Widget_RED}}},
 	{"repeated proto3 enum", Unmarshaler{}, `{"rFunny":["PUNS","SLAPSTICK"]}`,
 		&proto3pb.Message{RFunny: []proto3pb.Message_Humour{
 			proto3pb.Message_PUNS,
@@ -711,6 +698,7 @@ var unmarshalingShouldError = []struct {
 	{"gibberish", "{adskja123;l23=-=", new(pb.Simple)},
 	{"unknown field", `{"unknown": "foo"}`, new(pb.Simple)},
 	{"unknown enum name", `{"hilarity":"DAVE"}`, new(proto3pb.Message)},
+	{"unkownn enum value", `{"hilarity": 1000}`, new(proto3pb.Message)},
 }
 
 func TestUnmarshalingBadInput(t *testing.T) {

--- a/proto/properties.go
+++ b/proto/properties.go
@@ -806,21 +806,31 @@ func getbase(pb Message) (t reflect.Type, b structPointer, err error) {
 // A global registry of enum types.
 // The generated code will register the generated maps by calling RegisterEnum.
 
-var enumValueMaps = make(map[string]map[string]int32)
+var (
+	enumValueMaps = make(map[string]map[string]int32)
+	enumNameMaps  = make(map[string]map[int32]string)
+)
 
 // RegisterEnum is called from the generated code to install the enum descriptor
 // maps into the global table to aid parsing text format protocol buffers.
-func RegisterEnum(typeName string, unusedNameMap map[int32]string, valueMap map[string]int32) {
+func RegisterEnum(typeName string, nameMap map[int32]string, valueMap map[string]int32) {
 	if _, ok := enumValueMaps[typeName]; ok {
 		panic("proto: duplicate enum registered: " + typeName)
 	}
 	enumValueMaps[typeName] = valueMap
+	enumNameMaps[typeName] = nameMap
 }
 
 // EnumValueMap returns the mapping from names to integers of the
 // enum type enumType, or a nil if not found.
 func EnumValueMap(enumType string) map[string]int32 {
 	return enumValueMaps[enumType]
+}
+
+// EnumNameMap returns the mapping from integers to string of the
+// enum type enumType, or an empty string if not found.
+func EnumNameMap(enumType string) map[int32]string {
+	return enumNameMaps[enumType]
 }
 
 // A registry of all linked message types.


### PR DESCRIPTION
This checks enum integer values for JSONPb. Breaks one test that says this behavior is acceptable. However this caused a bug for me as I expected JSONPb to handled serialization to a know enum type.