### PR TITLE
proto: fix govet failures in Go 1.10

### DIFF
--- a/proto/extensions_test.go
+++ b/proto/extensions_test.go
@@ -623,7 +623,7 @@ func TestUnmarshalRepeatingNonRepeatedExtension(t *testing.T) {
 			t.Fatalf("[%s] Invalid extension", test.name)
 		}
 		if !proto.Equal(ext, &want) {
-			t.Errorf("[%s] Wrong value for ComplexExtension: got: %s want: %s\n", test.name, ext, want)
+			t.Errorf("[%s] Wrong value for ComplexExtension: got: %s want: %s\n", test.name, ext, &want)
 		}
 	}
 }


### PR DESCRIPTION
In Go 1.10, `go test` automatically runs `go vet` as well.  This
uncovered a vet failure in `TestUnmarshalRepeatingNonRepeatedExtension`
where `pb.ComplexExtension` is passed as a `fmt.Stringer` to `t.Errorf`.
The string method exists only on the pointer-receiver type,
`*pb.ComplexExtension`.