### PR TITLE
protoc-gen-go: regenerate golden tests

### DIFF
--- a/protoc-gen-go/testdata/imports/fmt/m.pb.go
+++ b/protoc-gen-go/testdata/imports/fmt/m.pb.go
@@ -28,10 +28,10 @@ func (m *M) Reset()                    { *m = M{} }
 func (m *M) String() string            { return proto.CompactTextString(m) }
 func (*M) ProtoMessage()               {}
 func (*M) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *M) Unmarshal(b []byte) error {
+func (m *M) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M.Unmarshal(m, b)
 }
-func (m *M) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *M) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M.Marshal(b, m, deterministic)
 }
 func (dst *M) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -28,10 +28,10 @@ func (m *M1) Reset()                    { *m = M1{} }
 func (m *M1) String() string            { return proto.CompactTextString(m) }
 func (*M1) ProtoMessage()               {}
 func (*M1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *M1) Unmarshal(b []byte) error {
+func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
 }
-func (m *M1) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *M1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M1.Marshal(b, m, deterministic)
 }
 func (dst *M1) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
@@ -22,10 +22,10 @@ func (m *M2) Reset()                    { *m = M2{} }
 func (m *M2) String() string            { return proto.CompactTextString(m) }
 func (*M2) ProtoMessage()               {}
 func (*M2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
-func (m *M2) Unmarshal(b []byte) error {
+func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
 }
-func (m *M2) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *M2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M2.Marshal(b, m, deterministic)
 }
 func (dst *M2) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
@@ -28,10 +28,10 @@ func (m *M3) Reset()                    { *m = M3{} }
 func (m *M3) String() string            { return proto.CompactTextString(m) }
 func (*M3) ProtoMessage()               {}
 func (*M3) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *M3) Unmarshal(b []byte) error {
+func (m *M3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M3.Unmarshal(m, b)
 }
-func (m *M3) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *M3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M3.Marshal(b, m, deterministic)
 }
 func (dst *M3) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
@@ -22,10 +22,10 @@ func (m *M4) Reset()                    { *m = M4{} }
 func (m *M4) String() string            { return proto.CompactTextString(m) }
 func (*M4) ProtoMessage()               {}
 func (*M4) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
-func (m *M4) Unmarshal(b []byte) error {
+func (m *M4) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M4.Unmarshal(m, b)
 }
-func (m *M4) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *M4) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M4.Marshal(b, m, deterministic)
 }
 func (dst *M4) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
@@ -28,10 +28,10 @@ func (m *M1) Reset()                    { *m = M1{} }
 func (m *M1) String() string            { return proto.CompactTextString(m) }
 func (*M1) ProtoMessage()               {}
 func (*M1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *M1) Unmarshal(b []byte) error {
+func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
 }
-func (m *M1) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *M1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M1.Marshal(b, m, deterministic)
 }
 func (dst *M1) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
@@ -22,10 +22,10 @@ func (m *M2) Reset()                    { *m = M2{} }
 func (m *M2) String() string            { return proto.CompactTextString(m) }
 func (*M2) ProtoMessage()               {}
 func (*M2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
-func (m *M2) Unmarshal(b []byte) error {
+func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
 }
-func (m *M2) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *M2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M2.Marshal(b, m, deterministic)
 }
 func (dst *M2) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
@@ -30,10 +30,10 @@ func (m *A1M1) Reset()                    { *m = A1M1{} }
 func (m *A1M1) String() string            { return proto.CompactTextString(m) }
 func (*A1M1) ProtoMessage()               {}
 func (*A1M1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
-func (m *A1M1) Unmarshal(b []byte) error {
+func (m *A1M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M1.Unmarshal(m, b)
 }
-func (m *A1M1) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *A1M1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_A1M1.Marshal(b, m, deterministic)
 }
 func (dst *A1M1) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
@@ -24,10 +24,10 @@ func (m *A1M2) Reset()                    { *m = A1M2{} }
 func (m *A1M2) String() string            { return proto.CompactTextString(m) }
 func (*A1M2) ProtoMessage()               {}
 func (*A1M2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
-func (m *A1M2) Unmarshal(b []byte) error {
+func (m *A1M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M2.Unmarshal(m, b)
 }
-func (m *A1M2) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *A1M2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_A1M2.Marshal(b, m, deterministic)
 }
 func (dst *A1M2) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_import_all.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_all.pb.go
@@ -36,10 +36,10 @@ func (m *All) Reset()                    { *m = All{} }
 func (m *All) String() string            { return proto.CompactTextString(m) }
 func (*All) ProtoMessage()               {}
 func (*All) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
-func (m *All) Unmarshal(b []byte) error {
+func (m *All) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_All.Unmarshal(m, b)
 }
-func (m *All) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *All) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_All.Marshal(b, m, deterministic)
 }
 func (dst *All) XXX_Merge(src proto.Message) {

--- a/protoc-gen-go/testdata/imports/test_import_public.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_public.pb.go
@@ -16,12 +16,12 @@ var _ = math.Inf
 // M1 from public import imports/test_a_1/m1.proto
 type M1 test_a.M1
 
-func (m *M1) Reset()                     { (*test_a.M1)(m).Reset() }
-func (m *M1) String() string             { return (*test_a.M1)(m).String() }
-func (*M1) ProtoMessage()                {}
-func (m *M1) Unmarshal(buf []byte) error { return (*test_a.M1)(m).Unmarshal(buf) }
-func (m *M1) Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return (*test_a.M1)(m).Marshal(b, deterministic)
+func (m *M1) Reset()                         { (*test_a.M1)(m).Reset() }
+func (m *M1) String() string                 { return (*test_a.M1)(m).String() }
+func (*M1) ProtoMessage()                    {}
+func (m *M1) XXX_Unmarshal(buf []byte) error { return (*test_a.M1)(m).XXX_Unmarshal(buf) }
+func (m *M1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return (*test_a.M1)(m).XXX_Marshal(b, deterministic)
 }
 func (m *M1) XXX_Size() int       { return (*test_a.M1)(m).XXX_Size() }
 func (m *M1) XXX_DiscardUnknown() { (*test_a.M1)(m).XXX_DiscardUnknown() }
@@ -37,10 +37,10 @@ func (m *Public) Reset()                    { *m = Public{} }
 func (m *Public) String() string            { return proto.CompactTextString(m) }
 func (*Public) ProtoMessage()               {}
 func (*Public) Descriptor() ([]byte, []int) { return fileDescriptor3, []int{0} }
-func (m *Public) Unmarshal(b []byte) error {
+func (m *Public) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Public.Unmarshal(m, b)
 }
-func (m *Public) Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *Public) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Public.Marshal(b, m, deterministic)
 }
 func (dst *Public) XXX_Merge(src proto.Message) {


### PR DESCRIPTION
New tests weren't updated for renamed Marshal/Unmarshal methods.