### PR TITLE
protoc-gen-go: statically calculate size of oneof wiretags

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2428,58 +2428,49 @@ func (g *Generator) generateMessage(message *Descriptor) {
 				}
 				g.P("case *", oneofTypeName[field], ":")
 				val := "x." + fieldNames[field]
-				var wire, varint, fixed string
+				var varint, fixed string
 				switch *field.Type {
 				case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
-					wire = "WireFixed64"
 					fixed = "8"
 				case descriptor.FieldDescriptorProto_TYPE_FLOAT:
-					wire = "WireFixed32"
 					fixed = "4"
 				case descriptor.FieldDescriptorProto_TYPE_INT64,
 					descriptor.FieldDescriptorProto_TYPE_UINT64,
 					descriptor.FieldDescriptorProto_TYPE_INT32,
 					descriptor.FieldDescriptorProto_TYPE_UINT32,
 					descriptor.FieldDescriptorProto_TYPE_ENUM:
-					wire = "WireVarint"
 					varint = val
 				case descriptor.FieldDescriptorProto_TYPE_FIXED64,
 					descriptor.FieldDescriptorProto_TYPE_SFIXED64:
-					wire = "WireFixed64"
 					fixed = "8"
 				case descriptor.FieldDescriptorProto_TYPE_FIXED32,
 					descriptor.FieldDescriptorProto_TYPE_SFIXED32:
-					wire = "WireFixed32"
 					fixed = "4"
 				case descriptor.FieldDescriptorProto_TYPE_BOOL:
-					wire = "WireVarint"
 					fixed = "1"
 				case descriptor.FieldDescriptorProto_TYPE_STRING:
-					wire = "WireBytes"
 					fixed = "len(" + val + ")"
 					varint = fixed
 				case descriptor.FieldDescriptorProto_TYPE_GROUP:
-					wire = "WireStartGroup"
 					fixed = g.Pkg["proto"] + ".Size(" + val + ")"
 				case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-					wire = "WireBytes"
 					g.P("s := ", g.Pkg["proto"], ".Size(", val, ")")
 					fixed = "s"
 					varint = fixed
 				case descriptor.FieldDescriptorProto_TYPE_BYTES:
-					wire = "WireBytes"
 					fixed = "len(" + val + ")"
 					varint = fixed
 				case descriptor.FieldDescriptorProto_TYPE_SINT32:
-					wire = "WireVarint"
 					varint = "(uint32(" + val + ") << 1) ^ uint32((int32(" + val + ") >> 31))"
 				case descriptor.FieldDescriptorProto_TYPE_SINT64:
-					wire = "WireVarint"
 					varint = "uint64(" + val + " << 1) ^ uint64((int64(" + val + ") >> 63))"
 				default:
 					g.Fail("unhandled oneof field type ", field.Type.String())
 				}
-				g.P("n += ", g.Pkg["proto"], ".SizeVarint(", field.Number, "<<3|", g.Pkg["proto"], ".", wire, ")")
+				// Tag and wire varint is known statically,
+				// so don't generate code for that part of the size computation.
+				tagAndWireSize := proto.SizeVarint(uint64(*field.Number << 3)) // wire doesn't affect varint size
+				g.P("n += ", tagAndWireSize, " // tag and wire")
 				if varint != "" {
 					g.P("n += ", g.Pkg["proto"], ".SizeVarint(uint64(", varint, "))")
 				}
@@ -2487,7 +2478,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 					g.P("n += ", fixed)
 				}
 				if *field.Type == descriptor.FieldDescriptorProto_TYPE_GROUP {
-					g.P("n += ", g.Pkg["proto"], ".SizeVarint(", field.Number, "<<3|", g.Pkg["proto"], ".WireEndGroup)")
+					g.P("n += ", tagAndWireSize, " // tag and wire")
 				}
 			}
 			g.P("case nil:")

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -511,7 +511,7 @@ type Communique_Delta_ struct {
 	Delta int32 `protobuf:"zigzag32,12,opt,name=delta,oneof"`
 }
 type Communique_Msg struct {
-	Msg *Reply `protobuf:"bytes,13,opt,name=msg,oneof"`
+	Msg *Reply `protobuf:"bytes,16,opt,name=msg,oneof"`
 }
 type Communique_Somegroup struct {
 	Somegroup *Communique_SomeGroup `protobuf:"group,14,opt,name=SomeGroup,json=somegroup,oneof"`
@@ -661,7 +661,7 @@ func _Communique_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 		b.EncodeVarint(12<<3 | proto.WireVarint)
 		b.EncodeZigzag32(uint64(x.Delta))
 	case *Communique_Msg:
-		b.EncodeVarint(13<<3 | proto.WireBytes)
+		b.EncodeVarint(16<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Msg); err != nil {
 			return err
 		}
@@ -737,7 +737,7 @@ func _Communique_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buf
 		x, err := b.DecodeZigzag32()
 		m.Union = &Communique_Delta_{int32(x)}
 		return true, err
-	case 13: // union.msg
+	case 16: // union.msg
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -763,40 +763,40 @@ func _Communique_OneofSizer(msg proto.Message) (n int) {
 	// union
 	switch x := m.Union.(type) {
 	case *Communique_Number:
-		n += proto.SizeVarint(5<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(x.Number))
 	case *Communique_Name:
-		n += proto.SizeVarint(6<<3 | proto.WireBytes)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(len(x.Name)))
 		n += len(x.Name)
 	case *Communique_Data:
-		n += proto.SizeVarint(7<<3 | proto.WireBytes)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(len(x.Data)))
 		n += len(x.Data)
 	case *Communique_TempC:
-		n += proto.SizeVarint(8<<3 | proto.WireFixed64)
+		n += 1 // tag and wire
 		n += 8
 	case *Communique_Height:
-		n += proto.SizeVarint(9<<3 | proto.WireFixed32)
+		n += 1 // tag and wire
 		n += 4
 	case *Communique_Today:
-		n += proto.SizeVarint(10<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(x.Today))
 	case *Communique_Maybe:
-		n += proto.SizeVarint(11<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += 1
 	case *Communique_Delta_:
-		n += proto.SizeVarint(12<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64((uint32(x.Delta) << 1) ^ uint32((int32(x.Delta) >> 31))))
 	case *Communique_Msg:
 		s := proto.Size(x.Msg)
-		n += proto.SizeVarint(13<<3 | proto.WireBytes)
+		n += 2 // tag and wire
 		n += proto.SizeVarint(uint64(s))
 		n += s
 	case *Communique_Somegroup:
-		n += proto.SizeVarint(14<<3 | proto.WireStartGroup)
+		n += 1 // tag and wire
 		n += proto.Size(x.Somegroup)
-		n += proto.SizeVarint(14<<3 | proto.WireEndGroup)
+		n += 1 // tag and wire
 	case nil:
 	default:
 		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))

