### PR TITLE
protoc-gen-go: add convenience function for getting ServiceDescriptorProtos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 - 1.x
 
 install:
-  - go get -v -d -t github.com/golang/protobuf/... google.golang.org/grpc
+  - go get -v -d -t github.com/golang/protobuf/...
   - curl -L https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip -o /tmp/protoc.zip
   - unzip /tmp/protoc.zip -d "$HOME"/protoc
   - mkdir -p "$HOME"/src && ln -s "$HOME"/protoc "$HOME"/src/protobuf

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 - 1.x
 
 install:
-  - go get -v -d -t github.com/golang/protobuf/...
+  - go get -v -d -t github.com/golang/protobuf/... google.golang.org/grpc
   - curl -L https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip -o /tmp/protoc.zip
   - unzip /tmp/protoc.zip -d "$HOME"/protoc
   - mkdir -p "$HOME"/src && ln -s "$HOME"/protoc "$HOME"/src/protobuf

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@
 all:	install
 
 deps:
-	go get -d -f ./...
+	go get -d ./...
 
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,13 @@
 
 all:	install
 
+deps:
+	go get -d -f ./...
+
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go
 
-test:
+test: deps
 	go test ./... ./protoc-gen-go/testdata
 	make -C conformance test
 
@@ -44,5 +47,5 @@ clean:
 nuke:
 	go clean -i ./...
 
-regenerate:
+regenerate: deps
 	./regenerate.sh

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,10 @@
 
 all:	install
 
-deps:
-	go get -d -u -f ./...
-
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go
 
-test: deps
+test:
 	go test ./... ./protoc-gen-go/testdata
 	make -C conformance test
 
@@ -47,5 +44,5 @@ clean:
 nuke:
 	go clean -i ./...
 
-regenerate: deps
+regenerate:
 	./regenerate.sh

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@
 all:	install
 
 deps:
-	go get -d -u github.com/golang/protobuf/...
+	go get -d -u google.golang.org/grpc
 
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@
 all:	install
 
 deps:
-	go get -d ./...
+	go get -d -t ./...
 
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ all:	install
 
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go
+	go get -d -u github.com/golang/protobuf/...
 
 test:
 	go test ./... ./protoc-gen-go/testdata

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@
 
 all:	install
 
-install:
-	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go
+deps:
 	go get -d -u github.com/golang/protobuf/...
 
-test:
+install:
+	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go
+
+test: deps
 	go test ./... ./protoc-gen-go/testdata
 	make -C conformance test
 
@@ -45,5 +47,5 @@ clean:
 nuke:
 	go clean -i ./...
 
-regenerate:
+regenerate: deps
 	./regenerate.sh

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@
 all:	install
 
 deps:
-	go get -d -u -f github.com/golang/protobuf/...
+	go get -d -u -f ./...
 
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@
 all:	install
 
 deps:
-	go get -d -u google.golang.org/grpc
+	go get -d -u -f github.com/golang/protobuf/...
 
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@
 all:	install
 
 deps:
-	go get -d -t ./...
+	go get -d -t ./... ./protoc-gen-go/testdata
 
 install:
 	go install ./proto ./jsonpb ./ptypes ./protoc-gen-go

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1260,6 +1260,9 @@ func (g *Generator) generate(file *FileDescriptor) {
 	for _, ext := range g.file.ext {
 		g.generateExtension(ext)
 	}
+	for i, service := range g.file.FileDescriptorProto.Service {
+		g.generateService(service, i)
+	}
 	g.generateInitFunction()
 
 	// Run the plugins before the imports so we know which imports are necessary.
@@ -1823,6 +1826,11 @@ var wellKnownTypes = map[string]bool{
 	"BoolValue":   true,
 	"StringValue": true,
 	"BytesValue":  true,
+}
+
+func (g *Generator) generateService(service *descriptor.ServiceDescriptorProto, index int) {
+	g.P("func Get", CamelCase(service.GetName()), "ServiceDescriptor() ([]byte, []int) { return ", g.file.VarName(), ", []int{", strconv.Itoa(index), "} }")
+	g.P()
 }
 
 // Generate the type and default constant definitions for this Descriptor.

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -122,6 +122,10 @@ func (m *DeprecatedResponse) GetDeprecatedField() DeprecatedEnum {
 	return DeprecatedEnum_DEPRECATED
 }
 
+func GetDeprecatedServiceServiceDescriptor() ([]byte, []int) {
+	return fileDescriptor_deprecated_9e1889ba21817fad, []int{0}
+}
+
 func init() {
 	proto.RegisterType((*DeprecatedRequest)(nil), "deprecated.DeprecatedRequest")
 	proto.RegisterType((*DeprecatedResponse)(nil), "deprecated.DeprecatedResponse")

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -143,6 +143,8 @@ func (m *StreamMsg2) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_StreamMsg2 proto.InternalMessageInfo
 
+func GetTestServiceDescriptor() ([]byte, []int) { return fileDescriptor_grpc_65bf3902e49ee873, []int{0} }
+
 func init() {
 	proto.RegisterType((*SimpleRequest)(nil), "grpc.testing.SimpleRequest")
 	proto.RegisterType((*SimpleResponse)(nil), "grpc.testing.SimpleResponse")

--- a/protoc-gen-go/testdata/servicedescriptor_test.go
+++ b/protoc-gen-go/testdata/servicedescriptor_test.go
@@ -1,0 +1,39 @@
+package testdata
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+
+	pb "github.com/golang/protobuf/protoc-gen-go/testdata/grpc"
+)
+
+func TestServiceDescriptorExposed(t *testing.T) {
+	data, idx := pb.GetTestServiceDescriptor()
+	if len(idx) != 1 || idx[0] != 0 {
+		t.Errorf("Expected idx to be [0], but was %v", idx)
+	}
+	decompressor, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decompressed, err := ioutil.ReadAll(decompressor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desc := &descriptor.FileDescriptorProto{}
+	if err := proto.Unmarshal(decompressed, desc); err != nil {
+		t.Fatal(err)
+	}
+	if len(desc.Service) != 1 {
+		t.Errorf("Expected 1 service, but found %v", len(desc.Service))
+	}
+	svc := desc.Service[0]
+	if svc.GetName() != "Test" {
+		t.Errorf("Expected service name to be Test, but was %s", svc.GetName())
+	}
+}


### PR DESCRIPTION
Like #516, but in the main go code generator instead of the grpc plugin.