### PR TITLE
[dev] protoc-gen-go: format interfaces for gofmt 1.9 and 1.10

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2174,7 +2174,11 @@ func (g *Generator) generateMessage(message *Descriptor) {
 	// TODO: Revisit this and consider reverting back to anonymous interfaces.
 	for oi := range message.OneofDecl {
 		dname := oneofDisc[int32(oi)]
-		g.P("type ", dname, " interface { ", dname, "() }")
+		g.P("type ", dname, " interface {")
+		g.In()
+		g.P(dname, "()")
+		g.Out()
+		g.P("}")
 	}
 	g.P()
 	for i, field := range message.Field {


### PR DESCRIPTION
Change the pre-gofmt generated code for oneof discriminant interfaces
from:
  type T interface { T() }
to:
  type T interface {
  T()
  }

Prior to Go 1.9, gofmt rewrote the single-line form into the multi-line
one. Go 1.10 and later preserve the single-line form for single-method
interfaces. Generating code that is handled identically by both versions
of gofmt avoids spurious diffs with golden test data.

Change-Id: Ibb229827823a50e963bcd1b34e59a286654b415f