### PR TITLE
protoc-gen-go: add paths=source_relative option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,48 @@ parameter set to the directory you want to output the Go code to.
 The generated files will be suffixed .pb.go.  See the Test code below
 for an example using such a file.
 
+## Packages and input paths ##
+
+The protocol buffer language has a concept of "packages" which does not
+correspond well to the Go notion of packages. In generated Go code,
+each source `.proto` file is associated with a single Go package. The
+name and import path for this package is specified with the `go_package`
+proto option:
+
+	option go_package = "github.com/golang/protobuf/ptypes/any";
+
+The protocol buffer compiler will attempt to derive a package name and
+import path if a `go_package` option is not present, but it is
+best to always specify one explicitly.
+
+There is a one-to-one relationship between source `.proto` files and
+generated `.pb.go` files, but any number of `.pb.go` files may be
+contained in the same Go package.
+
+The output name of a generated file is produced by replacing the
+`.proto` suffix with `.pb.go` (e.g., `foo.proto` produces `foo.pb.go`).
+However, the output directory is selected in one of two ways.  Let
+us say we have `inputs/x.proto` with a `go_package` option of
+`github.com/golang/protobuf/p`. The corresponding output file may
+be:
+
+- Relative to the import path:
+
+	protoc --go_out=. inputs/x.proto
+	# writes ./github.com/golang/protobuf/p/x.pb.go
+
+  (This can work well with `--go_out=$GOPATH`.)
+
+- Relative to the input file:
+
+	protoc --go_out=paths=source_relative:. inputs/x.proto
+	# generate ./inputs/x.pb.go
+
+## Generated code ##
 
 The package comment for the proto library contains text describing
 the interface provided in Go for protocol buffers. Here is an edited
 version.
-
-==========
 
 The proto package converts data structures to and from the
 wire format of protocol buffers.  It works in concert with the
@@ -170,21 +206,24 @@ To create and play with a Test object from the example package,
 To pass extra parameters to the plugin, use a comma-separated
 parameter list separated from the output directory by a colon:
 
-
 	protoc --go_out=plugins=grpc,import_path=mypackage:. *.proto
 
-
-- `import_prefix=xxx` - a prefix that is added onto the beginning of
-  all imports. Useful for things like generating protos in a
-  subdirectory, or regenerating vendored protobufs in-place.
-- `import_path=foo/bar` - used as the package if no input files
-  declare `go_package`. If it contains slashes, everything up to the
-  rightmost slash is ignored.
+- `paths=(import | source_relative)` - specifies how the paths of
+  generated files are structured. See the "Packages and imports paths"
+  section above.
 - `plugins=plugin1+plugin2` - specifies the list of sub-plugins to
   load. The only plugin in this repo is `grpc`.
 - `Mfoo/bar.proto=quux/shme` - declares that foo/bar.proto is
   associated with Go package quux/shme.  This is subject to the
   import_prefix parameter.
+
+The following parameters are deprecated and should not be used:
+
+- `import_prefix=xxx` - a prefix that is added onto the beginning of
+  all imports.
+- `import_path=foo/bar` - used as the package if no input files
+  declare `go_package`. If it contains slashes, everything up to the
+  rightmost slash is ignored.
 
 ## gRPC Support ##
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ parameter list separated from the output directory by a colon:
 
 - `paths=(import | source_relative)` - specifies how the paths of
   generated files are structured. See the "Packages and imports paths"
-  section above.
+  section above. The default is `import`.
 - `plugins=plugin1+plugin2` - specifies the list of sub-plugins to
   load. The only plugin in this repo is `grpc`.
 - `Mfoo/bar.proto=quux/shme` - declares that foo/bar.proto is

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -36,7 +36,7 @@
 */
 package generator
 
-import 
+import (
 	"bufio"
 	"bytes"
 	"compress/gzip"

--- a/protoc-gen-go/golden_test.go
+++ b/protoc-gen-go/golden_test.go
@@ -51,13 +51,12 @@ func TestGolden(t *testing.T) {
 
 	// Compile each package, using this binary as protoc-gen-go.
 	for _, sources := range packages {
-		args := []string{"-Itestdata", "--go_out=plugins=grpc:" + workdir}
+		args := []string{"-Itestdata", "--go_out=plugins=grpc,paths=source_relative:" + workdir}
 		args = append(args, sources...)
 		protoc(t, args)
 	}
 
 	// Compare each generated file to the golden version.
-	relRoot := filepath.Join(workdir, "github.com/golang/protobuf/protoc-gen-go/testdata")
 	filepath.Walk(workdir, func(genPath string, info os.FileInfo, _ error) error {
 		if info.IsDir() {
 			return nil
@@ -65,13 +64,13 @@ func TestGolden(t *testing.T) {
 
 		// For each generated file, figure out the path to the corresponding
 		// golden file in the testdata directory.
-		relPath, err := filepath.Rel(relRoot, genPath)
+		relPath, err := filepath.Rel(workdir, genPath)
 		if err != nil {
-			t.Errorf("filepath.Rel(%q, %q): %v", relRoot, genPath, err)
+			t.Errorf("filepath.Rel(%q, %q): %v", workdir, genPath, err)
 			return nil
 		}
 		if filepath.SplitList(relPath)[0] == ".." {
-			t.Errorf("generated file %q is not relative to %q", genPath, relRoot)
+			t.Errorf("generated file %q is not relative to %q", genPath, workdir)
 		}
 		goldenPath := filepath.Join("testdata", relPath)
 
@@ -179,6 +178,19 @@ func TestParameters(t *testing.T) {
 		wantImportsA: map[string]bool{
 			// import_prefix applies after M.
 			"prefixpackage/gamma": true,
+		},
+	}, {
+		parameters: "paths=source_relative",
+		wantFiles: map[string]bool{
+			"alpha/a.pb.go": true,
+			"beta/b.pb.go":  true,
+		},
+	}, {
+		parameters: "paths=source_relative,import_prefix=prefix",
+		wantFiles: map[string]bool{
+			// import_prefix doesn't affect filenames.
+			"alpha/a.pb.go": true,
+			"beta/b.pb.go":  true,
 		},
 	}} {
 		name := test.parameters


### PR DESCRIPTION
When --go_out=paths=source_relative:., output filenames are always
derived from the input filenames. For example, the output file
for a/b/c.proto will always be a/b/c.pb.go, regardless of the
presence or absence of a go_package option in the input file.

Fixes #515.