### PR TITLE
Fix minor godoc typos in any package

### DIFF
--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -52,7 +52,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -62,7 +62,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)
@@ -80,7 +80,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 //
 //
 // JSON
-// ====
+//
 // The JSON representation of an `Any` value uses the regular
 // representation of the deserialized, embedded message, with an
 // additional field `@type` which contains the type URL. Example:

--- a/ptypes/any/any.proto
+++ b/ptypes/any/any.proto
@@ -64,7 +64,7 @@ option objc_class_prefix = "GPB";
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -74,7 +74,7 @@ option objc_class_prefix = "GPB";
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)
@@ -92,7 +92,7 @@ option objc_class_prefix = "GPB";
 //
 //
 // JSON
-// ====
+//
 // The JSON representation of an `Any` value uses the regular
 // representation of the deserialized, embedded message, with an
 // additional field `@type` which contains the type URL. Example:


### PR DESCRIPTION
An extra space was causing Examples 3 and 4 to render in Example 2's code block. This commit fixes those minor typos.

Also removing the `====` denoting the JSON section will allow godoc to render a heading here.

<details><summary>Before - click to expand</summary><p>
<img width="711" alt="screen shot 2018-03-28 at 16 44 55" src="https://user-images.githubusercontent.com/83862/38040439-6fbe53f6-32a7-11e8-8fc6-e49b1fdcffd8.png">
</p></details>

<details><summary>After - click to expand</summary><p>
<img width="713" alt="screen shot 2018-03-28 at 16 45 12" src="https://user-images.githubusercontent.com/83862/38040452-76d38576-32a7-11e8-8956-e4ceb6086876.png">
</p></details>