### PR TITLE
golden_test: normalize path separators for Windows

### DIFF
--- a/protoc-gen-go/golden_test.go
+++ b/protoc-gen-go/golden_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -249,11 +250,17 @@ func TestParameters(t *testing.T) {
 			return nil
 		})
 		for got := range gotFiles {
+			if runtime.GOOS == "windows" {
+				got = filepath.ToSlash(got)
+			}
 			if !test.wantFiles[got] {
 				t.Errorf("unexpected output file: %v", got)
 			}
 		}
 		for want := range test.wantFiles {
+			if runtime.GOOS == "windows" {
+				want = filepath.FromSlash(want)
+			}
 			if !gotFiles[want] {
 				t.Errorf("missing output file:    %v", want)
 			}


### PR DESCRIPTION
On windows, the wantFiles in TestParameters will never match the
files discovered when doing filepath.Walk, because of the difference
in filepath separators.  For windows, just use filepath.To/FromSlash
to convert before comparing to the set of test cases.