### PR TITLE
Fix jsonName in generated json tag

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1781,7 +1781,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		ns := allocNames(base, "Get"+base)
 		fieldName, fieldGetterName := ns[0], ns[1]
 		typename, wiretype := g.GoType(message, field)
-		jsonName := *field.Name
+		jsonName := field.GetJsonName()
 		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
 
 		fieldNames[field] = fieldName


### PR DESCRIPTION
Generator produced json tag with field name instead of jsonName:
e.g. before:
```golang
RunWhen     string `protobuf:"bytes,6,opt,name=run_when,json=runWhen" json:"run_when,omitempty"`
```
after:
```golang
RunWhen     string `protobuf:"bytes,6,opt,name=run_when,json=runWhen" json:"runWhen,omitempty"`
```