### PR TITLE
Rename generated Marshal and Unmarshal protobuf method

### DIFF
--- a/_conformance/conformance.pb.go
+++ b/_conformance/conformance.pb.go
@@ -123,10 +123,10 @@ func (m *ConformanceRequest) Reset()                    { *m = ConformanceReques
 func (m *ConformanceRequest) String() string            { return proto.CompactTextString(m) }
 func (*ConformanceRequest) ProtoMessage()               {}
 func (*ConformanceRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *ConformanceRequest) Unmarshal(b []byte) error {
+func (m *ConformanceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConformanceRequest.Unmarshal(m, b)
 }
-func (m *ConformanceRequest) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ConformanceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ConformanceRequest.Marshal(b, m, deterministic)
 }
 func (dst *ConformanceRequest) XXX_Merge(src proto.Message) {
@@ -268,10 +268,10 @@ func (m *ConformanceResponse) Reset()                    { *m = ConformanceRespo
 func (m *ConformanceResponse) String() string            { return proto.CompactTextString(m) }
 func (*ConformanceResponse) ProtoMessage()               {}
 func (*ConformanceResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *ConformanceResponse) Unmarshal(b []byte) error {
+func (m *ConformanceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConformanceResponse.Unmarshal(m, b)
 }
-func (m *ConformanceResponse) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ConformanceResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ConformanceResponse.Marshal(b, m, deterministic)
 }
 func (dst *ConformanceResponse) XXX_Merge(src proto.Message) {
@@ -630,10 +630,10 @@ func (m *TestAllTypes) Reset()                    { *m = TestAllTypes{} }
 func (m *TestAllTypes) String() string            { return proto.CompactTextString(m) }
 func (*TestAllTypes) ProtoMessage()               {}
 func (*TestAllTypes) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
-func (m *TestAllTypes) Unmarshal(b []byte) error {
+func (m *TestAllTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestAllTypes.Unmarshal(m, b)
 }
-func (m *TestAllTypes) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *TestAllTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TestAllTypes.Marshal(b, m, deterministic)
 }
 func (dst *TestAllTypes) XXX_Merge(src proto.Message) {
@@ -1715,10 +1715,10 @@ func (m *TestAllTypes_NestedMessage) Reset()                    { *m = TestAllTy
 func (m *TestAllTypes_NestedMessage) String() string            { return proto.CompactTextString(m) }
 func (*TestAllTypes_NestedMessage) ProtoMessage()               {}
 func (*TestAllTypes_NestedMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2, 0} }
-func (m *TestAllTypes_NestedMessage) Unmarshal(b []byte) error {
+func (m *TestAllTypes_NestedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestAllTypes_NestedMessage.Unmarshal(m, b)
 }
-func (m *TestAllTypes_NestedMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *TestAllTypes_NestedMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TestAllTypes_NestedMessage.Marshal(b, m, deterministic)
 }
 func (dst *TestAllTypes_NestedMessage) XXX_Merge(src proto.Message) {
@@ -1758,10 +1758,10 @@ func (m *ForeignMessage) Reset()                    { *m = ForeignMessage{} }
 func (m *ForeignMessage) String() string            { return proto.CompactTextString(m) }
 func (*ForeignMessage) ProtoMessage()               {}
 func (*ForeignMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
-func (m *ForeignMessage) Unmarshal(b []byte) error {
+func (m *ForeignMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForeignMessage.Unmarshal(m, b)
 }
-func (m *ForeignMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ForeignMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ForeignMessage.Marshal(b, m, deterministic)
 }
 func (dst *ForeignMessage) XXX_Merge(src proto.Message) {

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -53,10 +53,10 @@ func (m *Simple3) Reset()                    { *m = Simple3{} }
 func (m *Simple3) String() string            { return proto.CompactTextString(m) }
 func (*Simple3) ProtoMessage()               {}
 func (*Simple3) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *Simple3) Unmarshal(b []byte) error {
+func (m *Simple3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Simple3.Unmarshal(m, b)
 }
-func (m *Simple3) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Simple3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Simple3.Marshal(b, m, deterministic)
 }
 func (dst *Simple3) XXX_Merge(src proto.Message) {
@@ -89,10 +89,10 @@ func (m *SimpleSlice3) Reset()                    { *m = SimpleSlice3{} }
 func (m *SimpleSlice3) String() string            { return proto.CompactTextString(m) }
 func (*SimpleSlice3) ProtoMessage()               {}
 func (*SimpleSlice3) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *SimpleSlice3) Unmarshal(b []byte) error {
+func (m *SimpleSlice3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleSlice3.Unmarshal(m, b)
 }
-func (m *SimpleSlice3) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SimpleSlice3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleSlice3.Marshal(b, m, deterministic)
 }
 func (dst *SimpleSlice3) XXX_Merge(src proto.Message) {
@@ -125,10 +125,10 @@ func (m *SimpleMap3) Reset()                    { *m = SimpleMap3{} }
 func (m *SimpleMap3) String() string            { return proto.CompactTextString(m) }
 func (*SimpleMap3) ProtoMessage()               {}
 func (*SimpleMap3) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
-func (m *SimpleMap3) Unmarshal(b []byte) error {
+func (m *SimpleMap3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleMap3.Unmarshal(m, b)
 }
-func (m *SimpleMap3) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SimpleMap3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleMap3.Marshal(b, m, deterministic)
 }
 func (dst *SimpleMap3) XXX_Merge(src proto.Message) {
@@ -161,10 +161,10 @@ func (m *SimpleNull3) Reset()                    { *m = SimpleNull3{} }
 func (m *SimpleNull3) String() string            { return proto.CompactTextString(m) }
 func (*SimpleNull3) ProtoMessage()               {}
 func (*SimpleNull3) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
-func (m *SimpleNull3) Unmarshal(b []byte) error {
+func (m *SimpleNull3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleNull3.Unmarshal(m, b)
 }
-func (m *SimpleNull3) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SimpleNull3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleNull3.Marshal(b, m, deterministic)
 }
 func (dst *SimpleNull3) XXX_Merge(src proto.Message) {
@@ -206,10 +206,10 @@ func (m *Mappy) Reset()                    { *m = Mappy{} }
 func (m *Mappy) String() string            { return proto.CompactTextString(m) }
 func (*Mappy) ProtoMessage()               {}
 func (*Mappy) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
-func (m *Mappy) Unmarshal(b []byte) error {
+func (m *Mappy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Mappy.Unmarshal(m, b)
 }
-func (m *Mappy) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Mappy) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Mappy.Marshal(b, m, deterministic)
 }
 func (dst *Mappy) XXX_Merge(src proto.Message) {

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -76,10 +76,10 @@ func (m *Simple) Reset()                    { *m = Simple{} }
 func (m *Simple) String() string            { return proto.CompactTextString(m) }
 func (*Simple) ProtoMessage()               {}
 func (*Simple) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
-func (m *Simple) Unmarshal(b []byte) error {
+func (m *Simple) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Simple.Unmarshal(m, b)
 }
-func (m *Simple) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Simple) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Simple.Marshal(b, m, deterministic)
 }
 func (dst *Simple) XXX_Merge(src proto.Message) {
@@ -188,10 +188,10 @@ func (m *NonFinites) Reset()                    { *m = NonFinites{} }
 func (m *NonFinites) String() string            { return proto.CompactTextString(m) }
 func (*NonFinites) ProtoMessage()               {}
 func (*NonFinites) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{1} }
-func (m *NonFinites) Unmarshal(b []byte) error {
+func (m *NonFinites) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NonFinites.Unmarshal(m, b)
 }
-func (m *NonFinites) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *NonFinites) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NonFinites.Marshal(b, m, deterministic)
 }
 func (dst *NonFinites) XXX_Merge(src proto.Message) {
@@ -270,10 +270,10 @@ func (m *Repeats) Reset()                    { *m = Repeats{} }
 func (m *Repeats) String() string            { return proto.CompactTextString(m) }
 func (*Repeats) ProtoMessage()               {}
 func (*Repeats) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{2} }
-func (m *Repeats) Unmarshal(b []byte) error {
+func (m *Repeats) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Repeats.Unmarshal(m, b)
 }
-func (m *Repeats) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Repeats) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Repeats.Marshal(b, m, deterministic)
 }
 func (dst *Repeats) XXX_Merge(src proto.Message) {
@@ -382,10 +382,10 @@ func (m *Widget) Reset()                    { *m = Widget{} }
 func (m *Widget) String() string            { return proto.CompactTextString(m) }
 func (*Widget) ProtoMessage()               {}
 func (*Widget) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{3} }
-func (m *Widget) Unmarshal(b []byte) error {
+func (m *Widget) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Widget.Unmarshal(m, b)
 }
-func (m *Widget) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Widget) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Widget.Marshal(b, m, deterministic)
 }
 func (dst *Widget) XXX_Merge(src proto.Message) {
@@ -454,10 +454,10 @@ func (m *Maps) Reset()                    { *m = Maps{} }
 func (m *Maps) String() string            { return proto.CompactTextString(m) }
 func (*Maps) ProtoMessage()               {}
 func (*Maps) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{4} }
-func (m *Maps) Unmarshal(b []byte) error {
+func (m *Maps) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Maps.Unmarshal(m, b)
 }
-func (m *Maps) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Maps) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Maps.Marshal(b, m, deterministic)
 }
 func (dst *Maps) XXX_Merge(src proto.Message) {
@@ -503,10 +503,10 @@ func (m *MsgWithOneof) Reset()                    { *m = MsgWithOneof{} }
 func (m *MsgWithOneof) String() string            { return proto.CompactTextString(m) }
 func (*MsgWithOneof) ProtoMessage()               {}
 func (*MsgWithOneof) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{5} }
-func (m *MsgWithOneof) Unmarshal(b []byte) error {
+func (m *MsgWithOneof) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithOneof.Unmarshal(m, b)
 }
-func (m *MsgWithOneof) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgWithOneof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithOneof.Marshal(b, m, deterministic)
 }
 func (dst *MsgWithOneof) XXX_Merge(src proto.Message) {
@@ -723,10 +723,10 @@ var extRange_Real = []proto.ExtensionRange{
 func (*Real) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_Real
 }
-func (m *Real) Unmarshal(b []byte) error {
+func (m *Real) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Real.Unmarshal(m, b)
 }
-func (m *Real) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Real) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Real.Marshal(b, m, deterministic)
 }
 func (dst *Real) XXX_Merge(src proto.Message) {
@@ -768,10 +768,10 @@ var extRange_Complex = []proto.ExtensionRange{
 func (*Complex) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_Complex
 }
-func (m *Complex) Unmarshal(b []byte) error {
+func (m *Complex) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Complex.Unmarshal(m, b)
 }
-func (m *Complex) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Complex) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Complex.Marshal(b, m, deterministic)
 }
 func (dst *Complex) XXX_Merge(src proto.Message) {
@@ -827,10 +827,10 @@ func (m *KnownTypes) Reset()                    { *m = KnownTypes{} }
 func (m *KnownTypes) String() string            { return proto.CompactTextString(m) }
 func (*KnownTypes) ProtoMessage()               {}
 func (*KnownTypes) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{8} }
