### PR TITLE
Remove raw interface

### DIFF
--- a/proto/equal.go
+++ b/proto/equal.go
@@ -109,15 +109,6 @@ func equalStruct(v1, v2 reflect.Value) bool {
 				// set/unset mismatch
 				return false
 			}
-			b1, ok := f1.Interface().(raw)
-			if ok {
-				b2 := f2.Interface().(raw)
-				// RawMessage
-				if !bytes.Equal(b1.Bytes(), b2.Bytes()) {
-					return false
-				}
-				continue
-			}
 			f1, f2 = f1.Elem(), f2.Elem()
 		}
 		if !equalAny(f1, f2, sprop.Prop[i]) {

--- a/proto/text.go
+++ b/proto/text.go
@@ -169,11 +169,6 @@ func writeName(w *textWriter, props *Properties) error {
 	return nil
 }
 
-// raw is the interface satisfied by RawMessage.
-type raw interface {
-	Bytes() []byte
-}
-
 func requiresQuotes(u string) bool {
 	// When type URL contains any characters except [0-9A-Za-z./\-]*, it must be quoted.
 	for _, ch := range u {
@@ -438,12 +433,6 @@ func (tm *TextMarshaler) writeStruct(w *textWriter, sv reflect.Value) error {
 			if err := w.WriteByte(' '); err != nil {
 				return err
 			}
-		}
-		if b, ok := fv.Interface().(raw); ok {
-			if err := writeRaw(w, b.Bytes()); err != nil {
-				return err
-			}
-			continue
 		}
 
 		// Enums have a String method, so writeAny will work fine.


### PR DESCRIPTION
There is an internal type to Google called RawMessage that is similar
to json.RawMessage. Since there is no proper proto reflection API,
we special-cased the Bytes method of RawMessage to access the raw bytes.
This is a gross hack since Bytes() []byte is such a common method signature.

Remove this hack.

Fixes #311