--- a/protoc-gen-go/testdata/my_test/test.pb.go.golden
+++ b/protoc-gen-go/testdata/my_test/test.pb.go.golden
@@ -511,7 +511,7 @@ type Communique_Delta_ struct {
 	Delta int32 `protobuf:"zigzag32,12,opt,name=delta,oneof"`
 }
 type Communique_Msg struct {
-	Msg *Reply `protobuf:"bytes,13,opt,name=msg,oneof"`
+	Msg *Reply `protobuf:"bytes,16,opt,name=msg,oneof"`
 }
 type Communique_Somegroup struct {
 	Somegroup *Communique_SomeGroup `protobuf:"group,14,opt,name=SomeGroup,json=somegroup,oneof"`
@@ -661,7 +661,7 @@ func _Communique_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
 		b.EncodeVarint(12<<3 | proto.WireVarint)
 		b.EncodeZigzag32(uint64(x.Delta))
 	case *Communique_Msg:
-		b.EncodeVarint(13<<3 | proto.WireBytes)
+		b.EncodeVarint(16<<3 | proto.WireBytes)
 		if err := b.EncodeMessage(x.Msg); err != nil {
 			return err
 		}
@@ -737,7 +737,7 @@ func _Communique_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buf
 		x, err := b.DecodeZigzag32()
 		m.Union = &Communique_Delta_{int32(x)}
 		return true, err
-	case 13: // union.msg
+	case 16: // union.msg
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
@@ -763,40 +763,40 @@ func _Communique_OneofSizer(msg proto.Message) (n int) {
 	// union
 	switch x := m.Union.(type) {
 	case *Communique_Number:
-		n += proto.SizeVarint(5<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(x.Number))
 	case *Communique_Name:
-		n += proto.SizeVarint(6<<3 | proto.WireBytes)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(len(x.Name)))
 		n += len(x.Name)
 	case *Communique_Data:
-		n += proto.SizeVarint(7<<3 | proto.WireBytes)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(len(x.Data)))
 		n += len(x.Data)
 	case *Communique_TempC:
-		n += proto.SizeVarint(8<<3 | proto.WireFixed64)
+		n += 1 // tag and wire
 		n += 8
 	case *Communique_Height:
-		n += proto.SizeVarint(9<<3 | proto.WireFixed32)
+		n += 1 // tag and wire
 		n += 4
 	case *Communique_Today:
-		n += proto.SizeVarint(10<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64(x.Today))
 	case *Communique_Maybe:
-		n += proto.SizeVarint(11<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += 1
 	case *Communique_Delta_:
-		n += proto.SizeVarint(12<<3 | proto.WireVarint)
+		n += 1 // tag and wire
 		n += proto.SizeVarint(uint64((uint32(x.Delta) << 1) ^ uint32((int32(x.Delta) >> 31))))
 	case *Communique_Msg:
 		s := proto.Size(x.Msg)
-		n += proto.SizeVarint(13<<3 | proto.WireBytes)
+		n += 2 // tag and wire
 		n += proto.SizeVarint(uint64(s))
 		n += s
 	case *Communique_Somegroup:
-		n += proto.SizeVarint(14<<3 | proto.WireStartGroup)
+		n += 1 // tag and wire
 		n += proto.Size(x.Somegroup)
-		n += proto.SizeVarint(14<<3 | proto.WireEndGroup)
+		n += 1 // tag and wire
 	case nil:
 	default:
 		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))

--- a/protoc-gen-go/testdata/my_test/test.proto
+++ b/protoc-gen-go/testdata/my_test/test.proto
@@ -145,7 +145,7 @@ message Communique {
     Days today = 10;
     bool maybe = 11;
     sint32 delta = 12;  // name will conflict with Delta below
-    Reply msg = 13;
+    Reply msg = 16;  // requires two bytes to encode field tag
     group SomeGroup = 14 {
       optional string member = 15;
     }


### PR DESCRIPTION
There's no need for oneof sizers to compute the size of the tag/wire
varint, since it can be computed at proto compile time instead (and it
is typically a small number like 1 or 2).