-func (m *KnownTypes) Unmarshal(b []byte) error {
+func (m *KnownTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_KnownTypes.Unmarshal(m, b)
 }
-func (m *KnownTypes) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *KnownTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_KnownTypes.Marshal(b, m, deterministic)
 }
 func (dst *KnownTypes) XXX_Merge(src proto.Message) {
@@ -962,10 +962,10 @@ func (m *MsgWithRequired) Reset()                    { *m = MsgWithRequired{} }
 func (m *MsgWithRequired) String() string            { return proto.CompactTextString(m) }
 func (*MsgWithRequired) ProtoMessage()               {}
 func (*MsgWithRequired) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{9} }
-func (m *MsgWithRequired) Unmarshal(b []byte) error {
+func (m *MsgWithRequired) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequired.Unmarshal(m, b)
 }
-func (m *MsgWithRequired) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgWithRequired) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithRequired.Marshal(b, m, deterministic)
 }
 func (dst *MsgWithRequired) XXX_Merge(src proto.Message) {
@@ -1000,10 +1000,10 @@ func (m *MsgWithIndirectRequired) Reset()                    { *m = MsgWithIndir
 func (m *MsgWithIndirectRequired) String() string            { return proto.CompactTextString(m) }
 func (*MsgWithIndirectRequired) ProtoMessage()               {}
 func (*MsgWithIndirectRequired) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{10} }
-func (m *MsgWithIndirectRequired) Unmarshal(b []byte) error {
+func (m *MsgWithIndirectRequired) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithIndirectRequired.Unmarshal(m, b)
 }
-func (m *MsgWithIndirectRequired) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgWithIndirectRequired) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithIndirectRequired.Marshal(b, m, deterministic)
 }
 func (dst *MsgWithIndirectRequired) XXX_Merge(src proto.Message) {
@@ -1050,10 +1050,10 @@ func (m *MsgWithRequiredBytes) Reset()                    { *m = MsgWithRequired
 func (m *MsgWithRequiredBytes) String() string            { return proto.CompactTextString(m) }
 func (*MsgWithRequiredBytes) ProtoMessage()               {}
 func (*MsgWithRequiredBytes) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{11} }
-func (m *MsgWithRequiredBytes) Unmarshal(b []byte) error {
+func (m *MsgWithRequiredBytes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequiredBytes.Unmarshal(m, b)
 }
-func (m *MsgWithRequiredBytes) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgWithRequiredBytes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithRequiredBytes.Marshal(b, m, deterministic)
 }
 func (dst *MsgWithRequiredBytes) XXX_Merge(src proto.Message) {
@@ -1086,10 +1086,10 @@ func (m *MsgWithRequiredWKT) Reset()                    { *m = MsgWithRequiredWK
 func (m *MsgWithRequiredWKT) String() string            { return proto.CompactTextString(m) }
 func (*MsgWithRequiredWKT) ProtoMessage()               {}
 func (*MsgWithRequiredWKT) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{12} }
-func (m *MsgWithRequiredWKT) Unmarshal(b []byte) error {
+func (m *MsgWithRequiredWKT) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequiredWKT.Unmarshal(m, b)
 }
-func (m *MsgWithRequiredWKT) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MsgWithRequiredWKT) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithRequiredWKT.Marshal(b, m, deterministic)
 }
 func (dst *MsgWithRequiredWKT) XXX_Merge(src proto.Message) {

--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -2579,9 +2579,15 @@ func (u *marshalInfo) appendV1Extensions(b []byte, m map[int32]Extension, determ
 	return b, nil
 }
 
+// newMarshaler is the interface representing objects that can marshal themselves.
+//
+// This exists to support protoc-gen-go generated messages.
+// The proto package will stop type-asserting to this interface in the future.
+//
+// DO NOT DEPEND ON THIS.
 type newMarshaler interface {
 	XXX_Size() int
-	Marshal(b []byte, deterministic bool) ([]byte, error)
+	XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 }
 
 // Size returns the encoded size of a protocol buffer message.
@@ -2611,7 +2617,7 @@ func Marshal(pb Message) ([]byte, error) {
 	if m, ok := pb.(newMarshaler); ok {
 		siz := m.XXX_Size()
 		b := make([]byte, 0, siz)
-		return m.Marshal(b, false)
+		return m.XXX_Marshal(b, false)
 	}
 	if m, ok := pb.(Marshaler); ok {
 		// If the message can marshal itself, let it do it, for compatibility.
@@ -2641,7 +2647,7 @@ func (p *Buffer) Marshal(pb Message) error {
 		if newCap := len(p.buf) + siz; newCap > cap(p.buf) {
 			p.buf = append(make([]byte, 0, newCap), p.buf...)
 		}
-		p.buf, err = m.Marshal(p.buf, p.deterministic)
+		p.buf, err = m.XXX_Marshal(p.buf, p.deterministic)
 		return err
 	}
 	if m, ok := pb.(Marshaler); ok {

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -276,10 +276,10 @@ func (m *GoEnum) Reset()                    { *m = GoEnum{} }
 func (m *GoEnum) String() string            { return proto.CompactTextString(m) }
 func (*GoEnum) ProtoMessage()               {}
 func (*GoEnum) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *GoEnum) Unmarshal(b []byte) error {
+func (m *GoEnum) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoEnum.Unmarshal(m, b)
 }
-func (m *GoEnum) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoEnum) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoEnum.Marshal(b, m, deterministic)
 }
 func (dst *GoEnum) XXX_Merge(src proto.Message) {
@@ -313,10 +313,10 @@ func (m *GoTestField) Reset()                    { *m = GoTestField{} }
 func (m *GoTestField) String() string            { return proto.CompactTextString(m) }
 func (*GoTestField) ProtoMessage()               {}
 func (*GoTestField) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *GoTestField) Unmarshal(b []byte) error {
+func (m *GoTestField) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestField.Unmarshal(m, b)
 }
-func (m *GoTestField) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoTestField) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTestField.Marshal(b, m, deterministic)
 }
 func (dst *GoTestField) XXX_Merge(src proto.Message) {
@@ -444,10 +444,10 @@ func (m *GoTest) Reset()                    { *m = GoTest{} }
 func (m *GoTest) String() string            { return proto.CompactTextString(m) }
 func (*GoTest) ProtoMessage()               {}
 func (*GoTest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
-func (m *GoTest) Unmarshal(b []byte) error {
+func (m *GoTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest.Unmarshal(m, b)
 }
-func (m *GoTest) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest.Marshal(b, m, deterministic)
 }
 func (dst *GoTest) XXX_Merge(src proto.Message) {
@@ -1066,10 +1066,10 @@ func (m *GoTest_RequiredGroup) Reset()                    { *m = GoTest_Required
 func (m *GoTest_RequiredGroup) String() string            { return proto.CompactTextString(m) }
 func (*GoTest_RequiredGroup) ProtoMessage()               {}
 func (*GoTest_RequiredGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2, 0} }
-func (m *GoTest_RequiredGroup) Unmarshal(b []byte) error {
+func (m *GoTest_RequiredGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_RequiredGroup.Unmarshal(m, b)
 }
-func (m *GoTest_RequiredGroup) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoTest_RequiredGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest_RequiredGroup.Marshal(b, m, deterministic)
 }
 func (dst *GoTest_RequiredGroup) XXX_Merge(src proto.Message) {
@@ -1102,10 +1102,10 @@ func (m *GoTest_RepeatedGroup) Reset()                    { *m = GoTest_Repeated
 func (m *GoTest_RepeatedGroup) String() string            { return proto.CompactTextString(m) }
 func (*GoTest_RepeatedGroup) ProtoMessage()               {}
 func (*GoTest_RepeatedGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2, 1} }
-func (m *GoTest_RepeatedGroup) Unmarshal(b []byte) error {
+func (m *GoTest_RepeatedGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_RepeatedGroup.Unmarshal(m, b)
 }
-func (m *GoTest_RepeatedGroup) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoTest_RepeatedGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest_RepeatedGroup.Marshal(b, m, deterministic)
 }
 func (dst *GoTest_RepeatedGroup) XXX_Merge(src proto.Message) {
@@ -1138,10 +1138,10 @@ func (m *GoTest_OptionalGroup) Reset()                    { *m = GoTest_Optional
 func (m *GoTest_OptionalGroup) String() string            { return proto.CompactTextString(m) }
 func (*GoTest_OptionalGroup) ProtoMessage()               {}
 func (*GoTest_OptionalGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2, 2} }
-func (m *GoTest_OptionalGroup) Unmarshal(b []byte) error {
+func (m *GoTest_OptionalGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_OptionalGroup.Unmarshal(m, b)
 }
-func (m *GoTest_OptionalGroup) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoTest_OptionalGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest_OptionalGroup.Marshal(b, m, deterministic)
 }
 func (dst *GoTest_OptionalGroup) XXX_Merge(src proto.Message) {
@@ -1175,10 +1175,10 @@ func (m *GoTestRequiredGroupField) Reset()                    { *m = GoTestRequi
 func (m *GoTestRequiredGroupField) String() string            { return proto.CompactTextString(m) }
 func (*GoTestRequiredGroupField) ProtoMessage()               {}
 func (*GoTestRequiredGroupField) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
-func (m *GoTestRequiredGroupField) Unmarshal(b []byte) error {
+func (m *GoTestRequiredGroupField) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestRequiredGroupField.Unmarshal(m, b)
 }
-func (m *GoTestRequiredGroupField) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoTestRequiredGroupField) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTestRequiredGroupField.Marshal(b, m, deterministic)
 }
 func (dst *GoTestRequiredGroupField) XXX_Merge(src proto.Message) {
@@ -1213,10 +1213,10 @@ func (*GoTestRequiredGroupField_Group) ProtoMessage()    {}
 func (*GoTestRequiredGroupField_Group) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{3, 0}
 }
-func (m *GoTestRequiredGroupField_Group) Unmarshal(b []byte) error {
+func (m *GoTestRequiredGroupField_Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestRequiredGroupField_Group.Unmarshal(m, b)
 }
-func (m *GoTestRequiredGroupField_Group) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoTestRequiredGroupField_Group) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTestRequiredGroupField_Group.Marshal(b, m, deterministic)
 }
 func (dst *GoTestRequiredGroupField_Group) XXX_Merge(src proto.Message) {
@@ -1256,10 +1256,10 @@ func (m *GoSkipTest) Reset()                    { *m = GoSkipTest{} }
 func (m *GoSkipTest) String() string            { return proto.CompactTextString(m) }
 func (*GoSkipTest) ProtoMessage()               {}
 func (*GoSkipTest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
-func (m *GoSkipTest) Unmarshal(b []byte) error {
+func (m *GoSkipTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoSkipTest.Unmarshal(m, b)
 }
-func (m *GoSkipTest) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoSkipTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoSkipTest.Marshal(b, m, deterministic)
 }
 func (dst *GoSkipTest) XXX_Merge(src proto.Message) {
@@ -1321,10 +1321,10 @@ func (m *GoSkipTest_SkipGroup) Reset()                    { *m = GoSkipTest_Skip
 func (m *GoSkipTest_SkipGroup) String() string            { return proto.CompactTextString(m) }
 func (*GoSkipTest_SkipGroup) ProtoMessage()               {}
 func (*GoSkipTest_SkipGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4, 0} }
-func (m *GoSkipTest_SkipGroup) Unmarshal(b []byte) error {
+func (m *GoSkipTest_SkipGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoSkipTest_SkipGroup.Unmarshal(m, b)
 }
-func (m *GoSkipTest_SkipGroup) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GoSkipTest_SkipGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoSkipTest_SkipGroup.Marshal(b, m, deterministic)
 }
 func (dst *GoSkipTest_SkipGroup) XXX_Merge(src proto.Message) {
@@ -1366,10 +1366,10 @@ func (m *NonPackedTest) Reset()                    { *m = NonPackedTest{} }
 func (m *NonPackedTest) String() string            { return proto.CompactTextString(m) }
 func (*NonPackedTest) ProtoMessage()               {}
 func (*NonPackedTest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
-func (m *NonPackedTest) Unmarshal(b []byte) error {
+func (m *NonPackedTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NonPackedTest.Unmarshal(m, b)
 }
-func (m *NonPackedTest) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *NonPackedTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NonPackedTest.Marshal(b, m, deterministic)
 }
 func (dst *NonPackedTest) XXX_Merge(src proto.Message) {
@@ -1402,10 +1402,10 @@ func (m *PackedTest) Reset()                    { *m = PackedTest{} }
 func (m *PackedTest) String() string            { return proto.CompactTextString(m) }
 func (*PackedTest) ProtoMessage()               {}
 func (*PackedTest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6} }
-func (m *PackedTest) Unmarshal(b []byte) error {
+func (m *PackedTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PackedTest.Unmarshal(m, b)
 }
-func (m *PackedTest) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *PackedTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PackedTest.Marshal(b, m, deterministic)
 }
 func (dst *PackedTest) XXX_Merge(src proto.Message) {
@@ -1439,10 +1439,10 @@ func (m *MaxTag) Reset()                    { *m = MaxTag{} }
 func (m *MaxTag) String() string            { return proto.CompactTextString(m) }
 func (*MaxTag) ProtoMessage()               {}
 func (*MaxTag) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7} }
-func (m *MaxTag) Unmarshal(b []byte) error {
+func (m *MaxTag) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MaxTag.Unmarshal(m, b)
 }
-func (m *MaxTag) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MaxTag) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MaxTag.Marshal(b, m, deterministic)
 }
 func (dst *MaxTag) XXX_Merge(src proto.Message) {
@@ -1476,10 +1476,10 @@ func (m *OldMessage) Reset()                    { *m = OldMessage{} }
 func (m *OldMessage) String() string            { return proto.CompactTextString(m) }
 func (*OldMessage) ProtoMessage()               {}
 func (*OldMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
-func (m *OldMessage) Unmarshal(b []byte) error {
+func (m *OldMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldMessage.Unmarshal(m, b)
 }
-func (m *OldMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OldMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldMessage.Marshal(b, m, deterministic)
 }
 func (dst *OldMessage) XXX_Merge(src proto.Message) {
@@ -1519,10 +1519,10 @@ func (m *OldMessage_Nested) Reset()                    { *m = OldMessage_Nested{
 func (m *OldMessage_Nested) String() string            { return proto.CompactTextString(m) }
 func (*OldMessage_Nested) ProtoMessage()               {}
 func (*OldMessage_Nested) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8, 0} }
-func (m *OldMessage_Nested) Unmarshal(b []byte) error {
+func (m *OldMessage_Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldMessage_Nested.Unmarshal(m, b)
 }
-func (m *OldMessage_Nested) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OldMessage_Nested) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldMessage_Nested.Marshal(b, m, deterministic)
 }
 func (dst *OldMessage_Nested) XXX_Merge(src proto.Message) {
@@ -1559,10 +1559,10 @@ func (m *NewMessage) Reset()                    { *m = NewMessage{} }
 func (m *NewMessage) String() string            { return proto.CompactTextString(m) }
 func (*NewMessage) ProtoMessage()               {}
 func (*NewMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
-func (m *NewMessage) Unmarshal(b []byte) error {
+func (m *NewMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewMessage.Unmarshal(m, b)
 }
-func (m *NewMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *NewMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NewMessage.Marshal(b, m, deterministic)
 }
 func (dst *NewMessage) XXX_Merge(src proto.Message) {
@@ -1603,10 +1603,10 @@ func (m *NewMessage_Nested) Reset()                    { *m = NewMessage_Nested{
 func (m *NewMessage_Nested) String() string            { return proto.CompactTextString(m) }
 func (*NewMessage_Nested) ProtoMessage()               {}
 func (*NewMessage_Nested) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9, 0} }
-func (m *NewMessage_Nested) Unmarshal(b []byte) error {
+func (m *NewMessage_Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewMessage_Nested.Unmarshal(m, b)
 }
-func (m *NewMessage_Nested) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *NewMessage_Nested) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NewMessage_Nested.Marshal(b, m, deterministic)
 }
 func (dst *NewMessage_Nested) XXX_Merge(src proto.Message) {
@@ -1648,10 +1648,10 @@ func (m *InnerMessage) Reset()                    { *m = InnerMessage{} }
 func (m *InnerMessage) String() string            { return proto.CompactTextString(m) }
 func (*InnerMessage) ProtoMessage()               {}
 func (*InnerMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{10} }
-func (m *InnerMessage) Unmarshal(b []byte) error {
+func (m *InnerMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InnerMessage.Unmarshal(m, b)
 }
-func (m *InnerMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *InnerMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_InnerMessage.Marshal(b, m, deterministic)
 }
 func (dst *InnerMessage) XXX_Merge(src proto.Message) {
@@ -1712,10 +1712,10 @@ var extRange_OtherMessage = []proto.ExtensionRange{
 func (*OtherMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OtherMessage
 }
-func (m *OtherMessage) Unmarshal(b []byte) error {
+func (m *OtherMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherMessage.Unmarshal(m, b)
 }
-func (m *OtherMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OtherMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OtherMessage.Marshal(b, m, deterministic)
 }
 func (dst *OtherMessage) XXX_Merge(src proto.Message) {
@@ -1769,10 +1769,10 @@ func (m *RequiredInnerMessage) Reset()                    { *m = RequiredInnerMe
 func (m *RequiredInnerMessage) String() string            { return proto.CompactTextString(m) }
 func (*RequiredInnerMessage) ProtoMessage()               {}
 func (*RequiredInnerMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{12} }
-func (m *RequiredInnerMessage) Unmarshal(b []byte) error {
+func (m *RequiredInnerMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RequiredInnerMessage.Unmarshal(m, b)
 }
-func (m *RequiredInnerMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *RequiredInnerMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RequiredInnerMessage.Marshal(b, m, deterministic)
 }
 func (dst *RequiredInnerMessage) XXX_Merge(src proto.Message) {
@@ -1826,10 +1826,10 @@ var extRange_MyMessage = []proto.ExtensionRange{
 func (*MyMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_MyMessage
 }
-func (m *MyMessage) Unmarshal(b []byte) error {
+func (m *MyMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MyMessage.Unmarshal(m, b)
 }
-func (m *MyMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MyMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MyMessage.Marshal(b, m, deterministic)
 }
 func (dst *MyMessage) XXX_Merge(src proto.Message) {
@@ -1939,10 +1939,10 @@ func (m *MyMessage_SomeGroup) Reset()                    { *m = MyMessage_SomeGr
 func (m *MyMessage_SomeGroup) String() string            { return proto.CompactTextString(m) }
 func (*MyMessage_SomeGroup) ProtoMessage()               {}
 func (*MyMessage_SomeGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{13, 0} }
-func (m *MyMessage_SomeGroup) Unmarshal(b []byte) error {
+func (m *MyMessage_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MyMessage_SomeGroup.Unmarshal(m, b)
 }
-func (m *MyMessage_SomeGroup) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MyMessage_SomeGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MyMessage_SomeGroup.Marshal(b, m, deterministic)
 }
 func (dst *MyMessage_SomeGroup) XXX_Merge(src proto.Message) {
@@ -1976,10 +1976,10 @@ func (m *Ext) Reset()                    { *m = Ext{} }
 func (m *Ext) String() string            { return proto.CompactTextString(m) }
 func (*Ext) ProtoMessage()               {}
 func (*Ext) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{14} }
-func (m *Ext) Unmarshal(b []byte) error {
+func (m *Ext) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Ext.Unmarshal(m, b)
 }
-func (m *Ext) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Ext) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Ext.Marshal(b, m, deterministic)
 }
 func (dst *Ext) XXX_Merge(src proto.Message) {
@@ -2048,10 +2048,10 @@ func (m *ComplexExtension) Reset()                    { *m = ComplexExtension{} 
 func (m *ComplexExtension) String() string            { return proto.CompactTextString(m) }
 func (*ComplexExtension) ProtoMessage()               {}
 func (*ComplexExtension) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{15} }
-func (m *ComplexExtension) Unmarshal(b []byte) error {
+func (m *ComplexExtension) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ComplexExtension.Unmarshal(m, b)
 }
-func (m *ComplexExtension) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ComplexExtension) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ComplexExtension.Marshal(b, m, deterministic)
 }
 func (dst *ComplexExtension) XXX_Merge(src proto.Message) {
@@ -2106,10 +2106,10 @@ var extRange_DefaultsMessage = []proto.ExtensionRange{
 func (*DefaultsMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_DefaultsMessage
 }
-func (m *DefaultsMessage) Unmarshal(b []byte) error {
+func (m *DefaultsMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DefaultsMessage.Unmarshal(m, b)
 }
-func (m *DefaultsMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *DefaultsMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DefaultsMessage.Marshal(b, m, deterministic)
 }
 func (dst *DefaultsMessage) XXX_Merge(src proto.Message) {
@@ -2143,9 +2143,6 @@ func (m *MyMessageSet) UnmarshalJSON(buf []byte) error {
 	return proto.UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)
 }
 
-// ensure MyMessageSet satisfies proto.Unmarshaler
-var _ proto.Unmarshaler = (*MyMessageSet)(nil)
-
 var extRange_MyMessageSet = []proto.ExtensionRange{
 	{100, 2147483646},
 }
@@ -2153,10 +2150,10 @@ var extRange_MyMessageSet = []proto.ExtensionRange{
 func (*MyMessageSet) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_MyMessageSet
 }
-func (m *MyMessageSet) Unmarshal(b []byte) error {
+func (m *MyMessageSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MyMessageSet.Unmarshal(m, b)
 }
-func (m *MyMessageSet) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MyMessageSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MyMessageSet.Marshal(b, m, deterministic)
 }
 func (dst *MyMessageSet) XXX_Merge(src proto.Message) {
@@ -2181,10 +2178,10 @@ func (m *Empty) Reset()                    { *m = Empty{} }
 func (m *Empty) String() string            { return proto.CompactTextString(m) }
 func (*Empty) ProtoMessage()               {}
 func (*Empty) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{18} }
-func (m *Empty) Unmarshal(b []byte) error {
+func (m *Empty) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Empty.Unmarshal(m, b)
 }
-func (m *Empty) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Empty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Empty.Marshal(b, m, deterministic)
 }
 func (dst *Empty) XXX_Merge(src proto.Message) {
@@ -2210,10 +2207,10 @@ func (m *MessageList) Reset()                    { *m = MessageList{} }
 func (m *MessageList) String() string            { return proto.CompactTextString(m) }
 func (*MessageList) ProtoMessage()               {}
 func (*MessageList) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{19} }
-func (m *MessageList) Unmarshal(b []byte) error {
+func (m *MessageList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageList.Unmarshal(m, b)
 }
-func (m *MessageList) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MessageList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageList.Marshal(b, m, deterministic)
 }
 func (dst *MessageList) XXX_Merge(src proto.Message) {
@@ -2247,10 +2244,10 @@ func (m *MessageList_Message) Reset()                    { *m = MessageList_Mess
 func (m *MessageList_Message) String() string            { return proto.CompactTextString(m) }
 func (*MessageList_Message) ProtoMessage()               {}
 func (*MessageList_Message) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{19, 0} }
-func (m *MessageList_Message) Unmarshal(b []byte) error {
+func (m *MessageList_Message) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageList_Message.Unmarshal(m, b)
 }
-func (m *MessageList_Message) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MessageList_Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageList_Message.Marshal(b, m, deterministic)
 }
 func (dst *MessageList_Message) XXX_Merge(src proto.Message) {
@@ -2291,10 +2288,10 @@ func (m *Strings) Reset()                    { *m = Strings{} }
 func (m *Strings) String() string            { return proto.CompactTextString(m) }
 func (*Strings) ProtoMessage()               {}
 func (*Strings) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{20} }
-func (m *Strings) Unmarshal(b []byte) error {
+func (m *Strings) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Strings.Unmarshal(m, b)
 }
-func (m *Strings) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Strings) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Strings.Marshal(b, m, deterministic)
 }
 func (dst *Strings) XXX_Merge(src proto.Message) {
@@ -2357,10 +2354,10 @@ func (m *Defaults) Reset()                    { *m = Defaults{} }
 func (m *Defaults) String() string            { return proto.CompactTextString(m) }
 func (*Defaults) ProtoMessage()               {}
 func (*Defaults) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{21} }
-func (m *Defaults) Unmarshal(b []byte) error {
+func (m *Defaults) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Defaults.Unmarshal(m, b)
 }
-func (m *Defaults) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Defaults) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Defaults.Marshal(b, m, deterministic)
 }
 func (dst *Defaults) XXX_Merge(src proto.Message) {
@@ -2540,10 +2537,10 @@ func (m *SubDefaults) Reset()                    { *m = SubDefaults{} }
 func (m *SubDefaults) String() string            { return proto.CompactTextString(m) }
 func (*SubDefaults) ProtoMessage()               {}
 func (*SubDefaults) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{22} }
-func (m *SubDefaults) Unmarshal(b []byte) error {
+func (m *SubDefaults) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SubDefaults.Unmarshal(m, b)
 }
-func (m *SubDefaults) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SubDefaults) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SubDefaults.Marshal(b, m, deterministic)
 }
 func (dst *SubDefaults) XXX_Merge(src proto.Message) {
@@ -2578,10 +2575,10 @@ func (m *RepeatedEnum) Reset()                    { *m = RepeatedEnum{} }
 func (m *RepeatedEnum) String() string            { return proto.CompactTextString(m) }
 func (*RepeatedEnum) ProtoMessage()               {}
 func (*RepeatedEnum) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{23} }
-func (m *RepeatedEnum) Unmarshal(b []byte) error {
+func (m *RepeatedEnum) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepeatedEnum.Unmarshal(m, b)
 }
-func (m *RepeatedEnum) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *RepeatedEnum) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RepeatedEnum.Marshal(b, m, deterministic)
 }
 func (dst *RepeatedEnum) XXX_Merge(src proto.Message) {
@@ -2620,10 +2617,10 @@ func (m *MoreRepeated) Reset()                    { *m = MoreRepeated{} }
 func (m *MoreRepeated) String() string            { return proto.CompactTextString(m) }
 func (*MoreRepeated) ProtoMessage()               {}
 func (*MoreRepeated) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{24} }
-func (m *MoreRepeated) Unmarshal(b []byte) error {
+func (m *MoreRepeated) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MoreRepeated.Unmarshal(m, b)
 }
-func (m *MoreRepeated) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MoreRepeated) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MoreRepeated.Marshal(b, m, deterministic)
 }
 func (dst *MoreRepeated) XXX_Merge(src proto.Message) {
@@ -2698,10 +2695,10 @@ func (m *GroupOld) Reset()                    { *m = GroupOld{} }
 func (m *GroupOld) String() string            { return proto.CompactTextString(m) }
 func (*GroupOld) ProtoMessage()               {}
 func (*GroupOld) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{25} }
-func (m *GroupOld) Unmarshal(b []byte) error {
+func (m *GroupOld) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupOld.Unmarshal(m, b)
 }
-func (m *GroupOld) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GroupOld) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupOld.Marshal(b, m, deterministic)
 }
 func (dst *GroupOld) XXX_Merge(src proto.Message) {
@@ -2734,10 +2731,10 @@ func (m *GroupOld_G) Reset()                    { *m = GroupOld_G{} }
 func (m *GroupOld_G) String() string            { return proto.CompactTextString(m) }
 func (*GroupOld_G) ProtoMessage()               {}
 func (*GroupOld_G) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{25, 0} }
-func (m *GroupOld_G) Unmarshal(b []byte) error {
+func (m *GroupOld_G) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupOld_G.Unmarshal(m, b)
 }
-func (m *GroupOld_G) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GroupOld_G) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupOld_G.Marshal(b, m, deterministic)
 }
 func (dst *GroupOld_G) XXX_Merge(src proto.Message) {
@@ -2770,10 +2767,10 @@ func (m *GroupNew) Reset()                    { *m = GroupNew{} }
 func (m *GroupNew) String() string            { return proto.CompactTextString(m) }
 func (*GroupNew) ProtoMessage()               {}
 func (*GroupNew) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{26} }
-func (m *GroupNew) Unmarshal(b []byte) error {
+func (m *GroupNew) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupNew.Unmarshal(m, b)
 }
-func (m *GroupNew) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GroupNew) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupNew.Marshal(b, m, deterministic)
 }
 func (dst *GroupNew) XXX_Merge(src proto.Message) {
@@ -2807,10 +2804,10 @@ func (m *GroupNew_G) Reset()                    { *m = GroupNew_G{} }
 func (m *GroupNew_G) String() string            { return proto.CompactTextString(m) }
 func (*GroupNew_G) ProtoMessage()               {}
 func (*GroupNew_G) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{26, 0} }
-func (m *GroupNew_G) Unmarshal(b []byte) error {
+func (m *GroupNew_G) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupNew_G.Unmarshal(m, b)
 }
-func (m *GroupNew_G) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *GroupNew_G) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupNew_G.Marshal(b, m, deterministic)
 }
 func (dst *GroupNew_G) XXX_Merge(src proto.Message) {
@@ -2851,10 +2848,10 @@ func (m *FloatingPoint) Reset()                    { *m = FloatingPoint{} }
 func (m *FloatingPoint) String() string            { return proto.CompactTextString(m) }
 func (*FloatingPoint) ProtoMessage()               {}
 func (*FloatingPoint) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{27} }
-func (m *FloatingPoint) Unmarshal(b []byte) error {
+func (m *FloatingPoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FloatingPoint.Unmarshal(m, b)
 }
-func (m *FloatingPoint) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *FloatingPoint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FloatingPoint.Marshal(b, m, deterministic)
 }
 func (dst *FloatingPoint) XXX_Merge(src proto.Message) {
@@ -2897,10 +2894,10 @@ func (m *MessageWithMap) Reset()                    { *m = MessageWithMap{} }
 func (m *MessageWithMap) String() string            { return proto.CompactTextString(m) }
 func (*MessageWithMap) ProtoMessage()               {}
 func (*MessageWithMap) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{28} }
-func (m *MessageWithMap) Unmarshal(b []byte) error {
+func (m *MessageWithMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageWithMap.Unmarshal(m, b)
 }
-func (m *MessageWithMap) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *MessageWithMap) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageWithMap.Marshal(b, m, deterministic)
 }
 func (dst *MessageWithMap) XXX_Merge(src proto.Message) {
@@ -2975,10 +2972,10 @@ func (m *Oneof) Reset()                    { *m = Oneof{} }
 func (m *Oneof) String() string            { return proto.CompactTextString(m) }
 func (*Oneof) ProtoMessage()               {}
 func (*Oneof) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{29} }
-func (m *Oneof) Unmarshal(b []byte) error {
+func (m *Oneof) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Oneof.Unmarshal(m, b)
 }
-func (m *Oneof) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Oneof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Oneof.Marshal(b, m, deterministic)
 }
 func (dst *Oneof) XXX_Merge(src proto.Message) {
@@ -3540,10 +3537,10 @@ func (m *Oneof_F_Group) Reset()                    { *m = Oneof_F_Group{} }
 func (m *Oneof_F_Group) String() string            { return proto.CompactTextString(m) }
 func (*Oneof_F_Group) ProtoMessage()               {}
 func (*Oneof_F_Group) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{29, 0} }
-func (m *Oneof_F_Group) Unmarshal(b []byte) error {
+func (m *Oneof_F_Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Oneof_F_Group.Unmarshal(m, b)
 }
-func (m *Oneof_F_Group) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Oneof_F_Group) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Oneof_F_Group.Marshal(b, m, deterministic)
 }
 func (dst *Oneof_F_Group) XXX_Merge(src proto.Message) {
@@ -3586,10 +3583,10 @@ func (m *Communique) Reset()                    { *m = Communique{} }
 func (m *Communique) String() string            { return proto.CompactTextString(m) }
 func (*Communique) ProtoMessage()               {}
 func (*Communique) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{30} }
-func (m *Communique) Unmarshal(b []byte) error {
+func (m *Communique) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique.Unmarshal(m, b)
 }
-func (m *Communique) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Communique) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique.Marshal(b, m, deterministic)
 }
 func (dst *Communique) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -367,10 +367,10 @@ func (ms *messageSymbol) GenerateAlias(g *Generator, pkg string) {
 	g.P("func (m *", ms.sym, ") Reset() { (*", remoteSym, ")(m).Reset() }")
 	g.P("func (m *", ms.sym, ") String() string { return (*", remoteSym, ")(m).String() }")
 	g.P("func (*", ms.sym, ") ProtoMessage() {}")
-	g.P("func (m *", ms.sym, ") Unmarshal(buf []byte) error ",
-		"{ return (*", remoteSym, ")(m).Unmarshal(buf) }")
-	g.P("func (m *", ms.sym, ") Marshal(b []byte, deterministic bool) ([]byte, error) ",
-		"{ return (*", remoteSym, ")(m).Marshal(b, deterministic) }")
+	g.P("func (m *", ms.sym, ") XXX_Unmarshal(buf []byte) error ",
+		"{ return (*", remoteSym, ")(m).XXX_Unmarshal(buf) }")
+	g.P("func (m *", ms.sym, ") XXX_Marshal(b []byte, deterministic bool) ([]byte, error) ",
+		"{ return (*", remoteSym, ")(m).XXX_Marshal(b, deterministic) }")
 	g.P("func (m *", ms.sym, ") XXX_Size() int ",
 		"{ return (*", remoteSym, ")(m).XXX_Size() }")
 	g.P("func (m *", ms.sym, ") XXX_DiscardUnknown() ",
@@ -2062,8 +2062,6 @@ func (g *Generator) generateMessage(message *Descriptor) {
 			g.P("return ", g.Pkg["proto"], ".UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)")
 			g.Out()
 			g.P("}")
-			g.P("// ensure ", ccTypeName, " satisfies proto.Unmarshaler")
-			g.P("var _ ", g.Pkg["proto"], ".Unmarshaler = (*", ccTypeName, ")(nil)")
 		}
 
 		g.P()
@@ -2089,13 +2087,13 @@ func (g *Generator) generateMessage(message *Descriptor) {
 	// calling Unmarshal, Marshal, Merge, Size, and Discard directly on that.
 
 	// Wrapper for table-driven marshaling and unmarshaling.
-	g.P("func (m *", ccTypeName, ") Unmarshal(b []byte) error {")
+	g.P("func (m *", ccTypeName, ") XXX_Unmarshal(b []byte) error {")
 	g.In()
 	g.P("return xxx_messageInfo_", ccTypeName, ".Unmarshal(m, b)")
 	g.Out()
 	g.P("}")
 
-	g.P("func (m *", ccTypeName, ") Marshal(b []byte, deterministic bool) ([]byte, error) {")
+	g.P("func (m *", ccTypeName, ") XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {")
 	g.In()
 	g.P("return xxx_messageInfo_", ccTypeName, ".Marshal(b, m, deterministic)")
 	g.Out()

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -59,10 +59,10 @@ func (m *DeprecatedRequest) Reset()                    { *m = DeprecatedRequest{
 func (m *DeprecatedRequest) String() string            { return proto.CompactTextString(m) }
 func (*DeprecatedRequest) ProtoMessage()               {}
 func (*DeprecatedRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *DeprecatedRequest) Unmarshal(b []byte) error {
+func (m *DeprecatedRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedRequest.Unmarshal(m, b)
 }
-func (m *DeprecatedRequest) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *DeprecatedRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DeprecatedRequest.Marshal(b, m, deterministic)
 }
 func (dst *DeprecatedRequest) XXX_Merge(src proto.Message) {
@@ -90,10 +90,10 @@ func (m *DeprecatedResponse) Reset()                    { *m = DeprecatedRespons
 func (m *DeprecatedResponse) String() string            { return proto.CompactTextString(m) }
 func (*DeprecatedResponse) ProtoMessage()               {}
 func (*DeprecatedResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *DeprecatedResponse) Unmarshal(b []byte) error {
+func (m *DeprecatedResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedResponse.Unmarshal(m, b)
 }
-func (m *DeprecatedResponse) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *DeprecatedResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DeprecatedResponse.Marshal(b, m, deterministic)
 }
 func (dst *DeprecatedResponse) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -39,10 +39,10 @@ var extRange_BaseMessage = []proto.ExtensionRange{
 func (*BaseMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_BaseMessage
 }
-func (m *BaseMessage) Unmarshal(b []byte) error {
+func (m *BaseMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BaseMessage.Unmarshal(m, b)
 }
-func (m *BaseMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *BaseMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BaseMessage.Marshal(b, m, deterministic)
 }
 func (dst *BaseMessage) XXX_Merge(src proto.Message) {
@@ -84,9 +84,6 @@ func (m *OldStyleMessage) UnmarshalJSON(buf []byte) error {
 	return proto.UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)
 }
 
-// ensure OldStyleMessage satisfies proto.Unmarshaler
-var _ proto.Unmarshaler = (*OldStyleMessage)(nil)
-
 var extRange_OldStyleMessage = []proto.ExtensionRange{
 	{100, 2147483646},
 }
@@ -94,10 +91,10 @@ var extRange_OldStyleMessage = []proto.ExtensionRange{
 func (*OldStyleMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OldStyleMessage
 }
-func (m *OldStyleMessage) Unmarshal(b []byte) error {
+func (m *OldStyleMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldStyleMessage.Unmarshal(m, b)
 }
-func (m *OldStyleMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OldStyleMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldStyleMessage.Marshal(b, m, deterministic)
 }
 func (dst *OldStyleMessage) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
+++ b/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
@@ -29,10 +29,10 @@ func (m *ExtraMessage) Reset()                    { *m = ExtraMessage{} }
 func (m *ExtraMessage) String() string            { return proto.CompactTextString(m) }
 func (*ExtraMessage) ProtoMessage()               {}
 func (*ExtraMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *ExtraMessage) Unmarshal(b []byte) error {
+func (m *ExtraMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExtraMessage.Unmarshal(m, b)
 }
-func (m *ExtraMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ExtraMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ExtraMessage.Marshal(b, m, deterministic)
 }
 func (dst *ExtraMessage) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -32,10 +32,10 @@ func (m *UserMessage) Reset()                    { *m = UserMessage{} }
 func (m *UserMessage) String() string            { return proto.CompactTextString(m) }
 func (*UserMessage) ProtoMessage()               {}
 func (*UserMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *UserMessage) Unmarshal(b []byte) error {
+func (m *UserMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UserMessage.Unmarshal(m, b)
 }
-func (m *UserMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *UserMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UserMessage.Marshal(b, m, deterministic)
 }
 func (dst *UserMessage) XXX_Merge(src proto.Message) {
@@ -84,10 +84,10 @@ var extRange_LoudMessage = []proto.ExtensionRange{
 func (*LoudMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_LoudMessage
 }
-func (m *LoudMessage) Unmarshal(b []byte) error {
+func (m *LoudMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoudMessage.Unmarshal(m, b)
 }
-func (m *LoudMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *LoudMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_LoudMessage.Marshal(b, m, deterministic)
 }
 func (dst *LoudMessage) XXX_Merge(src proto.Message) {
@@ -122,10 +122,10 @@ func (m *LoginMessage) Reset()                    { *m = LoginMessage{} }
 func (m *LoginMessage) String() string            { return proto.CompactTextString(m) }
 func (*LoginMessage) ProtoMessage()               {}
 func (*LoginMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
-func (m *LoginMessage) Unmarshal(b []byte) error {
+func (m *LoginMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoginMessage.Unmarshal(m, b)
 }
-func (m *LoginMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *LoginMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_LoginMessage.Marshal(b, m, deterministic)
 }
 func (dst *LoginMessage) XXX_Merge(src proto.Message) {
@@ -160,10 +160,10 @@ func (m *Detail) Reset()                    { *m = Detail{} }
 func (m *Detail) String() string            { return proto.CompactTextString(m) }
 func (*Detail) ProtoMessage()               {}
 func (*Detail) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
-func (m *Detail) Unmarshal(b []byte) error {
+func (m *Detail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Detail.Unmarshal(m, b)
 }
-func (m *Detail) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Detail) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Detail.Marshal(b, m, deterministic)
 }
 func (dst *Detail) XXX_Merge(src proto.Message) {
@@ -197,10 +197,10 @@ func (m *Announcement) Reset()                    { *m = Announcement{} }
 func (m *Announcement) String() string            { return proto.CompactTextString(m) }
 func (*Announcement) ProtoMessage()               {}
 func (*Announcement) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
-func (m *Announcement) Unmarshal(b []byte) error {
+func (m *Announcement) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Announcement.Unmarshal(m, b)
 }
-func (m *Announcement) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Announcement) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Announcement.Marshal(b, m, deterministic)
 }
 func (dst *Announcement) XXX_Merge(src proto.Message) {
@@ -244,10 +244,10 @@ func (m *OldStyleParcel) Reset()                    { *m = OldStyleParcel{} }
 func (m *OldStyleParcel) String() string            { return proto.CompactTextString(m) }
 func (*OldStyleParcel) ProtoMessage()               {}
 func (*OldStyleParcel) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
-func (m *OldStyleParcel) Unmarshal(b []byte) error {
+func (m *OldStyleParcel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldStyleParcel.Unmarshal(m, b)
 }
-func (m *OldStyleParcel) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OldStyleParcel) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldStyleParcel.Marshal(b, m, deterministic)
 }
 func (dst *OldStyleParcel) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -33,10 +33,10 @@ func (m *SimpleRequest) Reset()                    { *m = SimpleRequest{} }
 func (m *SimpleRequest) String() string            { return proto.CompactTextString(m) }
 func (*SimpleRequest) ProtoMessage()               {}
 func (*SimpleRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *SimpleRequest) Unmarshal(b []byte) error {
+func (m *SimpleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleRequest.Unmarshal(m, b)
 }
-func (m *SimpleRequest) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SimpleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleRequest.Marshal(b, m, deterministic)
 }
 func (dst *SimpleRequest) XXX_Merge(src proto.Message) {
@@ -61,10 +61,10 @@ func (m *SimpleResponse) Reset()                    { *m = SimpleResponse{} }
 func (m *SimpleResponse) String() string            { return proto.CompactTextString(m) }
 func (*SimpleResponse) ProtoMessage()               {}
 func (*SimpleResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *SimpleResponse) Unmarshal(b []byte) error {
+func (m *SimpleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleResponse.Unmarshal(m, b)
 }
-func (m *SimpleResponse) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SimpleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleResponse.Marshal(b, m, deterministic)
 }
 func (dst *SimpleResponse) XXX_Merge(src proto.Message) {
@@ -89,10 +89,10 @@ func (m *StreamMsg) Reset()                    { *m = StreamMsg{} }
 func (m *StreamMsg) String() string            { return proto.CompactTextString(m) }
 func (*StreamMsg) ProtoMessage()               {}
 func (*StreamMsg) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
-func (m *StreamMsg) Unmarshal(b []byte) error {
+func (m *StreamMsg) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg.Unmarshal(m, b)
 }
-func (m *StreamMsg) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *StreamMsg) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StreamMsg.Marshal(b, m, deterministic)
 }
 func (dst *StreamMsg) XXX_Merge(src proto.Message) {
@@ -117,10 +117,10 @@ func (m *StreamMsg2) Reset()                    { *m = StreamMsg2{} }
 func (m *StreamMsg2) String() string            { return proto.CompactTextString(m) }
 func (*StreamMsg2) ProtoMessage()               {}
 func (*StreamMsg2) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
-func (m *StreamMsg2) Unmarshal(b []byte) error {
+func (m *StreamMsg2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg2.Unmarshal(m, b)
 }
-func (m *StreamMsg2) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *StreamMsg2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StreamMsg2.Marshal(b, m, deterministic)
 }
 func (dst *StreamMsg2) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imp/imp.pb.go
+++ b/protoc-gen-go/testdata/imp/imp.pb.go
@@ -83,10 +83,10 @@ var extRange_ImportedMessage = []proto.ExtensionRange{
 func (*ImportedMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_ImportedMessage
 }
-func (m *ImportedMessage) Unmarshal(b []byte) error {
+func (m *ImportedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportedMessage.Unmarshal(m, b)
 }
-func (m *ImportedMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ImportedMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportedMessage.Marshal(b, m, deterministic)
 }
 func (dst *ImportedMessage) XXX_Merge(src proto.Message) {
@@ -241,10 +241,10 @@ func (m *ImportedMessage2) Reset()                    { *m = ImportedMessage2{} 
 func (m *ImportedMessage2) String() string            { return proto.CompactTextString(m) }
 func (*ImportedMessage2) ProtoMessage()               {}
 func (*ImportedMessage2) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *ImportedMessage2) Unmarshal(b []byte) error {
+func (m *ImportedMessage2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportedMessage2.Unmarshal(m, b)
 }
-func (m *ImportedMessage2) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ImportedMessage2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportedMessage2.Marshal(b, m, deterministic)
 }
 func (dst *ImportedMessage2) XXX_Merge(src proto.Message) {
@@ -278,9 +278,6 @@ func (m *ImportedExtendable) UnmarshalJSON(buf []byte) error {
 	return proto.UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)
 }
 
-// ensure ImportedExtendable satisfies proto.Unmarshaler
-var _ proto.Unmarshaler = (*ImportedExtendable)(nil)
-
 var extRange_ImportedExtendable = []proto.ExtensionRange{
 	{100, 2147483646},
 }
@@ -288,10 +285,10 @@ var extRange_ImportedExtendable = []proto.ExtensionRange{
 func (*ImportedExtendable) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_ImportedExtendable
 }
-func (m *ImportedExtendable) Unmarshal(b []byte) error {
+func (m *ImportedExtendable) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportedExtendable.Unmarshal(m, b)
 }
-func (m *ImportedExtendable) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ImportedExtendable) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ImportedExtendable.Marshal(b, m, deterministic)
 }
 func (dst *ImportedExtendable) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imp/imp2.pb.go
+++ b/protoc-gen-go/testdata/imp/imp2.pb.go
@@ -57,10 +57,10 @@ func (m *PubliclyImportedMessage) Reset()                    { *m = PubliclyImpo
 func (m *PubliclyImportedMessage) String() string            { return proto.CompactTextString(m) }
 func (*PubliclyImportedMessage) ProtoMessage()               {}
 func (*PubliclyImportedMessage) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
-func (m *PubliclyImportedMessage) Unmarshal(b []byte) error {
+func (m *PubliclyImportedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PubliclyImportedMessage.Unmarshal(m, b)
 }
-func (m *PubliclyImportedMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *PubliclyImportedMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PubliclyImportedMessage.Marshal(b, m, deterministic)
 }
 func (dst *PubliclyImportedMessage) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imp/imp3.pb.go
+++ b/protoc-gen-go/testdata/imp/imp3.pb.go
@@ -23,10 +23,10 @@ func (m *ForeignImportedMessage) Reset()                    { *m = ForeignImport
 func (m *ForeignImportedMessage) String() string            { return proto.CompactTextString(m) }
 func (*ForeignImportedMessage) ProtoMessage()               {}
 func (*ForeignImportedMessage) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
-func (m *ForeignImportedMessage) Unmarshal(b []byte) error {
+func (m *ForeignImportedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForeignImportedMessage.Unmarshal(m, b)
 }
-func (m *ForeignImportedMessage) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ForeignImportedMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ForeignImportedMessage.Marshal(b, m, deterministic)
 }
 func (dst *ForeignImportedMessage) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/multi/multi1.pb.go
+++ b/protoc-gen-go/testdata/multi/multi1.pb.go
@@ -31,10 +31,10 @@ func (m *Multi1) Reset()                    { *m = Multi1{} }
 func (m *Multi1) String() string            { return proto.CompactTextString(m) }
 func (*Multi1) ProtoMessage()               {}
 func (*Multi1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *Multi1) Unmarshal(b []byte) error {
+func (m *Multi1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi1.Unmarshal(m, b)
 }
-func (m *Multi1) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Multi1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Multi1.Marshal(b, m, deterministic)
 }
 func (dst *Multi1) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -61,10 +61,10 @@ func (m *Multi2) Reset()                    { *m = Multi2{} }
 func (m *Multi2) String() string            { return proto.CompactTextString(m) }
 func (*Multi2) ProtoMessage()               {}
 func (*Multi2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
-func (m *Multi2) Unmarshal(b []byte) error {
+func (m *Multi2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi2.Unmarshal(m, b)
 }
-func (m *Multi2) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Multi2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Multi2.Marshal(b, m, deterministic)
 }
 func (dst *Multi2) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -57,10 +57,10 @@ func (m *Multi3) Reset()                    { *m = Multi3{} }
 func (m *Multi3) String() string            { return proto.CompactTextString(m) }
 func (*Multi3) ProtoMessage()               {}
 func (*Multi3) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
-func (m *Multi3) Unmarshal(b []byte) error {
+func (m *Multi3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi3.Unmarshal(m, b)
 }
-func (m *Multi3) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Multi3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Multi3.Marshal(b, m, deterministic)
 }
 func (dst *Multi3) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -192,10 +192,10 @@ func (m *Request) Reset()                    { *m = Request{} }
 func (m *Request) String() string            { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()               {}
 func (*Request) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *Request) Unmarshal(b []byte) error {
+func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
 }
-func (m *Request) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Request.Marshal(b, m, deterministic)
 }
 func (dst *Request) XXX_Merge(src proto.Message) {
@@ -288,10 +288,10 @@ func (m *Request_SomeGroup) Reset()                    { *m = Request_SomeGroup{
 func (m *Request_SomeGroup) String() string            { return proto.CompactTextString(m) }
 func (*Request_SomeGroup) ProtoMessage()               {}
 func (*Request_SomeGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0, 0} }
-func (m *Request_SomeGroup) Unmarshal(b []byte) error {
+func (m *Request_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request_SomeGroup.Unmarshal(m, b)
 }
-func (m *Request_SomeGroup) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Request_SomeGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Request_SomeGroup.Marshal(b, m, deterministic)
 }
 func (dst *Request_SomeGroup) XXX_Merge(src proto.Message) {
@@ -334,10 +334,10 @@ var extRange_Reply = []proto.ExtensionRange{
 func (*Reply) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_Reply
 }
-func (m *Reply) Unmarshal(b []byte) error {
+func (m *Reply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Reply.Unmarshal(m, b)
 }
-func (m *Reply) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Reply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Reply.Marshal(b, m, deterministic)
 }
 func (dst *Reply) XXX_Merge(src proto.Message) {
@@ -379,10 +379,10 @@ func (m *Reply_Entry) Reset()                    { *m = Reply_Entry{} }
 func (m *Reply_Entry) String() string            { return proto.CompactTextString(m) }
 func (*Reply_Entry) ProtoMessage()               {}
 func (*Reply_Entry) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1, 0} }
-func (m *Reply_Entry) Unmarshal(b []byte) error {
+func (m *Reply_Entry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Reply_Entry.Unmarshal(m, b)
 }
-func (m *Reply_Entry) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Reply_Entry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Reply_Entry.Marshal(b, m, deterministic)
 }
 func (dst *Reply_Entry) XXX_Merge(src proto.Message) {
@@ -440,10 +440,10 @@ var extRange_OtherBase = []proto.ExtensionRange{
 func (*OtherBase) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OtherBase
 }
-func (m *OtherBase) Unmarshal(b []byte) error {
+func (m *OtherBase) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherBase.Unmarshal(m, b)
 }
-func (m *OtherBase) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OtherBase) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OtherBase.Marshal(b, m, deterministic)
 }
 func (dst *OtherBase) XXX_Merge(src proto.Message) {
@@ -475,10 +475,10 @@ func (m *ReplyExtensions) Reset()                    { *m = ReplyExtensions{} }
 func (m *ReplyExtensions) String() string            { return proto.CompactTextString(m) }
 func (*ReplyExtensions) ProtoMessage()               {}
 func (*ReplyExtensions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
-func (m *ReplyExtensions) Unmarshal(b []byte) error {
+func (m *ReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReplyExtensions.Unmarshal(m, b)
 }
-func (m *ReplyExtensions) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ReplyExtensions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReplyExtensions.Marshal(b, m, deterministic)
 }
 func (dst *ReplyExtensions) XXX_Merge(src proto.Message) {
@@ -531,10 +531,10 @@ func (m *OtherReplyExtensions) Reset()                    { *m = OtherReplyExten
 func (m *OtherReplyExtensions) String() string            { return proto.CompactTextString(m) }
 func (*OtherReplyExtensions) ProtoMessage()               {}
 func (*OtherReplyExtensions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
-func (m *OtherReplyExtensions) Unmarshal(b []byte) error {
+func (m *OtherReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherReplyExtensions.Unmarshal(m, b)
 }
-func (m *OtherReplyExtensions) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OtherReplyExtensions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OtherReplyExtensions.Marshal(b, m, deterministic)
 }
 func (dst *OtherReplyExtensions) XXX_Merge(src proto.Message) {
@@ -575,9 +575,6 @@ func (m *OldReply) UnmarshalJSON(buf []byte) error {
 	return proto.UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)
 }
 
-// ensure OldReply satisfies proto.Unmarshaler
-var _ proto.Unmarshaler = (*OldReply)(nil)
-
 var extRange_OldReply = []proto.ExtensionRange{
 	{100, 2147483646},
 }
@@ -585,10 +582,10 @@ var extRange_OldReply = []proto.ExtensionRange{
 func (*OldReply) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OldReply
 }
-func (m *OldReply) Unmarshal(b []byte) error {
+func (m *OldReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldReply.Unmarshal(m, b)
 }
-func (m *OldReply) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *OldReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldReply.Marshal(b, m, deterministic)
 }
 func (dst *OldReply) XXX_Merge(src proto.Message) {
@@ -628,10 +625,10 @@ func (m *Communique) Reset()                    { *m = Communique{} }
 func (m *Communique) String() string            { return proto.CompactTextString(m) }
 func (*Communique) ProtoMessage()               {}
 func (*Communique) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6} }
-func (m *Communique) Unmarshal(b []byte) error {
+func (m *Communique) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique.Unmarshal(m, b)
 }
-func (m *Communique) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Communique) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique.Marshal(b, m, deterministic)
 }
 func (dst *Communique) XXX_Merge(src proto.Message) {
@@ -979,10 +976,10 @@ func (m *Communique_SomeGroup) Reset()                    { *m = Communique_Some
 func (m *Communique_SomeGroup) String() string            { return proto.CompactTextString(m) }
 func (*Communique_SomeGroup) ProtoMessage()               {}
 func (*Communique_SomeGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6, 0} }
-func (m *Communique_SomeGroup) Unmarshal(b []byte) error {
+func (m *Communique_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_SomeGroup.Unmarshal(m, b)
 }
-func (m *Communique_SomeGroup) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Communique_SomeGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique_SomeGroup.Marshal(b, m, deterministic)
 }
 func (dst *Communique_SomeGroup) XXX_Merge(src proto.Message) {
@@ -1014,10 +1011,10 @@ func (m *Communique_Delta) Reset()                    { *m = Communique_Delta{} 
 func (m *Communique_Delta) String() string            { return proto.CompactTextString(m) }
 func (*Communique_Delta) ProtoMessage()               {}
 func (*Communique_Delta) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6, 1} }
-func (m *Communique_Delta) Unmarshal(b []byte) error {
+func (m *Communique_Delta) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_Delta.Unmarshal(m, b)
 }
-func (m *Communique_Delta) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Communique_Delta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique_Delta.Marshal(b, m, deterministic)
 }
 func (dst *Communique_Delta) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -60,10 +60,10 @@ func (m *Request) Reset()                    { *m = Request{} }
 func (m *Request) String() string            { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()               {}
 func (*Request) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *Request) Unmarshal(b []byte) error {
+func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
 }
-func (m *Request) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Request.Marshal(b, m, deterministic)
 }
 func (dst *Request) XXX_Merge(src proto.Message) {
@@ -125,10 +125,10 @@ func (m *Book) Reset()                    { *m = Book{} }
 func (m *Book) String() string            { return proto.CompactTextString(m) }
 func (*Book) ProtoMessage()               {}
 func (*Book) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
-func (m *Book) Unmarshal(b []byte) error {
+func (m *Book) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Book.Unmarshal(m, b)
 }
-func (m *Book) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Book) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Book.Marshal(b, m, deterministic)
 }
 func (dst *Book) XXX_Merge(src proto.Message) {


### PR DESCRIPTION
As part of the recent protobuf optimization work, we started generating
Unmarshal and Marshal methods on generated messages. These were done to
support the table-driven implementation within the proto package.

We are renaming Marshal as XXX_Marshal and Unmarshal as XXX_Unmarshal
to make it clear that users are not supposed to call these directly.
There are several reasons for the rename:
* The Marshal method assumes that deterministic is the only option we
would ever support for protos, and is not very forward compatible.
* The presence of a deterministic boolean is confusing for users,
where many set it without considering whether it is necessary.
* The Unmarshal method has a slightly different semantic than the previously
documented proto.Unmarshaler interface. The documented Unmarshal specifies
that Reset is called, while the new method does no such thing. The semantic
difference warrants a rename of the method.
* Some users in the Go community depend on these methods not being
generated by default.

Fixes #530