### PR TITLE
proto: remove Proto3UnknownFields flag

### DIFF
--- a/_conformance/conformance.pb.go
+++ b/_conformance/conformance.pb.go
@@ -127,7 +127,7 @@ type ConformanceRequest struct {
 	// Which format should the testee serialize its message to?
 	RequestedOutputFormat WireFormat `protobuf:"varint,3,opt,name=requested_output_format,json=requestedOutputFormat,enum=conformance.WireFormat" json:"requested_output_format,omitempty"`
 	XXX_NoUnkeyedLiteral  struct{}   `json:"-"`
-	XXX_unrecognized      []byte     `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized      []byte     `json:"-"`
 	XXX_sizecache         int32      `json:"-"`
 }
 
@@ -272,7 +272,7 @@ type ConformanceResponse struct {
 	//	*ConformanceResponse_Skipped
 	Result               isConformanceResponse_Result `protobuf_oneof:"result"`
 	XXX_NoUnkeyedLiteral struct{}                     `json:"-"`
-	XXX_unrecognized     []byte                       `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte                       `json:"-"`
 	XXX_sizecache        int32                        `json:"-"`
 }
 
@@ -634,7 +634,7 @@ type TestAllTypes struct {
 	FieldName17__        int32    `protobuf:"varint,417,opt,name=field_name17__,json=fieldName17" json:"field_name17__,omitempty"`
 	FieldName18__        int32    `protobuf:"varint,418,opt,name=Field_name18__,json=FieldName18" json:"Field_name18__,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -1719,7 +1719,7 @@ type TestAllTypes_NestedMessage struct {
 	A                    int32         `protobuf:"varint,1,opt,name=a" json:"a,omitempty"`
 	Corecursive          *TestAllTypes `protobuf:"bytes,2,opt,name=corecursive" json:"corecursive,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
 }
 
