### PR TITLE
protoc-gen-go: fix test

### DIFF
--- a/protoc-gen-go/generator/name_test.go
+++ b/protoc-gen-go/generator/name_test.go
@@ -59,9 +59,10 @@ func TestCamelCase(t *testing.T) {
 
 func TestGoPackageOption(t *testing.T) {
 	tests := []struct {
-		in           string
-		impPath, pkg string
-		ok           bool
+		in      string
+		impPath GoImportPath
+		pkg     GoPackageName
+		ok      bool
 	}{
 		{"", "", "", false},
 		{"foo", "", "foo", true},


### PR DESCRIPTION
Broken by addition of GoImportPath/GoPackageName.