### PR TITLE
protoc-gen-go: use keyed ExtensionRange literals

### DIFF
--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -739,7 +739,7 @@ func (*Real) Descriptor() ([]byte, []int) {
 }
 
 var extRange_Real = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*Real) ExtensionRangeArray() []proto.ExtensionRange {
@@ -786,7 +786,7 @@ func (*Complex) Descriptor() ([]byte, []int) {
 }
 
 var extRange_Complex = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*Complex) ExtensionRangeArray() []proto.ExtensionRange {

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -1752,7 +1752,7 @@ func (*OtherMessage) Descriptor() ([]byte, []int) {
 }
 
 var extRange_OtherMessage = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*OtherMessage) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1870,7 +1870,7 @@ func (*MyMessage) Descriptor() ([]byte, []int) {
 }
 
 var extRange_MyMessage = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*MyMessage) ExtensionRangeArray() []proto.ExtensionRange {
@@ -2158,7 +2158,7 @@ func (*DefaultsMessage) Descriptor() ([]byte, []int) {
 }
 
 var extRange_DefaultsMessage = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*DefaultsMessage) ExtensionRangeArray() []proto.ExtensionRange {
@@ -2204,7 +2204,7 @@ func (m *MyMessageSet) UnmarshalJSON(buf []byte) error {
 }
 
 var extRange_MyMessageSet = []proto.ExtensionRange{
-	{100, 2147483646},
+	{Start: 100, End: 2147483646},
 }
 
 func (*MyMessageSet) ExtensionRangeArray() []proto.ExtensionRange {

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -729,7 +729,7 @@ func (*ExtensionRangeOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_ExtensionRangeOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*ExtensionRangeOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1353,7 +1353,7 @@ func (*FileOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_FileOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*FileOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1588,7 +1588,7 @@ func (*MessageOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_MessageOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*MessageOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1727,7 +1727,7 @@ func (*FieldOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_FieldOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*FieldOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1823,7 +1823,7 @@ func (*OneofOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_OneofOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*OneofOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1879,7 +1879,7 @@ func (*EnumOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_EnumOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*EnumOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -1948,7 +1948,7 @@ func (*EnumValueOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_EnumValueOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*EnumValueOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -2010,7 +2010,7 @@ func (*ServiceOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_ServiceOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*ServiceOptions) ExtensionRangeArray() []proto.ExtensionRange {
@@ -2073,7 +2073,7 @@ func (*MethodOptions) Descriptor() ([]byte, []int) {
 }
 
 var extRange_MethodOptions = []proto.ExtensionRange{
-	{1000, 536870911},
+	{Start: 1000, End: 536870911},
 }
 
 func (*MethodOptions) ExtensionRangeArray() []proto.ExtensionRange {

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2080,7 +2080,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		g.In()
 		for _, r := range message.ExtensionRange {
 			end := fmt.Sprint(*r.End - 1) // make range inclusive on both ends
-			g.P("{", r.Start, ", ", end, "},")
+			g.P("{Start: ", r.Start, ", End: ", end, "},")
 		}
 		g.Out()
 		g.P("}")

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -34,8 +34,8 @@ func (*BaseMessage) Descriptor() ([]byte, []int) {
 }
 
 var extRange_BaseMessage = []proto.ExtensionRange{
-	{4, 9},
-	{16, 536870911},
+	{Start: 4, End: 9},
+	{Start: 16, End: 536870911},
 }
 
 func (*BaseMessage) ExtensionRangeArray() []proto.ExtensionRange {
@@ -89,7 +89,7 @@ func (m *OldStyleMessage) UnmarshalJSON(buf []byte) error {
 }
 
 var extRange_OldStyleMessage = []proto.ExtensionRange{
-	{100, 2147483646},
+	{Start: 100, End: 2147483646},
 }
 
 func (*OldStyleMessage) ExtensionRangeArray() []proto.ExtensionRange {

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -82,7 +82,7 @@ func (*LoudMessage) Descriptor() ([]byte, []int) {
 }
 
 var extRange_LoudMessage = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*LoudMessage) ExtensionRangeArray() []proto.ExtensionRange {

--- a/protoc-gen-go/testdata/imp/imp.pb.go
+++ b/protoc-gen-go/testdata/imp/imp.pb.go
@@ -144,7 +144,7 @@ func (*ImportedMessage) Descriptor() ([]byte, []int) {
 }
 
 var extRange_ImportedMessage = []proto.ExtensionRange{
-	{90, 100},
+	{Start: 90, End: 100},
 }
 
 func (*ImportedMessage) ExtensionRangeArray() []proto.ExtensionRange {
@@ -350,7 +350,7 @@ func (m *ImportedExtendable) UnmarshalJSON(buf []byte) error {
 }
 
 var extRange_ImportedExtendable = []proto.ExtensionRange{
-	{100, 2147483646},
+	{Start: 100, End: 2147483646},
 }
 
 func (*ImportedExtendable) ExtensionRangeArray() []proto.ExtensionRange {

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -342,7 +342,7 @@ func (*Reply) Descriptor() ([]byte, []int) {
 }
 
 var extRange_Reply = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*Reply) ExtensionRangeArray() []proto.ExtensionRange {
@@ -452,7 +452,7 @@ func (*OtherBase) Descriptor() ([]byte, []int) {
 }
 
 var extRange_OtherBase = []proto.ExtensionRange{
-	{100, 536870911},
+	{Start: 100, End: 536870911},
 }
 
 func (*OtherBase) ExtensionRangeArray() []proto.ExtensionRange {
@@ -600,7 +600,7 @@ func (m *OldReply) UnmarshalJSON(buf []byte) error {
 }
 
 var extRange_OldReply = []proto.ExtensionRange{
-	{100, 2147483646},
+	{Start: 100, End: 2147483646},
 }
 
 func (*OldReply) ExtensionRangeArray() []proto.ExtensionRange {


### PR DESCRIPTION
The ExtensionRange struct isn't going to change, but do so silences go vet.

Fixes #214