### PR TITLE
descriptor: fix example name

### DIFF
--- a/descriptor/descriptor_test.go
+++ b/descriptor/descriptor_test.go
@@ -20,7 +20,7 @@ func TestMessage(t *testing.T) {
 	}
 }
 
-func Example_Options() {
+func Example_options() {
 	var msg *tpb.MyMessageSet
 	_, md := descriptor.ForMessage(msg)
 	if md.GetOptions().GetMessageSetWireFormat() {


### PR DESCRIPTION
Example_Options is an example on the Options type or function.
Example_options is an example on the package with a suffix of "options".