### PR TITLE
protoc-gen-go: Don't rely on local package name for mset name hack.

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2782,10 +2782,15 @@ func (g *Generator) generateExtension(ext *ExtensionDescriptor) {
 	typeName := ext.TypeName()
 
 	// Special case for proto2 message sets: If this extension is extending
-	// proto2_bridge.MessageSet, and its final name component is "message_set_extension",
+	// proto2.bridge.MessageSet, and its final name component is "message_set_extension",
 	// then drop that last component.
+	//
+	// TODO: This should be implemented in the text formatter rather than the generator.
+	// In addition, the situation for when to apply this special case is implemented
+	// differently in other languages:
+	// https://github.com/google/protobuf/blob/aff10976/src/google/protobuf/text_format.cc#L1560
 	mset := false
-	if extendedType == "*proto2_bridge.MessageSet" && typeName[len(typeName)-1] == "message_set_extension" {
+	if extDesc.GetOptions().GetMessageSetWireFormat() && typeName[len(typeName)-1] == "message_set_extension" {
 		typeName = typeName[:len(typeName)-1]
 		mset = true
 	}

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -292,7 +292,7 @@ var E_OldStyleParcel_MessageSetExtension = &proto.ExtensionDesc{
 	ExtendedType:  (*extension_base.OldStyleMessage)(nil),
 	ExtensionType: (*OldStyleParcel)(nil),
 	Field:         2001,
-	Name:          "extension_user.OldStyleParcel.message_set_extension",
+	Name:          "extension_user.OldStyleParcel",
 	Tag:           "bytes,2001,opt,name=message_set_extension,json=messageSetExtension",
 	Filename:      "extension_user/extension_user.proto",
 }
@@ -348,6 +348,7 @@ func init() {
 	proto.RegisterType((*LoginMessage)(nil), "extension_user.LoginMessage")
 	proto.RegisterType((*Detail)(nil), "extension_user.Detail")
 	proto.RegisterType((*Announcement)(nil), "extension_user.Announcement")
+	proto.RegisterMessageSetType((*OldStyleParcel)(nil), 2001, "extension_user.OldStyleParcel")
 	proto.RegisterType((*OldStyleParcel)(nil), "extension_user.OldStyleParcel")
 	proto.RegisterExtension(E_LoudMessage_Volume)
 	proto.RegisterExtension(E_LoginMessage_UserMessage)


### PR DESCRIPTION
The generator includes a hack for generating the name of fields which
extend proto2.bridge.MessageSet. (The ultimate motivation appears to
be compatibility with proto1 text formats.) Apply this hack based
on whether the message being extended defines the message_set_wire_format
option, not on the local name of that message type.