### PR TITLE
Revert "protoc-gen-go: use standard library context (requires Go1.9) (#548)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Google's data interchange format.
 Copyright 2010 The Go Authors.
 https://github.com/golang/protobuf
 
-This package and the code it generates requires at least Go 1.9.
+This package and the code it generates requires at least Go 1.6.
 
 This software implements Go bindings for protocol buffers.  For
 information about protocol buffers themselves, see

--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -53,7 +53,7 @@ const generatedCodeVersion = 4
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.
 const (
-	contextPkgPath = "context"
+	contextPkgPath = "golang.org/x/net/context"
 	grpcPkgPath    = "google.golang.org/grpc"
 )
 

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -12,7 +12,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "context"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -8,7 +8,7 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "context"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
This reverts commit 3dc8a89f965ba7bf716fd0d92b83c5da1792ab9c.

cc #537, #579