### PR TITLE
protoc-gen-go: don't depend on input file ordering

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -40,6 +40,8 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"go/parser"
 	"go/printer"
@@ -258,7 +260,7 @@ type FileDescriptor struct {
 	// This is used for supporting public imports.
 	exported map[Object][]symbol
 
-	index int // The index of this file in the list of files to generate code for
+	fingerprint string // Fingerprint of this file's contents.
 
 	proto3 bool // whether to generate proto3 code for this file
 }
@@ -269,7 +271,10 @@ func (d *FileDescriptor) PackageName() string { return uniquePackageOf(d.FileDes
 // VarName is the variable name we'll use in the generated code to refer
 // to the compressed bytes of this descriptor. It is not exported, so
 // it is only valid inside the generated package.
-func (d *FileDescriptor) VarName() string { return fmt.Sprintf("fileDescriptor%d", d.index) }
+func (d *FileDescriptor) VarName() string {
+	name := strings.Map(badToUnderscore, baseName(d.GetName()))
+	return fmt.Sprintf("fileDescriptor_%s_%s", name, d.fingerprint)
+}
 
 // goPackageOption interprets the file's go_package option.
 // If there is no go_package, it returns ("", "", false).
@@ -847,9 +852,25 @@ func (g *Generator) WrapTypes() {
 		if fd == nil {
 			g.Fail("could not find file named", fileName)
 		}
-		fd.index = len(g.genFiles)
+		fingerprint, err := fingerprintProto(fd.FileDescriptorProto)
+		if err != nil {
+			g.Error(err)
+		}
+		fd.fingerprint = fingerprint
 		g.genFiles = append(g.genFiles, fd)
 	}
+}
+
+// fingerprintProto returns a fingerprint for a message.
+// The fingerprint is intended to prevent conflicts between generated fileds,
+// not to provide cryptographic security.
+func fingerprintProto(m proto.Message) (string, error) {
+	b, err := proto.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:8]), nil
 }
 
 // Scan the descriptors in this file.  For each one, build the slice of nested descriptors
@@ -1237,15 +1258,13 @@ func (g *Generator) generate(file *FileDescriptor) {
 	g.file = g.FileOf(file.FileDescriptorProto)
 	g.usedPackages = make(map[string]bool)
 
-	if g.file.index == 0 {
-		// For one file in the package, assert version compatibility.
-		g.P("// This is a compile-time assertion to ensure that this generated file")
-		g.P("// is compatible with the proto package it is being compiled against.")
-		g.P("// A compilation error at this line likely means your copy of the")
-		g.P("// proto package needs to be updated.")
-		g.P("const _ = ", g.Pkg["proto"], ".ProtoPackageIsVersion", generatedCodeVersion, " // please upgrade the proto package")
-		g.P()
-	}
+	g.P("// This is a compile-time assertion to ensure that this generated file")
+	g.P("// is compatible with the proto package it is being compiled against.")
+	g.P("// A compilation error at this line likely means your copy of the")
+	g.P("// proto package needs to be updated.")
+	g.P("const _ = ", g.Pkg["proto"], ".ProtoPackageIsVersion", generatedCodeVersion, " // please upgrade the proto package")
+	g.P()
+
 	for _, td := range g.file.imp {
 		g.generateImported(td)
 	}

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -44,7 +44,9 @@ var DeprecatedEnum_value = map[string]int32{
 func (x DeprecatedEnum) String() string {
 	return proto.EnumName(DeprecatedEnum_name, int32(x))
 }
-func (DeprecatedEnum) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (DeprecatedEnum) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_deprecated_9e1889ba21817fad, []int{0}
+}
 
 // DeprecatedRequest is a request to DeprecatedCall.
 //
@@ -55,10 +57,12 @@ type DeprecatedRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *DeprecatedRequest) Reset()                    { *m = DeprecatedRequest{} }
-func (m *DeprecatedRequest) String() string            { return proto.CompactTextString(m) }
-func (*DeprecatedRequest) ProtoMessage()               {}
-func (*DeprecatedRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *DeprecatedRequest) Reset()         { *m = DeprecatedRequest{} }
+func (m *DeprecatedRequest) String() string { return proto.CompactTextString(m) }
+func (*DeprecatedRequest) ProtoMessage()    {}
+func (*DeprecatedRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_deprecated_9e1889ba21817fad, []int{0}
+}
 func (m *DeprecatedRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedRequest.Unmarshal(m, b)
 }
@@ -86,10 +90,12 @@ type DeprecatedResponse struct {
 	XXX_sizecache        int32          `json:"-"`
 }
 
-func (m *DeprecatedResponse) Reset()                    { *m = DeprecatedResponse{} }
-func (m *DeprecatedResponse) String() string            { return proto.CompactTextString(m) }
-func (*DeprecatedResponse) ProtoMessage()               {}
-func (*DeprecatedResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (m *DeprecatedResponse) Reset()         { *m = DeprecatedResponse{} }
+func (m *DeprecatedResponse) String() string { return proto.CompactTextString(m) }
+func (*DeprecatedResponse) ProtoMessage()    {}
+func (*DeprecatedResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_deprecated_9e1889ba21817fad, []int{1}
+}
 func (m *DeprecatedResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedResponse.Unmarshal(m, b)
 }
@@ -201,9 +207,11 @@ var _DeprecatedService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "deprecated/deprecated.proto",
 }
 
