### PR TITLE
don't panic when trying to check for required fields

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -1107,6 +1107,13 @@ func (s mapKeys) Less(i, j int) bool {
 // This function is used by both Marshal and Unmarshal.  While required fields only exist in a
 // proto2 message, a proto3 message can contain proto2 message(s).
 func checkRequiredFields(pb proto.Message) error {
+	type validatingMessage interface {
+		ValidateRecursive() error
+	}
+	if vm, ok := pb.(validatingMessage); ok {
+		return vm.ValidateRecursive()
+	}
+
 	// Most well-known type messages do not contain required fields.  The "Any" type may contain
 	// a message that has required fields.
 	//

--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -50,7 +50,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/golang/protobuf/proto"
 
@@ -1136,12 +1135,8 @@ func checkRequiredFields(pb proto.Message) error {
 		field := v.Field(i)
 		sfield := v.Type().Field(i)
 
-		var exported bool
-		for _, r := range sfield.Name {
-			exported = unicode.IsUpper(r)
-			break
-		}
-		if !exported {
+		if sfield.PkgPath != "" {
+			// blank PkgPath means the field is exported; skip if not exported
 			continue
 		}
 

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -34,6 +34,7 @@ package jsonpb
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"math"
 	"reflect"
@@ -533,6 +534,26 @@ func TestMarshalAnyJSONPBMarshaler(t *testing.T) {
 	}
 }
 
+func TestMarshalWithCustomValidation(t *testing.T) {
+	msg := dynamicMessage{rawJson: `{ "foo": "bar", "baz": [0, 1, 2, 3] }`, dummy1: &dynamicMessage{}}
+
+	js, err := new(Marshaler).MarshalToString(&msg)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when marshalling to json: %v", err)
+	}
+	err = Unmarshal(strings.NewReader(js), &msg)
+	if err != nil {
+		t.Errorf("an unexpected error occurred when unmarshalling from json: %v", err)
+	}
+
+	// tickle an error in custom validation
+	msg.dummy2 = int32(len(msg.rawJson) + 1)
+	_, err = new(Marshaler).MarshalToString(&msg)
+	if err == nil {
+		t.Errorf("marshalling to json should have generated validation error but did not")
+	}
+}
+
 // Test marshaling message containing unset required fields should produce error.
 func TestMarshalUnsetRequiredFields(t *testing.T) {
 	msgExt := &pb.Real{}
@@ -1004,6 +1025,13 @@ func (s *stringField) UnmarshalJSONPB(jum *Unmarshaler, js []byte) error {
 // It provides implementations of JSONPBMarshaler and JSONPBUnmarshaler for JSON support.
 type dynamicMessage struct {
 	rawJson string `protobuf:"bytes,1,opt,name=rawJson"`
+
+	// an unexported nested message is present just to ensure that it
+	// won't result in a panic (see issue #509)
+	dummy1 *dynamicMessage `protobuf:"bytes,2,opt,name=dummy1"`
+
+	// this is used to implement a custom validation rule
+	dummy2 int32 `protobuf:"varint,3,opt,name=dummy2"`
 }
 
 func (m *dynamicMessage) Reset() {
@@ -1023,6 +1051,13 @@ func (m *dynamicMessage) MarshalJSONPB(jm *Marshaler) ([]byte, error) {
 
 func (m *dynamicMessage) UnmarshalJSONPB(jum *Unmarshaler, js []byte) error {
 	m.rawJson = string(js)
+	return nil
+}
+
+func (m *dynamicMessage) ValidateRecursive() error {
+	if int(m.dummy2) > len(m.rawJson) {
+		return errors.New("dummy2 should be <= rawJson length")
+	}
 	return nil
 }
 


### PR DESCRIPTION
As mentioned in #509, `jsonpb` panics when marshaling/unmarshaling a non-generated message that has an unexported pointer field. This change will restore [dynamic messages](https://godoc.org/github.com/jhump/protoreflect/dynamic) to working with `jsonpb` (they work fine in `master`; just broken in this `dev` branch as of #472).