### PR TITLE
protoc-gen-go: use standard library context (requires Go1.9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: go
 go:
-- 1.6.x
-- 1.7.x
-- 1.8.x
 - 1.9.x
 - 1.10.x
 - 1.x

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Google's data interchange format.
 Copyright 2010 The Go Authors.
 https://github.com/golang/protobuf
 
-This package and the code it generates requires at least Go 1.6.
+This package and the code it generates requires at least Go 1.9.
 
 This software implements Go bindings for protocol buffers.  For
 information about protocol buffers themselves, see

--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -53,7 +53,7 @@ const generatedCodeVersion = 4
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.
 const (
-	contextPkgPath = "golang.org/x/net/context"
+	contextPkgPath = "context"
 	grpcPkgPath    = "google.golang.org/grpc"
 )
 

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -12,7 +12,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
This change effectively makes Go1.9 the minimum required version of Go
when using gRPC since type aliases are needed to truly unify context.
Even though this only affects those who use gRPC, there are other reasons we
need Go1.9 (such as type aliases for import public).

Fixes #537