-func init() { proto.RegisterFile("deprecated/deprecated.proto", fileDescriptor0) }
+func init() {
+	proto.RegisterFile("deprecated/deprecated.proto", fileDescriptor_deprecated_9e1889ba21817fad)
+}
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_deprecated_9e1889ba21817fad = []byte{
 	// 248 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4e, 0x49, 0x2d, 0x28,
 	0x4a, 0x4d, 0x4e, 0x2c, 0x49, 0x4d, 0xd1, 0x47, 0x30, 0xf5, 0x0a, 0x8a, 0xf2, 0x4b, 0xf2, 0x85,

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -26,10 +26,12 @@ type BaseMessage struct {
 	XXX_sizecache                int32  `json:"-"`
 }
 
-func (m *BaseMessage) Reset()                    { *m = BaseMessage{} }
-func (m *BaseMessage) String() string            { return proto.CompactTextString(m) }
-func (*BaseMessage) ProtoMessage()               {}
-func (*BaseMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *BaseMessage) Reset()         { *m = BaseMessage{} }
+func (m *BaseMessage) String() string { return proto.CompactTextString(m) }
+func (*BaseMessage) ProtoMessage()    {}
+func (*BaseMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_base_41d3c712c9fc37fc, []int{0}
+}
 
 var extRange_BaseMessage = []proto.ExtensionRange{
 	{4, 9},
@@ -72,10 +74,12 @@ type OldStyleMessage struct {
 	XXX_sizecache                int32  `json:"-"`
 }
 
-func (m *OldStyleMessage) Reset()                    { *m = OldStyleMessage{} }
-func (m *OldStyleMessage) String() string            { return proto.CompactTextString(m) }
-func (*OldStyleMessage) ProtoMessage()               {}
-func (*OldStyleMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (m *OldStyleMessage) Reset()         { *m = OldStyleMessage{} }
+func (m *OldStyleMessage) String() string { return proto.CompactTextString(m) }
+func (*OldStyleMessage) ProtoMessage()    {}
+func (*OldStyleMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_base_41d3c712c9fc37fc, []int{1}
+}
 
 func (m *OldStyleMessage) MarshalJSON() ([]byte, error) {
 	return proto.MarshalMessageSetJSON(&m.XXX_InternalExtensions)
@@ -114,9 +118,11 @@ func init() {
 	proto.RegisterType((*OldStyleMessage)(nil), "extension_base.OldStyleMessage")
 }
 
-func init() { proto.RegisterFile("extension_base/extension_base.proto", fileDescriptor0) }
+func init() {
+	proto.RegisterFile("extension_base/extension_base.proto", fileDescriptor_extension_base_41d3c712c9fc37fc)
+}
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_extension_base_41d3c712c9fc37fc = []byte{
 	// 179 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x4e, 0xad, 0x28, 0x49,
 	0xcd, 0x2b, 0xce, 0xcc, 0xcf, 0x8b, 0x4f, 0x4a, 0x2c, 0x4e, 0xd5, 0x47, 0xe5, 0xea, 0x15, 0x14,

--- a/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
+++ b/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
@@ -25,10 +25,12 @@ type ExtraMessage struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ExtraMessage) Reset()                    { *m = ExtraMessage{} }
-func (m *ExtraMessage) String() string            { return proto.CompactTextString(m) }
-func (*ExtraMessage) ProtoMessage()               {}
-func (*ExtraMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *ExtraMessage) Reset()         { *m = ExtraMessage{} }
+func (m *ExtraMessage) String() string { return proto.CompactTextString(m) }
+func (*ExtraMessage) ProtoMessage()    {}
+func (*ExtraMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_extra_83adf2410f49f816, []int{0}
+}
 func (m *ExtraMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExtraMessage.Unmarshal(m, b)
 }
@@ -58,9 +60,11 @@ func init() {
 	proto.RegisterType((*ExtraMessage)(nil), "extension_extra.ExtraMessage")
 }
 
-func init() { proto.RegisterFile("extension_extra/extension_extra.proto", fileDescriptor0) }
+func init() {
+	proto.RegisterFile("extension_extra/extension_extra.proto", fileDescriptor_extension_extra_83adf2410f49f816)
+}
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_extension_extra_83adf2410f49f816 = []byte{
 	// 133 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x4d, 0xad, 0x28, 0x49,
 	0xcd, 0x2b, 0xce, 0xcc, 0xcf, 0x8b, 0x4f, 0xad, 0x28, 0x29, 0x4a, 0xd4, 0x47, 0xe3, 0xeb, 0x15,

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -28,10 +28,12 @@ type UserMessage struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *UserMessage) Reset()                    { *m = UserMessage{} }
-func (m *UserMessage) String() string            { return proto.CompactTextString(m) }
-func (*UserMessage) ProtoMessage()               {}
-func (*UserMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *UserMessage) Reset()         { *m = UserMessage{} }
+func (m *UserMessage) String() string { return proto.CompactTextString(m) }
+func (*UserMessage) ProtoMessage()    {}
+func (*UserMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{0}
+}
 func (m *UserMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UserMessage.Unmarshal(m, b)
 }
@@ -72,10 +74,12 @@ type LoudMessage struct {
 	XXX_sizecache                int32  `json:"-"`
 }
 
-func (m *LoudMessage) Reset()                    { *m = LoudMessage{} }
-func (m *LoudMessage) String() string            { return proto.CompactTextString(m) }
-func (*LoudMessage) ProtoMessage()               {}
-func (*LoudMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (m *LoudMessage) Reset()         { *m = LoudMessage{} }
+func (m *LoudMessage) String() string { return proto.CompactTextString(m) }
+func (*LoudMessage) ProtoMessage()    {}
+func (*LoudMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{1}
+}
 
 var extRange_LoudMessage = []proto.ExtensionRange{
 	{100, 536870911},
@@ -118,10 +122,12 @@ type LoginMessage struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *LoginMessage) Reset()                    { *m = LoginMessage{} }
-func (m *LoginMessage) String() string            { return proto.CompactTextString(m) }
-func (*LoginMessage) ProtoMessage()               {}
-func (*LoginMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+func (m *LoginMessage) Reset()         { *m = LoginMessage{} }
+func (m *LoginMessage) String() string { return proto.CompactTextString(m) }
+func (*LoginMessage) ProtoMessage()    {}
+func (*LoginMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{2}
+}
 func (m *LoginMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoginMessage.Unmarshal(m, b)
 }
@@ -156,10 +162,12 @@ type Detail struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Detail) Reset()                    { *m = Detail{} }
-func (m *Detail) String() string            { return proto.CompactTextString(m) }
-func (*Detail) ProtoMessage()               {}
-func (*Detail) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+func (m *Detail) Reset()         { *m = Detail{} }
+func (m *Detail) String() string { return proto.CompactTextString(m) }
+func (*Detail) ProtoMessage()    {}
+func (*Detail) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{3}
+}
 func (m *Detail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Detail.Unmarshal(m, b)
 }
@@ -193,10 +201,12 @@ type Announcement struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Announcement) Reset()                    { *m = Announcement{} }
-func (m *Announcement) String() string            { return proto.CompactTextString(m) }
-func (*Announcement) ProtoMessage()               {}
-func (*Announcement) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+func (m *Announcement) Reset()         { *m = Announcement{} }
+func (m *Announcement) String() string { return proto.CompactTextString(m) }
+func (*Announcement) ProtoMessage()    {}
+func (*Announcement) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{4}
+}
 func (m *Announcement) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Announcement.Unmarshal(m, b)
 }
@@ -240,10 +250,12 @@ type OldStyleParcel struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *OldStyleParcel) Reset()                    { *m = OldStyleParcel{} }
-func (m *OldStyleParcel) String() string            { return proto.CompactTextString(m) }
-func (*OldStyleParcel) ProtoMessage()               {}
-func (*OldStyleParcel) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+func (m *OldStyleParcel) Reset()         { *m = OldStyleParcel{} }
+func (m *OldStyleParcel) String() string { return proto.CompactTextString(m) }
+func (*OldStyleParcel) ProtoMessage()    {}
+func (*OldStyleParcel) Descriptor() ([]byte, []int) {
+	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{5}
+}
 func (m *OldStyleParcel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldStyleParcel.Unmarshal(m, b)
 }
@@ -348,9 +360,11 @@ func init() {
 	proto.RegisterExtension(E_Detail)
 }
 
