### PR TITLE
proto: reject invalid UTF-8 in strings

### DIFF
--- a/proto/all_test.go
+++ b/proto/all_test.go
@@ -2184,6 +2184,21 @@ func TestConcurrentMarshal(t *testing.T) {
 	}
 }
 
+func TestInvalidUTF8(t *testing.T) {
+	const wire = "\x12\x04\xde\xea\xca\xfe"
+
+	var m GoTest
+	if err := Unmarshal([]byte(wire), &m); err == nil {
+		t.Errorf("Unmarshal error: got nil, want non-nil")
+	}
+
+	m.Reset()
+	m.Table = String(wire[2:])
+	if _, err := Marshal(&m); err == nil {
+		t.Errorf("Marshal error: got nil, want non-nil")
+	}
+}
+
 // Benchmarks
 
 func testMsg() *GoTest {

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -265,6 +265,7 @@ package proto
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -278,6 +279,8 @@ import (
 // This variable should only be set at init time.
 // This variable is temporary and will go away soon. Do not rely on it.
 var Proto3UnknownFields = false
+
+var errInvalidUTF8 = errors.New("proto: invalid UTF-8 string")
 
 // Message is implemented by generated protocol buffer messages.
 type Message interface {

--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -41,6 +41,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unicode/utf8"
 )
 
 // Unmarshal is the entry point from the generated .pb.go files.
@@ -1514,6 +1515,9 @@ func unmarshalStringValue(b []byte, f pointer, w int) ([]byte, error) {
 		return nil, io.ErrUnexpectedEOF
 	}
 	v := string(b[:x])
+	if !utf8.ValidString(v) {
+		return nil, errInvalidUTF8
+	}
 	*f.toString() = v
 	return b[x:], nil
 }
@@ -1531,6 +1535,9 @@ func unmarshalStringPtr(b []byte, f pointer, w int) ([]byte, error) {
 		return nil, io.ErrUnexpectedEOF
 	}
 	v := string(b[:x])
+	if !utf8.ValidString(v) {
+		return nil, errInvalidUTF8
+	}
 	*f.toStringPtr() = &v
 	return b[x:], nil
 }
@@ -1548,6 +1555,9 @@ func unmarshalStringSlice(b []byte, f pointer, w int) ([]byte, error) {
 		return nil, io.ErrUnexpectedEOF
 	}
 	v := string(b[:x])
+	if !utf8.ValidString(v) {
+		return nil, errInvalidUTF8
+	}
 	s := f.toStringSlice()
 	*s = append(*s, v)
 	return b[x:], nil


### PR DESCRIPTION
The proto2 and proto3 specifications explicitly say that strings must be
composed of valid UTF-8 characters. Thus, report a marshal/unmarshal error
if any string fields are invalid.

The C++ implementation prints an error anytime invalid UTF-8 strings
is present during parsing or serializing. For proto3, it explicitly
errors out when parsing an invalid string.

In Go, we'll attempt to apply this check on proto2 and proto3,
but may relax that constraint depending on the extent of problems.