@@ -1762,7 +1762,7 @@ func (m *TestAllTypes_NestedMessage) GetCorecursive() *TestAllTypes {
 type ForeignMessage struct {
 	C                    int32    `protobuf:"varint,1,opt,name=c" json:"c,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 

--- a/_conformance/conformance_proto/conformance.pb.go
+++ b/_conformance/conformance_proto/conformance.pb.go
@@ -127,7 +127,7 @@ type ConformanceRequest struct {
 	// Which format should the testee serialize its message to?
 	RequestedOutputFormat WireFormat `protobuf:"varint,3,opt,name=requested_output_format,json=requestedOutputFormat,enum=conformance.WireFormat" json:"requested_output_format,omitempty"`
 	XXX_NoUnkeyedLiteral  struct{}   `json:"-"`
-	XXX_unrecognized      []byte     `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized      []byte     `json:"-"`
 	XXX_sizecache         int32      `json:"-"`
 }
 
@@ -272,7 +272,7 @@ type ConformanceResponse struct {
 	//	*ConformanceResponse_Skipped
 	Result               isConformanceResponse_Result `protobuf_oneof:"result"`
 	XXX_NoUnkeyedLiteral struct{}                     `json:"-"`
-	XXX_unrecognized     []byte                       `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte                       `json:"-"`
 	XXX_sizecache        int32                        `json:"-"`
 }
 
@@ -634,7 +634,7 @@ type TestAllTypes struct {
 	FieldName17__        int32    `protobuf:"varint,417,opt,name=field_name17__,json=fieldName17" json:"field_name17__,omitempty"`
 	FieldName18__        int32    `protobuf:"varint,418,opt,name=Field_name18__,json=fieldName18" json:"Field_name18__,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -1719,7 +1719,7 @@ type TestAllTypes_NestedMessage struct {
 	A                    int32         `protobuf:"varint,1,opt,name=a" json:"a,omitempty"`
 	Corecursive          *TestAllTypes `protobuf:"bytes,2,opt,name=corecursive" json:"corecursive,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
 }
 
@@ -1762,7 +1762,7 @@ func (m *TestAllTypes_NestedMessage) GetCorecursive() *TestAllTypes {
 type ForeignMessage struct {
 	C                    int32    `protobuf:"varint,1,opt,name=c" json:"c,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -72,7 +72,7 @@ func (Numeral) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{
 type Simple3 struct {
 	Dub                  float64  `protobuf:"fixed64,1,opt,name=dub" json:"dub,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -108,7 +108,7 @@ func (m *Simple3) GetDub() float64 {
 type SimpleSlice3 struct {
 	Slices               []string `protobuf:"bytes,1,rep,name=slices" json:"slices,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -144,7 +144,7 @@ func (m *SimpleSlice3) GetSlices() []string {
 type SimpleMap3 struct {
 	Stringy              map[string]string `protobuf:"bytes,1,rep,name=stringy" json:"stringy,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
 }
 
@@ -180,7 +180,7 @@ func (m *SimpleMap3) GetStringy() map[string]string {
 type SimpleNull3 struct {
 	Simple               *Simple3 `protobuf:"bytes,1,opt,name=simple" json:"simple,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -225,7 +225,7 @@ type Mappy struct {
 	U32Booly             map[uint32]bool    `protobuf:"bytes,9,rep,name=u32booly" json:"u32booly,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	U64Booly             map[uint64]bool    `protobuf:"bytes,10,rep,name=u64booly" json:"u64booly,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
 }
 

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -274,12 +274,6 @@ import (
 	"sync"
 )
 
-// Proto3UnknownFields enables whether unknown fields are preserved when
-// unmarshaling proto3 messages. By default, this is disabled.
-// This variable should only be set at init time.
-// This variable is temporary and will go away soon. Do not rely on it.
-var Proto3UnknownFields = false
-
 var errInvalidUTF8 = errors.New("proto: invalid UTF-8 string")
 
 // Message is implemented by generated protocol buffer messages.

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -80,7 +80,7 @@ type Message struct {
 	Submessage           *Message                           `protobuf:"bytes,17,opt,name=submessage" json:"submessage,omitempty"`
 	Children             []*Message                         `protobuf:"bytes,18,rep,name=children" json:"children,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                           `json:"-"`
-	XXX_unrecognized     []byte                             `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte                             `json:"-"`
 	XXX_sizecache        int32                              `json:"-"`
 }
 
@@ -236,7 +236,7 @@ type Nested struct {
 	Bunny                string   `protobuf:"bytes,1,opt,name=bunny" json:"bunny,omitempty"`
 	Cute                 bool     `protobuf:"varint,2,opt,name=cute" json:"cute,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -279,7 +279,7 @@ func (m *Nested) GetCute() bool {
 type MessageWithMap struct {
 	ByteMapping          map[bool][]byte `protobuf:"bytes,1,rep,name=byte_mapping,json=byteMapping" json:"byte_mapping,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
-	XXX_unrecognized     []byte          `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
 }
 
@@ -315,7 +315,7 @@ func (m *MessageWithMap) GetByteMapping() map[bool][]byte {
 type IntMap struct {
 	Rtt                  map[int32]int32 `protobuf:"bytes,1,rep,name=rtt" json:"rtt,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
-	XXX_unrecognized     []byte          `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
 }
 
@@ -351,7 +351,7 @@ func (m *IntMap) GetRtt() map[int32]int32 {
 type IntMaps struct {
 	Maps                 []*IntMap `protobuf:"bytes,1,rep,name=maps" json:"maps,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
-	XXX_unrecognized     []byte    `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
 }
 

--- a/proto/proto3_test.go
+++ b/proto/proto3_test.go
@@ -145,13 +145,7 @@ func TestUnknownFieldPreservation(t *testing.T) {
 		t.Fatalf("proto.Unmarshal: %v", err)
 	}
 
-	if proto.Proto3UnknownFields {
-		if !bytes.Equal(m.XXX_unrecognized, []byte(b2)) {
-			t.Fatalf("mismatching unknown fields:\ngot  %q\nwant %q", m.XXX_unrecognized, b2)
-		}
-	} else {
-		if len(m.XXX_unrecognized) > 0 {
-			t.Fatalf("unexpected unknown fields: got %q", m.XXX_unrecognized)
-		}
+	if !bytes.Equal(m.XXX_unrecognized, []byte(b2)) {
+		t.Fatalf("mismatching unknown fields:\ngot  %q\nwant %q", m.XXX_unrecognized, b2)
 	}
 }

--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -344,11 +344,6 @@ func (u *unmarshalInfo) computeUnmarshalInfo() {
 	for i := 0; i < n; i++ {
 		f := t.Field(i)
 		if f.Name == "XXX_unrecognized" {
-			isProto3 := f.Tag.Get("protobuf_unrecognized") == "proto3"
-			if isProto3 && !Proto3UnknownFields {
-				continue // Explicit disabling of unknown fields in proto3
-			}
-
 			// The byte slice used to hold unrecognized input is special.
 			if f.Type != reflect.TypeOf(([]byte)(nil)) {
 				panic("bad type for XXX_unrecognized field: " + f.Type.Name())

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1978,12 +1978,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		}
 		g.P(g.Pkg["proto"], ".XXX_InternalExtensions `", messageset, "json:\"-\"`")
 	}
-	if message.proto3() {
-		// TODO: Remove this when proto3 always preserves unknown fields.
-		g.P("XXX_unrecognized\t[]byte `protobuf_unrecognized:\"proto3\" json:\"-\"`")
-	} else {
-		g.P("XXX_unrecognized\t[]byte `json:\"-\"`")
-	}
+	g.P("XXX_unrecognized\t[]byte `json:\"-\"`")
 	g.P("XXX_sizecache\tint32 `json:\"-\"`")
 	g.Out()
 	g.P("}")

--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -134,7 +134,7 @@ type Any struct {
 	// Must be a valid serialized protocol buffer of the above specified type.
 	Value                []byte   `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 

--- a/ptypes/duration/duration.pb.go
+++ b/ptypes/duration/duration.pb.go
@@ -100,7 +100,7 @@ type Duration struct {
 	// to +999,999,999 inclusive.
 	Nanos                int32    `protobuf:"varint,2,opt,name=nanos" json:"nanos,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 

--- a/ptypes/empty/empty.pb.go
+++ b/ptypes/empty/empty.pb.go
@@ -38,7 +38,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 // The JSON representation for `Empty` is empty JSON object `{}`.
 type Empty struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -65,7 +65,7 @@ type Struct struct {
 	// Unordered map of dynamically typed values.
 	Fields               map[string]*Value `protobuf:"bytes,1,rep,name=fields" json:"fields,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
 }
 
@@ -117,7 +117,7 @@ type Value struct {
 	//	*Value_ListValue
 	Kind                 isValue_Kind `protobuf_oneof:"kind"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
-	XXX_unrecognized     []byte       `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
 }
 
@@ -365,7 +365,7 @@ type ListValue struct {
 	// Repeated field of dynamically typed values.
 	Values               []*Value `protobuf:"bytes,1,rep,name=values" json:"values,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 

--- a/ptypes/timestamp/timestamp.pb.go
+++ b/ptypes/timestamp/timestamp.pb.go
@@ -116,7 +116,7 @@ type Timestamp struct {
 	// inclusive.
 	Nanos                int32    `protobuf:"varint,2,opt,name=nanos" json:"nanos,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 

--- a/ptypes/wrappers/wrappers.pb.go
+++ b/ptypes/wrappers/wrappers.pb.go
@@ -42,7 +42,7 @@ type DoubleValue struct {
 	// The double value.
 	Value                float64  `protobuf:"fixed64,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -83,7 +83,7 @@ type FloatValue struct {
 	// The float value.
 	Value                float32  `protobuf:"fixed32,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -124,7 +124,7 @@ type Int64Value struct {
 	// The int64 value.
 	Value                int64    `protobuf:"varint,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -165,7 +165,7 @@ type UInt64Value struct {
 	// The uint64 value.
 	Value                uint64   `protobuf:"varint,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -206,7 +206,7 @@ type Int32Value struct {
 	// The int32 value.
 	Value                int32    `protobuf:"varint,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -247,7 +247,7 @@ type UInt32Value struct {
 	// The uint32 value.
 	Value                uint32   `protobuf:"varint,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -288,7 +288,7 @@ type BoolValue struct {
 	// The bool value.
 	Value                bool     `protobuf:"varint,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -329,7 +329,7 @@ type StringValue struct {
 	// The string value.
 	Value                string   `protobuf:"bytes,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
@@ -370,7 +370,7 @@ type BytesValue struct {
 	// The bytes value.
 	Value                []byte   `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `protobuf_unrecognized:"proto3" json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 


### PR DESCRIPTION
This flag was necessary inside Google for the transition to having
proto3 preserve unknown fields by default.
Outside of Google, this is unnecessary since the dev branch is
the transition.