-func init() { proto.RegisterFile("extension_user/extension_user.proto", fileDescriptor0) }
+func init() {
+	proto.RegisterFile("extension_user/extension_user.proto", fileDescriptor_extension_user_af41b5e0bdfb7846)
+}
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_extension_user_af41b5e0bdfb7846 = []byte{
 	// 492 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0x51, 0x6f, 0x94, 0x40,
 	0x10, 0x0e, 0x6d, 0x8f, 0x5e, 0x87, 0x6b, 0xad, 0xa8, 0xcd, 0xa5, 0x6a, 0x25, 0x18, 0x13, 0x62,

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -29,10 +29,12 @@ type SimpleRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *SimpleRequest) Reset()                    { *m = SimpleRequest{} }
-func (m *SimpleRequest) String() string            { return proto.CompactTextString(m) }
-func (*SimpleRequest) ProtoMessage()               {}
-func (*SimpleRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *SimpleRequest) Reset()         { *m = SimpleRequest{} }
+func (m *SimpleRequest) String() string { return proto.CompactTextString(m) }
+func (*SimpleRequest) ProtoMessage()    {}
+func (*SimpleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_grpc_65bf3902e49ee873, []int{0}
+}
 func (m *SimpleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleRequest.Unmarshal(m, b)
 }
@@ -57,10 +59,12 @@ type SimpleResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *SimpleResponse) Reset()                    { *m = SimpleResponse{} }
-func (m *SimpleResponse) String() string            { return proto.CompactTextString(m) }
-func (*SimpleResponse) ProtoMessage()               {}
-func (*SimpleResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (m *SimpleResponse) Reset()         { *m = SimpleResponse{} }
+func (m *SimpleResponse) String() string { return proto.CompactTextString(m) }
+func (*SimpleResponse) ProtoMessage()    {}
+func (*SimpleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_grpc_65bf3902e49ee873, []int{1}
+}
 func (m *SimpleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleResponse.Unmarshal(m, b)
 }
@@ -88,7 +92,7 @@ type StreamMsg struct {
 func (m *StreamMsg) Reset()                    { *m = StreamMsg{} }
 func (m *StreamMsg) String() string            { return proto.CompactTextString(m) }
 func (*StreamMsg) ProtoMessage()               {}
-func (*StreamMsg) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+func (*StreamMsg) Descriptor() ([]byte, []int) { return fileDescriptor_grpc_65bf3902e49ee873, []int{2} }
 func (m *StreamMsg) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg.Unmarshal(m, b)
 }
@@ -116,7 +120,7 @@ type StreamMsg2 struct {
 func (m *StreamMsg2) Reset()                    { *m = StreamMsg2{} }
 func (m *StreamMsg2) String() string            { return proto.CompactTextString(m) }
 func (*StreamMsg2) ProtoMessage()               {}
-func (*StreamMsg2) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+func (*StreamMsg2) Descriptor() ([]byte, []int) { return fileDescriptor_grpc_65bf3902e49ee873, []int{3} }
 func (m *StreamMsg2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg2.Unmarshal(m, b)
 }
@@ -413,9 +417,9 @@ var _Test_serviceDesc = grpc.ServiceDesc{
 	Metadata: "grpc/grpc.proto",
 }
 
-func init() { proto.RegisterFile("grpc/grpc.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("grpc/grpc.proto", fileDescriptor_grpc_65bf3902e49ee873) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_grpc_65bf3902e49ee873 = []byte{
 	// 244 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x4f, 0x2f, 0x2a, 0x48,
 	0xd6, 0x07, 0x11, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x3c, 0x60, 0x76, 0x49, 0x6a, 0x71,

--- a/protoc-gen-go/testdata/imp/imp.pb.go
+++ b/protoc-gen-go/testdata/imp/imp.pb.go
@@ -50,7 +50,9 @@ func (x *ImportedMessage_Owner) UnmarshalJSON(data []byte) error {
 	*x = ImportedMessage_Owner(value)
 	return nil
 }
-func (ImportedMessage_Owner) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{0, 0} }
+func (ImportedMessage_Owner) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_imp_81275c260ac30f8b, []int{0, 0}
+}
 
 type ImportedMessage struct {
 	Field *int64 `protobuf:"varint,1,req,name=field" json:"field,omitempty"`
@@ -71,10 +73,12 @@ type ImportedMessage struct {
 	XXX_sizecache                int32  `json:"-"`
 }
 
-func (m *ImportedMessage) Reset()                    { *m = ImportedMessage{} }
-func (m *ImportedMessage) String() string            { return proto.CompactTextString(m) }
-func (*ImportedMessage) ProtoMessage()               {}
-func (*ImportedMessage) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *ImportedMessage) Reset()         { *m = ImportedMessage{} }
+func (m *ImportedMessage) String() string { return proto.CompactTextString(m) }
+func (*ImportedMessage) ProtoMessage()    {}
+func (*ImportedMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_imp_81275c260ac30f8b, []int{0}
+}
 
 var extRange_ImportedMessage = []proto.ExtensionRange{
 	{90, 100},
@@ -237,10 +241,12 @@ type ImportedMessage2 struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ImportedMessage2) Reset()                    { *m = ImportedMessage2{} }
-func (m *ImportedMessage2) String() string            { return proto.CompactTextString(m) }
-func (*ImportedMessage2) ProtoMessage()               {}
-func (*ImportedMessage2) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (m *ImportedMessage2) Reset()         { *m = ImportedMessage2{} }
+func (m *ImportedMessage2) String() string { return proto.CompactTextString(m) }
+func (*ImportedMessage2) ProtoMessage()    {}
+func (*ImportedMessage2) Descriptor() ([]byte, []int) {
+	return fileDescriptor_imp_81275c260ac30f8b, []int{1}
+}
 func (m *ImportedMessage2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ImportedMessage2.Unmarshal(m, b)
 }
@@ -266,10 +272,12 @@ type ImportedExtendable struct {
 	XXX_sizecache                int32  `json:"-"`
 }
 
-func (m *ImportedExtendable) Reset()                    { *m = ImportedExtendable{} }
-func (m *ImportedExtendable) String() string            { return proto.CompactTextString(m) }
-func (*ImportedExtendable) ProtoMessage()               {}
-func (*ImportedExtendable) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+func (m *ImportedExtendable) Reset()         { *m = ImportedExtendable{} }
+func (m *ImportedExtendable) String() string { return proto.CompactTextString(m) }
+func (*ImportedExtendable) ProtoMessage()    {}
+func (*ImportedExtendable) Descriptor() ([]byte, []int) {
+	return fileDescriptor_imp_81275c260ac30f8b, []int{2}
+}
 
 func (m *ImportedExtendable) MarshalJSON() ([]byte, error) {
 	return proto.MarshalMessageSetJSON(&m.XXX_InternalExtensions)
@@ -311,9 +319,9 @@ func init() {
 	proto.RegisterEnum("imp.ImportedMessage_Owner", ImportedMessage_Owner_name, ImportedMessage_Owner_value)
 }
 
-func init() { proto.RegisterFile("imp/imp.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("imp/imp.proto", fileDescriptor_imp_81275c260ac30f8b) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_imp_81275c260ac30f8b = []byte{
 	// 421 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x92, 0x4f, 0x8b, 0xd4, 0x30,
 	0x18, 0xc6, 0x4d, 0xff, 0xec, 0xb4, 0xef, 0xe0, 0x5a, 0x82, 0x4a, 0x99, 0xbd, 0x84, 0x9e, 0xea,

--- a/protoc-gen-go/testdata/imp/imp2.pb.go
+++ b/protoc-gen-go/testdata/imp/imp2.pb.go
@@ -12,6 +12,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type PubliclyImportedEnum int32
 
 const (
@@ -44,7 +50,9 @@ func (x *PubliclyImportedEnum) UnmarshalJSON(data []byte) error {
 	*x = PubliclyImportedEnum(value)
 	return nil
 }
-func (PubliclyImportedEnum) EnumDescriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
+func (PubliclyImportedEnum) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_imp2_dcbceb16a8ff78d7, []int{0}
+}
 
 type PubliclyImportedMessage struct {
 	Field                *int64   `protobuf:"varint,1,opt,name=field" json:"field,omitempty"`
@@ -53,10 +61,12 @@ type PubliclyImportedMessage struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *PubliclyImportedMessage) Reset()                    { *m = PubliclyImportedMessage{} }
-func (m *PubliclyImportedMessage) String() string            { return proto.CompactTextString(m) }
-func (*PubliclyImportedMessage) ProtoMessage()               {}
-func (*PubliclyImportedMessage) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
+func (m *PubliclyImportedMessage) Reset()         { *m = PubliclyImportedMessage{} }
+func (m *PubliclyImportedMessage) String() string { return proto.CompactTextString(m) }
+func (*PubliclyImportedMessage) ProtoMessage()    {}
+func (*PubliclyImportedMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_imp2_dcbceb16a8ff78d7, []int{0}
+}
 func (m *PubliclyImportedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PubliclyImportedMessage.Unmarshal(m, b)
 }
@@ -87,9 +97,9 @@ func init() {
 	proto.RegisterEnum("imp.PubliclyImportedEnum", PubliclyImportedEnum_name, PubliclyImportedEnum_value)
 }
 
-func init() { proto.RegisterFile("imp/imp2.proto", fileDescriptor1) }
+func init() { proto.RegisterFile("imp/imp2.proto", fileDescriptor_imp2_dcbceb16a8ff78d7) }
 
-var fileDescriptor1 = []byte{
+var fileDescriptor_imp2_dcbceb16a8ff78d7 = []byte{
 	// 171 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0xcb, 0xcc, 0x2d, 0xd0,
 	0xcf, 0xcc, 0x2d, 0x30, 0xd2, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0xce, 0xcc, 0x2d, 0x50,

--- a/protoc-gen-go/testdata/imp/imp3.pb.go
+++ b/protoc-gen-go/testdata/imp/imp3.pb.go
@@ -12,6 +12,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type ForeignImportedMessage struct {
 	Tuber                *string  `protobuf:"bytes,1,opt,name=tuber" json:"tuber,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -19,10 +25,12 @@ type ForeignImportedMessage struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ForeignImportedMessage) Reset()                    { *m = ForeignImportedMessage{} }
-func (m *ForeignImportedMessage) String() string            { return proto.CompactTextString(m) }
-func (*ForeignImportedMessage) ProtoMessage()               {}
-func (*ForeignImportedMessage) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
+func (m *ForeignImportedMessage) Reset()         { *m = ForeignImportedMessage{} }
+func (m *ForeignImportedMessage) String() string { return proto.CompactTextString(m) }
+func (*ForeignImportedMessage) ProtoMessage()    {}
+func (*ForeignImportedMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_imp3_dbacc1715de7e782, []int{0}
+}
 func (m *ForeignImportedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForeignImportedMessage.Unmarshal(m, b)
 }
@@ -52,9 +60,9 @@ func init() {
 	proto.RegisterType((*ForeignImportedMessage)(nil), "imp.ForeignImportedMessage")
 }
 
-func init() { proto.RegisterFile("imp/imp3.proto", fileDescriptor2) }
+func init() { proto.RegisterFile("imp/imp3.proto", fileDescriptor_imp3_dbacc1715de7e782) }
 
-var fileDescriptor2 = []byte{
+var fileDescriptor_imp3_dbacc1715de7e782 = []byte{
 	// 137 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0xcb, 0xcc, 0x2d, 0xd0,
 	0xcf, 0xcc, 0x2d, 0x30, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0xce, 0xcc, 0x2d, 0x50,

--- a/protoc-gen-go/testdata/imports/fmt/m.pb.go
+++ b/protoc-gen-go/testdata/imports/fmt/m.pb.go
@@ -27,7 +27,7 @@ type M struct {
 func (m *M) Reset()                    { *m = M{} }
 func (m *M) String() string            { return proto.CompactTextString(m) }
 func (*M) ProtoMessage()               {}
-func (*M) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (*M) Descriptor() ([]byte, []int) { return fileDescriptor_m_867dd34c461422b8, []int{0} }
 func (m *M) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M.Unmarshal(m, b)
 }
@@ -50,9 +50,9 @@ func init() {
 	proto.RegisterType((*M)(nil), "fmt.M")
 }
 
-func init() { proto.RegisterFile("imports/fmt/m.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("imports/fmt/m.proto", fileDescriptor_m_867dd34c461422b8) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_m_867dd34c461422b8 = []byte{
 	// 109 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xce, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x4f, 0xcb, 0x2d, 0xd1, 0xcf, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17,

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -27,7 +27,7 @@ type M1 struct {
 func (m *M1) Reset()                    { *m = M1{} }
 func (m *M1) String() string            { return proto.CompactTextString(m) }
 func (*M1) ProtoMessage()               {}
-func (*M1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (*M1) Descriptor() ([]byte, []int) { return fileDescriptor_m1_4abc85f8d0361bef, []int{0} }
 func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
 }
@@ -50,9 +50,9 @@ func init() {
 	proto.RegisterType((*M1)(nil), "test.a.M1")
 }
 
-func init() { proto.RegisterFile("imports/test_a_1/m1.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("imports/test_a_1/m1.proto", fileDescriptor_m1_4abc85f8d0361bef) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_m1_4abc85f8d0361bef = []byte{
 	// 114 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd4, 0xcf, 0x35, 0xd4,

--- a/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
@@ -12,6 +12,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type M2 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -21,7 +27,7 @@ type M2 struct {
 func (m *M2) Reset()                    { *m = M2{} }
 func (m *M2) String() string            { return proto.CompactTextString(m) }
 func (*M2) ProtoMessage()               {}
-func (*M2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
+func (*M2) Descriptor() ([]byte, []int) { return fileDescriptor_m2_ccd6356c045a9ac3, []int{0} }
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
 }
@@ -44,9 +50,9 @@ func init() {
 	proto.RegisterType((*M2)(nil), "test.a.M2")
 }
 
-func init() { proto.RegisterFile("imports/test_a_1/m2.proto", fileDescriptor1) }
+func init() { proto.RegisterFile("imports/test_a_1/m2.proto", fileDescriptor_m2_ccd6356c045a9ac3) }
 
-var fileDescriptor1 = []byte{
+var fileDescriptor_m2_ccd6356c045a9ac3 = []byte{
 	// 114 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd4, 0xcf, 0x35, 0xd2,

--- a/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
@@ -27,7 +27,7 @@ type M3 struct {
 func (m *M3) Reset()                    { *m = M3{} }
 func (m *M3) String() string            { return proto.CompactTextString(m) }
 func (*M3) ProtoMessage()               {}
-func (*M3) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (*M3) Descriptor() ([]byte, []int) { return fileDescriptor_m3_de310e87d08d4216, []int{0} }
 func (m *M3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M3.Unmarshal(m, b)
 }
@@ -50,9 +50,9 @@ func init() {
 	proto.RegisterType((*M3)(nil), "test.a.M3")
 }
 
-func init() { proto.RegisterFile("imports/test_a_2/m3.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("imports/test_a_2/m3.proto", fileDescriptor_m3_de310e87d08d4216) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_m3_de310e87d08d4216 = []byte{
 	// 114 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd2, 0xcf, 0x35, 0xd6,

--- a/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
@@ -12,6 +12,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type M4 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -21,7 +27,7 @@ type M4 struct {
 func (m *M4) Reset()                    { *m = M4{} }
 func (m *M4) String() string            { return proto.CompactTextString(m) }
 func (*M4) ProtoMessage()               {}
-func (*M4) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
+func (*M4) Descriptor() ([]byte, []int) { return fileDescriptor_m4_da12b386229f3791, []int{0} }
 func (m *M4) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M4.Unmarshal(m, b)
 }
@@ -44,9 +50,9 @@ func init() {
 	proto.RegisterType((*M4)(nil), "test.a.M4")
 }
 
-func init() { proto.RegisterFile("imports/test_a_2/m4.proto", fileDescriptor1) }
+func init() { proto.RegisterFile("imports/test_a_2/m4.proto", fileDescriptor_m4_da12b386229f3791) }
 
-var fileDescriptor1 = []byte{
+var fileDescriptor_m4_da12b386229f3791 = []byte{
 	// 114 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd2, 0xcf, 0x35, 0xd1,

--- a/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
@@ -27,7 +27,7 @@ type M1 struct {
 func (m *M1) Reset()                    { *m = M1{} }
 func (m *M1) String() string            { return proto.CompactTextString(m) }
 func (*M1) ProtoMessage()               {}
-func (*M1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (*M1) Descriptor() ([]byte, []int) { return fileDescriptor_m1_aff127b054aec649, []int{0} }
 func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
 }
@@ -50,9 +50,9 @@ func init() {
 	proto.RegisterType((*M1)(nil), "test.b.part1.M1")
 }
 
-func init() { proto.RegisterFile("imports/test_b_1/m1.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("imports/test_b_1/m1.proto", fileDescriptor_m1_aff127b054aec649) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_m1_aff127b054aec649 = []byte{
 	// 125 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8a, 0x37, 0xd4, 0xcf, 0x35, 0xd4,

--- a/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
@@ -12,6 +12,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type M2 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -21,7 +27,7 @@ type M2 struct {
 func (m *M2) Reset()                    { *m = M2{} }
 func (m *M2) String() string            { return proto.CompactTextString(m) }
 func (*M2) ProtoMessage()               {}
-func (*M2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
+func (*M2) Descriptor() ([]byte, []int) { return fileDescriptor_m2_0c59cab35ba1b0d8, []int{0} }
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
 }
@@ -44,9 +50,9 @@ func init() {
 	proto.RegisterType((*M2)(nil), "test.b.part2.M2")
 }
 
-func init() { proto.RegisterFile("imports/test_b_1/m2.proto", fileDescriptor1) }
+func init() { proto.RegisterFile("imports/test_b_1/m2.proto", fileDescriptor_m2_0c59cab35ba1b0d8) }
 
-var fileDescriptor1 = []byte{
+var fileDescriptor_m2_0c59cab35ba1b0d8 = []byte{
 	// 125 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8a, 0x37, 0xd4, 0xcf, 0x35, 0xd2,

--- a/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
@@ -26,10 +26,12 @@ type A1M1 struct {
 	XXX_sizecache        int32      `json:"-"`
 }
 
-func (m *A1M1) Reset()                    { *m = A1M1{} }
-func (m *A1M1) String() string            { return proto.CompactTextString(m) }
-func (*A1M1) ProtoMessage()               {}
-func (*A1M1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (m *A1M1) Reset()         { *m = A1M1{} }
+func (m *A1M1) String() string { return proto.CompactTextString(m) }
+func (*A1M1) ProtoMessage()    {}
+func (*A1M1) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_import_a1m1_d7f2b5c638a69f6e, []int{0}
+}
 func (m *A1M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M1.Unmarshal(m, b)
 }
@@ -59,9 +61,11 @@ func init() {
 	proto.RegisterType((*A1M1)(nil), "test.A1M1")
 }
 
-func init() { proto.RegisterFile("imports/test_import_a1m1.proto", fileDescriptor0) }
+func init() {
+	proto.RegisterFile("imports/test_import_a1m1.proto", fileDescriptor_test_import_a1m1_d7f2b5c638a69f6e)
+}
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_test_import_a1m1_d7f2b5c638a69f6e = []byte{
 	// 149 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcb, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x87, 0x70, 0xe2, 0x13, 0x0d, 0x73, 0x0d,

--- a/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
@@ -13,6 +13,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type A1M2 struct {
 	F                    *test_a1.M2 `protobuf:"bytes,1,opt,name=f" json:"f,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
@@ -20,10 +26,12 @@ type A1M2 struct {
 	XXX_sizecache        int32       `json:"-"`
 }
 
-func (m *A1M2) Reset()                    { *m = A1M2{} }
-func (m *A1M2) String() string            { return proto.CompactTextString(m) }
-func (*A1M2) ProtoMessage()               {}
-func (*A1M2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
+func (m *A1M2) Reset()         { *m = A1M2{} }
+func (m *A1M2) String() string { return proto.CompactTextString(m) }
+func (*A1M2) ProtoMessage()    {}
+func (*A1M2) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_import_a1m2_9a3281ce9464e116, []int{0}
+}
 func (m *A1M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M2.Unmarshal(m, b)
 }
@@ -53,9 +61,11 @@ func init() {
 	proto.RegisterType((*A1M2)(nil), "test.A1M2")
 }
 
-func init() { proto.RegisterFile("imports/test_import_a1m2.proto", fileDescriptor1) }
+func init() {
+	proto.RegisterFile("imports/test_import_a1m2.proto", fileDescriptor_test_import_a1m2_9a3281ce9464e116)
+}
 
-var fileDescriptor1 = []byte{
+var fileDescriptor_test_import_a1m2_9a3281ce9464e116 = []byte{
 	// 149 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcb, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x87, 0x70, 0xe2, 0x13, 0x0d, 0x73, 0x8d,

--- a/protoc-gen-go/testdata/imports/test_import_all.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_all.pb.go
@@ -19,6 +19,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type All struct {
 	Am1                  *test_a.M1       `protobuf:"bytes,1,opt,name=am1" json:"am1,omitempty"`
 	Am2                  *test_a1.M2      `protobuf:"bytes,2,opt,name=am2" json:"am2,omitempty"`
@@ -32,10 +38,12 @@ type All struct {
 	XXX_sizecache        int32            `json:"-"`
 }
 
-func (m *All) Reset()                    { *m = All{} }
-func (m *All) String() string            { return proto.CompactTextString(m) }
-func (*All) ProtoMessage()               {}
-func (*All) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
+func (m *All) Reset()         { *m = All{} }
+func (m *All) String() string { return proto.CompactTextString(m) }
+func (*All) ProtoMessage()    {}
+func (*All) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_import_all_b41dc4592e4a4f3b, []int{0}
+}
 func (m *All) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_All.Unmarshal(m, b)
 }
@@ -107,9 +115,11 @@ func init() {
 	proto.RegisterType((*All)(nil), "test.All")
 }
 
-func init() { proto.RegisterFile("imports/test_import_all.proto", fileDescriptor2) }
+func init() {
+	proto.RegisterFile("imports/test_import_all.proto", fileDescriptor_test_import_all_b41dc4592e4a4f3b)
+}
 
-var fileDescriptor2 = []byte{
+var fileDescriptor_test_import_all_b41dc4592e4a4f3b = []byte{
 	// 258 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0xd0, 0xb1, 0x4e, 0xc3, 0x30,
 	0x10, 0x06, 0x60, 0x15, 0x97, 0x20, 0x99, 0x05, 0x85, 0xc5, 0x20, 0x90, 0x50, 0x27, 0x96, 0xda,

--- a/protoc-gen-go/testdata/imports/test_import_public.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_public.pb.go
@@ -13,6 +13,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 // M1 from public import imports/test_a_1/m1.proto
 type M1 test_a.M1
 
@@ -33,10 +39,12 @@ type Public struct {
 	XXX_sizecache        int32      `json:"-"`
 }
 
-func (m *Public) Reset()                    { *m = Public{} }
-func (m *Public) String() string            { return proto.CompactTextString(m) }
-func (*Public) ProtoMessage()               {}
-func (*Public) Descriptor() ([]byte, []int) { return fileDescriptor3, []int{0} }
+func (m *Public) Reset()         { *m = Public{} }
+func (m *Public) String() string { return proto.CompactTextString(m) }
+func (*Public) ProtoMessage()    {}
+func (*Public) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_import_public_592f461eca0812f7, []int{0}
+}
 func (m *Public) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Public.Unmarshal(m, b)
 }
@@ -66,9 +74,11 @@ func init() {
 	proto.RegisterType((*Public)(nil), "test.Public")
 }
 
-func init() { proto.RegisterFile("imports/test_import_public.proto", fileDescriptor3) }
+func init() {
+	proto.RegisterFile("imports/test_import_public.proto", fileDescriptor_test_import_public_592f461eca0812f7)
+}
 
-var fileDescriptor3 = []byte{
+var fileDescriptor_test_import_public_592f461eca0812f7 = []byte{
 	// 154 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0xc8, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x87, 0x70, 0xe2, 0x0b, 0x4a, 0x93, 0x72,

--- a/protoc-gen-go/testdata/multi/multi1.pb.go
+++ b/protoc-gen-go/testdata/multi/multi1.pb.go
@@ -30,7 +30,7 @@ type Multi1 struct {
 func (m *Multi1) Reset()                    { *m = Multi1{} }
 func (m *Multi1) String() string            { return proto.CompactTextString(m) }
 func (*Multi1) ProtoMessage()               {}
-func (*Multi1) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (*Multi1) Descriptor() ([]byte, []int) { return fileDescriptor_multi1_08e50c6822e808b8, []int{0} }
 func (m *Multi1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi1.Unmarshal(m, b)
 }
@@ -74,9 +74,9 @@ func init() {
 	proto.RegisterType((*Multi1)(nil), "multitest.Multi1")
 }
 
-func init() { proto.RegisterFile("multi/multi1.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("multi/multi1.proto", fileDescriptor_multi1_08e50c6822e808b8) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_multi1_08e50c6822e808b8 = []byte{
 	// 200 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xca, 0x2d, 0xcd, 0x29,
 	0xc9, 0xd4, 0x07, 0x93, 0x86, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x9c, 0x60, 0x5e, 0x49,

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -12,6 +12,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type Multi2_Color int32
 
 const (
@@ -47,7 +53,9 @@ func (x *Multi2_Color) UnmarshalJSON(data []byte) error {
 	*x = Multi2_Color(value)
 	return nil
 }
-func (Multi2_Color) EnumDescriptor() ([]byte, []int) { return fileDescriptor1, []int{0, 0} }
+func (Multi2_Color) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_multi2_c47490ad66d93e67, []int{0, 0}
+}
 
 type Multi2 struct {
 	RequiredValue        *int32        `protobuf:"varint,1,req,name=required_value,json=requiredValue" json:"required_value,omitempty"`
@@ -60,7 +68,7 @@ type Multi2 struct {
 func (m *Multi2) Reset()                    { *m = Multi2{} }
 func (m *Multi2) String() string            { return proto.CompactTextString(m) }
 func (*Multi2) ProtoMessage()               {}
-func (*Multi2) Descriptor() ([]byte, []int) { return fileDescriptor1, []int{0} }
+func (*Multi2) Descriptor() ([]byte, []int) { return fileDescriptor_multi2_c47490ad66d93e67, []int{0} }
 func (m *Multi2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi2.Unmarshal(m, b)
 }
@@ -98,9 +106,9 @@ func init() {
 	proto.RegisterEnum("multitest.Multi2_Color", Multi2_Color_name, Multi2_Color_value)
 }
 
-func init() { proto.RegisterFile("multi/multi2.proto", fileDescriptor1) }
+func init() { proto.RegisterFile("multi/multi2.proto", fileDescriptor_multi2_c47490ad66d93e67) }
 
-var fileDescriptor1 = []byte{
+var fileDescriptor_multi2_c47490ad66d93e67 = []byte{
 	// 202 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xca, 0x2d, 0xcd, 0x29,
 	0xc9, 0xd4, 0x07, 0x93, 0x46, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x9c, 0x60, 0x5e, 0x49,

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -12,6 +12,12 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+// A compilation error at this line likely means your copy of the
+// proto package needs to be updated.
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
 type Multi3_HatType int32
 
 const (
@@ -44,7 +50,9 @@ func (x *Multi3_HatType) UnmarshalJSON(data []byte) error {
 	*x = Multi3_HatType(value)
 	return nil
 }
-func (Multi3_HatType) EnumDescriptor() ([]byte, []int) { return fileDescriptor2, []int{0, 0} }
+func (Multi3_HatType) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_multi3_d55a72b4628b7875, []int{0, 0}
+}
 
 type Multi3 struct {
 	HatType              *Multi3_HatType `protobuf:"varint,1,opt,name=hat_type,json=hatType,enum=multitest.Multi3_HatType" json:"hat_type,omitempty"`
@@ -56,7 +64,7 @@ type Multi3 struct {
 func (m *Multi3) Reset()                    { *m = Multi3{} }
 func (m *Multi3) String() string            { return proto.CompactTextString(m) }
 func (*Multi3) ProtoMessage()               {}
-func (*Multi3) Descriptor() ([]byte, []int) { return fileDescriptor2, []int{0} }
+func (*Multi3) Descriptor() ([]byte, []int) { return fileDescriptor_multi3_d55a72b4628b7875, []int{0} }
 func (m *Multi3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi3.Unmarshal(m, b)
 }
@@ -87,9 +95,9 @@ func init() {
 	proto.RegisterEnum("multitest.Multi3_HatType", Multi3_HatType_name, Multi3_HatType_value)
 }
 
-func init() { proto.RegisterFile("multi/multi3.proto", fileDescriptor2) }
+func init() { proto.RegisterFile("multi/multi3.proto", fileDescriptor_multi3_d55a72b4628b7875) }
 
-var fileDescriptor2 = []byte{
+var fileDescriptor_multi3_d55a72b4628b7875 = []byte{
 	// 170 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xca, 0x2d, 0xcd, 0x29,
 	0xc9, 0xd4, 0x07, 0x93, 0xc6, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x9c, 0x60, 0x5e, 0x49,

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -56,7 +56,7 @@ func (x *HatType) UnmarshalJSON(data []byte) error {
 	*x = HatType(value)
 	return nil
 }
-func (HatType) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (HatType) EnumDescriptor() ([]byte, []int) { return fileDescriptor_test_4c0531be33cf90ba, []int{0} }
 
 // This enum represents days of the week.
 type Days int32
@@ -94,7 +94,7 @@ func (x *Days) UnmarshalJSON(data []byte) error {
 	*x = Days(value)
 	return nil
 }
-func (Days) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (Days) EnumDescriptor() ([]byte, []int) { return fileDescriptor_test_4c0531be33cf90ba, []int{1} }
 
 type Request_Color int32
 
@@ -131,7 +131,9 @@ func (x *Request_Color) UnmarshalJSON(data []byte) error {
 	*x = Request_Color(value)
 	return nil
 }
-func (Request_Color) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{0, 0} }
+func (Request_Color) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{0, 0}
+}
 
 type Reply_Entry_Game int32
 
@@ -165,7 +167,9 @@ func (x *Reply_Entry_Game) UnmarshalJSON(data []byte) error {
 	*x = Reply_Entry_Game(value)
 	return nil
 }
-func (Reply_Entry_Game) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{1, 0, 0} }
+func (Reply_Entry_Game) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{1, 0, 0}
+}
 
 // This is a message that might be sent somewhere.
 type Request struct {
@@ -191,7 +195,7 @@ type Request struct {
 func (m *Request) Reset()                    { *m = Request{} }
 func (m *Request) String() string            { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()               {}
-func (*Request) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (*Request) Descriptor() ([]byte, []int) { return fileDescriptor_test_4c0531be33cf90ba, []int{0} }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
 }
@@ -284,10 +288,12 @@ type Request_SomeGroup struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Request_SomeGroup) Reset()                    { *m = Request_SomeGroup{} }
-func (m *Request_SomeGroup) String() string            { return proto.CompactTextString(m) }
-func (*Request_SomeGroup) ProtoMessage()               {}
-func (*Request_SomeGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0, 0} }
+func (m *Request_SomeGroup) Reset()         { *m = Request_SomeGroup{} }
+func (m *Request_SomeGroup) String() string { return proto.CompactTextString(m) }
+func (*Request_SomeGroup) ProtoMessage()    {}
+func (*Request_SomeGroup) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{0, 0}
+}
 func (m *Request_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request_SomeGroup.Unmarshal(m, b)
 }
@@ -325,7 +331,7 @@ type Reply struct {
 func (m *Reply) Reset()                    { *m = Reply{} }
 func (m *Reply) String() string            { return proto.CompactTextString(m) }
 func (*Reply) ProtoMessage()               {}
-func (*Reply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (*Reply) Descriptor() ([]byte, []int) { return fileDescriptor_test_4c0531be33cf90ba, []int{1} }
 
 var extRange_Reply = []proto.ExtensionRange{
 	{100, 536870911},
@@ -375,10 +381,12 @@ type Reply_Entry struct {
 	XXX_sizecache                 int32    `json:"-"`
 }
 
-func (m *Reply_Entry) Reset()                    { *m = Reply_Entry{} }
-func (m *Reply_Entry) String() string            { return proto.CompactTextString(m) }
-func (*Reply_Entry) ProtoMessage()               {}
-func (*Reply_Entry) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1, 0} }
+func (m *Reply_Entry) Reset()         { *m = Reply_Entry{} }
+func (m *Reply_Entry) String() string { return proto.CompactTextString(m) }
+func (*Reply_Entry) ProtoMessage()    {}
+func (*Reply_Entry) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{1, 0}
+}
 func (m *Reply_Entry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Reply_Entry.Unmarshal(m, b)
 }
@@ -431,7 +439,7 @@ type OtherBase struct {
 func (m *OtherBase) Reset()                    { *m = OtherBase{} }
 func (m *OtherBase) String() string            { return proto.CompactTextString(m) }
 func (*OtherBase) ProtoMessage()               {}
-func (*OtherBase) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+func (*OtherBase) Descriptor() ([]byte, []int) { return fileDescriptor_test_4c0531be33cf90ba, []int{2} }
 
 var extRange_OtherBase = []proto.ExtensionRange{
 	{100, 536870911},
@@ -471,10 +479,12 @@ type ReplyExtensions struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ReplyExtensions) Reset()                    { *m = ReplyExtensions{} }
-func (m *ReplyExtensions) String() string            { return proto.CompactTextString(m) }
-func (*ReplyExtensions) ProtoMessage()               {}
-func (*ReplyExtensions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+func (m *ReplyExtensions) Reset()         { *m = ReplyExtensions{} }
+func (m *ReplyExtensions) String() string { return proto.CompactTextString(m) }
+func (*ReplyExtensions) ProtoMessage()    {}
+func (*ReplyExtensions) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{3}
+}
 func (m *ReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReplyExtensions.Unmarshal(m, b)
 }
@@ -527,10 +537,12 @@ type OtherReplyExtensions struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *OtherReplyExtensions) Reset()                    { *m = OtherReplyExtensions{} }
-func (m *OtherReplyExtensions) String() string            { return proto.CompactTextString(m) }
-func (*OtherReplyExtensions) ProtoMessage()               {}
-func (*OtherReplyExtensions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+func (m *OtherReplyExtensions) Reset()         { *m = OtherReplyExtensions{} }
+func (m *OtherReplyExtensions) String() string { return proto.CompactTextString(m) }
+func (*OtherReplyExtensions) ProtoMessage()    {}
+func (*OtherReplyExtensions) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{4}
+}
 func (m *OtherReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherReplyExtensions.Unmarshal(m, b)
 }
@@ -566,7 +578,7 @@ type OldReply struct {
 func (m *OldReply) Reset()                    { *m = OldReply{} }
 func (m *OldReply) String() string            { return proto.CompactTextString(m) }
 func (*OldReply) ProtoMessage()               {}
-func (*OldReply) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+func (*OldReply) Descriptor() ([]byte, []int) { return fileDescriptor_test_4c0531be33cf90ba, []int{5} }
 
 func (m *OldReply) MarshalJSON() ([]byte, error) {
 	return proto.MarshalMessageSetJSON(&m.XXX_InternalExtensions)
@@ -624,7 +636,7 @@ type Communique struct {
 func (m *Communique) Reset()                    { *m = Communique{} }
 func (m *Communique) String() string            { return proto.CompactTextString(m) }
 func (*Communique) ProtoMessage()               {}
-func (*Communique) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6} }
+func (*Communique) Descriptor() ([]byte, []int) { return fileDescriptor_test_4c0531be33cf90ba, []int{6} }
 func (m *Communique) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique.Unmarshal(m, b)
 }
@@ -972,10 +984,12 @@ type Communique_SomeGroup struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Communique_SomeGroup) Reset()                    { *m = Communique_SomeGroup{} }
-func (m *Communique_SomeGroup) String() string            { return proto.CompactTextString(m) }
-func (*Communique_SomeGroup) ProtoMessage()               {}
-func (*Communique_SomeGroup) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6, 0} }
+func (m *Communique_SomeGroup) Reset()         { *m = Communique_SomeGroup{} }
+func (m *Communique_SomeGroup) String() string { return proto.CompactTextString(m) }
+func (*Communique_SomeGroup) ProtoMessage()    {}
+func (*Communique_SomeGroup) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{6, 0}
+}
 func (m *Communique_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_SomeGroup.Unmarshal(m, b)
 }
@@ -1007,10 +1021,12 @@ type Communique_Delta struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Communique_Delta) Reset()                    { *m = Communique_Delta{} }
-func (m *Communique_Delta) String() string            { return proto.CompactTextString(m) }
-func (*Communique_Delta) ProtoMessage()               {}
-func (*Communique_Delta) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6, 1} }
+func (m *Communique_Delta) Reset()         { *m = Communique_Delta{} }
+func (m *Communique_Delta) String() string { return proto.CompactTextString(m) }
+func (*Communique_Delta) ProtoMessage()    {}
+func (*Communique_Delta) Descriptor() ([]byte, []int) {
+	return fileDescriptor_test_4c0531be33cf90ba, []int{6, 1}
+}
 func (m *Communique_Delta) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_Delta.Unmarshal(m, b)
 }
@@ -1072,9 +1088,9 @@ func init() {
 	proto.RegisterExtension(E_Donut)
 }
 
-func init() { proto.RegisterFile("my_test/test.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("my_test/test.proto", fileDescriptor_test_4c0531be33cf90ba) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_test_4c0531be33cf90ba = []byte{
 	// 1035 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x55, 0xdb, 0x6e, 0xdb, 0x46,
 	0x13, 0xd6, 0x92, 0xa2, 0x0e, 0x23, 0xc5, 0xe6, 0xbf, 0x30, 0x6c, 0x42, 0x3f, 0x12, 0xb3, 0x6a,

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -43,7 +43,9 @@ var Request_Flavour_value = map[string]int32{
 func (x Request_Flavour) String() string {
 	return proto.EnumName(Request_Flavour_name, int32(x))
 }
-func (Request_Flavour) EnumDescriptor() ([]byte, []int) { return fileDescriptor0, []int{0, 0} }
+func (Request_Flavour) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_proto3_a752e09251f17e01, []int{0, 0}
+}
 
 type Request struct {
 	Name                 string          `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
@@ -59,7 +61,7 @@ type Request struct {
 func (m *Request) Reset()                    { *m = Request{} }
 func (m *Request) String() string            { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()               {}
-func (*Request) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
+func (*Request) Descriptor() ([]byte, []int) { return fileDescriptor_proto3_a752e09251f17e01, []int{0} }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
 }
@@ -124,7 +126,7 @@ type Book struct {
 func (m *Book) Reset()                    { *m = Book{} }
 func (m *Book) String() string            { return proto.CompactTextString(m) }
 func (*Book) ProtoMessage()               {}
-func (*Book) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+func (*Book) Descriptor() ([]byte, []int) { return fileDescriptor_proto3_a752e09251f17e01, []int{1} }
 func (m *Book) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Book.Unmarshal(m, b)
 }
@@ -163,9 +165,9 @@ func init() {
 	proto.RegisterEnum("proto3.Request_Flavour", Request_Flavour_name, Request_Flavour_value)
 }
 
-func init() { proto.RegisterFile("proto3/proto3.proto", fileDescriptor0) }
+func init() { proto.RegisterFile("proto3/proto3.proto", fileDescriptor_proto3_a752e09251f17e01) }
 
-var fileDescriptor0 = []byte{
+var fileDescriptor_proto3_a752e09251f17e01 = []byte{
 	// 306 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x3c, 0x90, 0xcf, 0x4e, 0xf2, 0x40,
 	0x14, 0xc5, 0x99, 0xfe, 0xf9, 0x80, 0xfb, 0xa1, 0x19, 0xaf, 0x26, 0x8e, 0x1b, 0x33, 0x61, 0xd5,


### PR DESCRIPTION
Remove generate code dependencies on the order in which source files were
provided to the compiler. In other words, "protoc a.proto b.proto" produces
the same output as "protoc b.proto a.proto".

- Include the proto package version assertion in all files.

- Use the source file name and contents to generate unique var names for
  file descriptors, rather than the file index. In other words,
  "fileDescriptor_imp_81275c260ac30f8b" rather than "fileDescriptor0".

Makes the generated code more stable in the face of unrelated changes
(i.e., adding a new file to a package won't cause generated code for
other files in irrelevant ways), as well as trivial changes in the
protoc command line.

Removes the requirement that all files in a package be compiled at
the same time. Compiling each file individually will produce the same
results as compiling all at once.