### PR TITLE
proto,protoc-gen-go: fix vet and gofmt errors for Go 1.10

### DIFF
--- a/proto/extensions_test.go
+++ b/proto/extensions_test.go
@@ -478,7 +478,7 @@ func TestUnmarshalRepeatingNonRepeatedExtension(t *testing.T) {
 			t.Fatalf("[%s] Invalid extension", test.name)
 		}
 		if !reflect.DeepEqual(*ext, want) {
-			t.Errorf("[%s] Wrong value for ComplexExtension: got: %s want: %s\n", test.name, ext, want)
+			t.Errorf("[%s] Wrong value for ComplexExtension: got: %s want: %s\n", test.name, ext, &want)
 		}
 	}
 }

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2029,7 +2029,11 @@ func (g *Generator) generateMessage(message *Descriptor) {
 	// TODO: Revisit this and consider reverting back to anonymous interfaces.
 	for oi := range message.OneofDecl {
 		dname := oneofDisc[int32(oi)]
-		g.P("type ", dname, " interface { ", dname, "() }")
+		g.P("type ", dname, " interface {")
+		g.In()
+		g.P(dname, "()")
+		g.Out()
+		g.P("}")
 	}
 	g.P()
 	for _, field := range message.Field {


### PR DESCRIPTION
In Go 1.10, go vet and gofmt have changed their output in a way to breaks the current build and test cycle.
* gofmt turns a one-line definition of a single-method interface into three lines; this causes a golden 
  comparison test to produce different results between Go 1.9 and Go 1.10.
* go vet is now run by default with go test, which uncovered a bad Stringer argument in extension_test.go.

Tested on Go1.10rc1 and Go1.9.3.