### PR TITLE
proto: do not allow unknown fields to satisfy required field bit

### DIFF
--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -166,20 +166,21 @@ func (u *unmarshalInfo) unmarshal(m pointer, b []byte) error {
 		} else {
 			f = u.sparse[tag]
 		}
-		reqMask |= f.reqMask
 		if fn := f.unmarshal; fn != nil {
 			var err error
 			b, err = fn(b, m.offset(f.field), wire)
 			if err == nil {
+				reqMask |= f.reqMask
 				continue
 			}
 			if r, ok := err.(*RequiredNotSetError); ok {
 				// Remember this error, but keep parsing. We need to produce
 				// a full parse even if a required field is missing.
 				rnse = r
+				reqMask |= f.reqMask
 				continue
 			}
-			if err == nil || err != errInternalBadWireType {
+			if err != errInternalBadWireType {
 				return err
 			}
 			// Fragments with bad wire type are treated as unknown fields.


### PR DESCRIPTION
A prior changed (see #511) allows Unmarshal to treat fields with
unknown wire types with known tags as unknown fields.
When doing so, we must be careful not to set the required field bit.

For example, suppose we have:
    message Foo { require fixed32 my_field = 1; }

Then parsing a message with a field of type varint and tag 1 should
not satisfy the required that Foo.my_field be set.