### PR TITLE
proto: ensure consistency of behavior in Register* functions

### DIFF
--- a/proto/properties.go
+++ b/proto/properties.go
@@ -866,6 +866,10 @@ var (
 // RegisterFile is called from generated code and maps from the
 // full file name of a .proto file to its compressed FileDescriptorProto.
 func RegisterFile(filename string, fileDescriptor []byte) {
+	if _, ok := protoFiles[filename]; ok {
+		log.Printf("proto: duplicate proto file registered: %s", filename)
+		return
+	}
 	protoFiles[filename] = fileDescriptor
 }
 

--- a/proto/properties.go
+++ b/proto/properties.go
@@ -812,7 +812,8 @@ var enumValueMaps = make(map[string]map[string]int32)
 // maps into the global table to aid parsing text format protocol buffers.
 func RegisterEnum(typeName string, unusedNameMap map[int32]string, valueMap map[string]int32) {
 	if _, ok := enumValueMaps[typeName]; ok {
-		panic("proto: duplicate enum registered: " + typeName)
+		log.Printf("proto: duplicate enum registered: %s", typeName)
+		return
 	}
 	enumValueMaps[typeName] = valueMap
 }


### PR DESCRIPTION
At first, `panic` will not work properly on appengine. In fact, in order to avoid this, [deletion by sed is done in appengine official package](https://github.com/golang/appengine/blob/ad39d7fab7c60b2493fdc318c3d2cdb2128f92a4/internal/regen.sh#L39).

This behavior is not a consistent behavior in `Register*` functions.
I think that it is enough to just log back and do a return like `RegisterType` without generating panic.

In addition, `RegisterFile` also changes to make it behave consistently as well.