### PR TITLE
Fix godoc examples for Any (#569)

### DIFF
--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -43,7 +43,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -53,7 +53,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)
@@ -71,7 +71,7 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 //
 //
 // JSON
-// ====
+//
 // The JSON representation of an `Any` value uses the regular
 // representation of the deserialized, embedded message, with an
 // additional field `@type` which contains the type URL. Example:

--- a/ptypes/any/any.proto
+++ b/ptypes/any/any.proto
@@ -64,7 +64,7 @@ option objc_class_prefix = "GPB";
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -74,7 +74,7 @@ option objc_class_prefix = "GPB";
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)
@@ -92,7 +92,7 @@ option objc_class_prefix = "GPB";
 //
 //
 // JSON
-// ====
+//
 // The JSON representation of an `Any` value uses the regular
 // representation of the deserialized, embedded message, with an
 // additional field `@type` which contains the type URL. Example:


### PR DESCRIPTION
An extra space was causing Examples 3 and 4 to render in Example 2's
code block. This commit fixes those minor typos.

Also removing the `====` denoting the JSON section will allow godoc to
render a heading here.

Signed-off-by: John McCabe <john@johnmccabe.net>