### PR TITLE
protoc-gen-go: remove relative import in main_test.go

### DIFF
--- a/protoc-gen-go/testdata/main_test.go
+++ b/protoc-gen-go/testdata/main_test.go
@@ -36,8 +36,8 @@ package testdata
 import (
 	"testing"
 
-	mytestpb "./my_test"
 	multipb "github.com/golang/protobuf/protoc-gen-go/testdata/multi"
+	mytestpb "github.com/golang/protobuf/protoc-gen-go/testdata/my_test"
 )
 
 func TestLink(t *testing.T) {


### PR DESCRIPTION
No particular reason for this to be a ./ import, and it confuses vgo.