### PR TITLE
proto: robustify tests that compare error messages

### DIFF
--- a/proto/extensions_test.go
+++ b/proto/extensions_test.go
@@ -97,7 +97,7 @@ func TestGetExtensionForIncompleteDesc(t *testing.T) {
 		Name:          "a.c",
 		Tag:           "bytes,123456790,opt",
 	}
-	ext2 := []byte{0,1,2,3,4,5,6,7}
+	ext2 := []byte{0, 1, 2, 3, 4, 5, 6, 7}
 	if err := proto.SetExtension(msg, extdesc2, ext2); err != nil {
 		t.Fatalf("Could not set ext2: %s", err)
 	}
@@ -479,7 +479,7 @@ func TestNilExtension(t *testing.T) {
 	}
 	if err := proto.SetExtension(msg, pb.E_Ext_More, (*pb.Ext)(nil)); err == nil {
 		t.Error("expected SetExtension to fail due to a nil extension")
-	} else if want := "proto: SetExtension called with nil value of type *test_proto.Ext"; err.Error() != want {
+	} else if want := fmt.Sprintf("proto: SetExtension called with nil value of type %T", new(pb.Ext)); err.Error() != want {
 		t.Errorf("expected error %v, got %v", want, err)
 	}
 	// Note: if the behavior of Marshal is ever changed to ignore nil extensions, update

--- a/proto/text_parser_test.go
+++ b/proto/text_parser_test.go
@@ -32,6 +32,7 @@
 package proto_test
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -362,7 +363,7 @@ var unMarshalTextTests = []UnmarshalTextTest{
 	// Missing required field
 	{
 		in:  `name: "Pawel"`,
-		err: `proto: required field "test_proto.MyMessage.count" not set`,
+		err: fmt.Sprintf(`proto: required field "%T.count" not set`, MyMessage{}),
 		out: &MyMessage{
 			Name: String("Pawel"),
 		},
@@ -371,7 +372,7 @@ var unMarshalTextTests = []UnmarshalTextTest{
 	// Missing required field in a required submessage
 	{
 		in:  `count: 42 we_must_go_deeper < leo_finally_won_an_oscar <> >`,
-		err: `proto: required field "test_proto.InnerMessage.host" not set`,
+		err: fmt.Sprintf(`proto: required field "%T.host" not set`, InnerMessage{}),
 		out: &MyMessage{
 			Count:          Int32(42),
 			WeMustGoDeeper: &RequiredInnerMessage{LeoFinallyWonAnOscar: &InnerMessage{}},


### PR DESCRIPTION
For now, use fmt.Sprintf to get the proper type name that is
agnostic to the package that the type is defined in.
However, in the future, we should avoid such brittle testing
and have more distinguishable errors.