### PR TITLE
README: change minimum required Go version Go 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Google's data interchange format.
 Copyright 2010 The Go Authors.
 https://github.com/golang/protobuf
 
-This package and the code it generates requires at least Go 1.4.
+This package and the code it generates requires at least Go 1.6.
 
 This software implements Go bindings for protocol buffers.  For
 information about protocol buffers themselves, see


### PR DESCRIPTION
We're only testing with 1.6+, so claiming support for earlier versions is dubious.