### PR TITLE
make json tag the same name as protobuf json_name

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1781,7 +1781,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		ns := allocNames(base, "Get"+base)
 		fieldName, fieldGetterName := ns[0], ns[1]
 		typename, wiretype := g.GoType(message, field)
-		jsonName := *field.Name
+		jsonName := field.GetJsonName()
 		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
 
 		fieldNames[field] = fieldName


### PR DESCRIPTION
Currently, the generator uses field name as json name, so set the `json_name` of field make none sense.

```
syntax = "proto3";

message Foo {
    string id = 1 [json_name = "_id"];
}
```

will generate go struct:

```
type Foo struct {
	Id string `protobuf:"bytes,1,opt,name=id,json=_id" json:"id,omitempty"`
}
```