### PR TITLE
jsonpb: emit null value for oneof field with 'nil-interface' value.

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -293,9 +293,15 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 		// Oneof fields need special handling.
 		if valueField.Tag.Get("protobuf_oneof") != "" {
 			// value is an interface containing &T{real_value}.
-			sv := value.Elem().Elem() // interface -> *T -> T
-			value = sv.Field(0)
-			valueField = sv.Type().Field(0)
+			svPtr := value.Elem() // interface -> *T
+			if !svPtr.IsNil() {
+				sv := svPtr.Elem() // *T -> T
+				value = sv.Field(0)
+				valueField = sv.Type().Field(0)
+			} else {
+				value = reflect.ValueOf(nil)
+				valueField = svPtr.Type().Elem().Field(0)
+			}
 		}
 		prop := jsonProperties(valueField, m.OrigName)
 		if !firstField {


### PR DESCRIPTION
example proto:
```
message test {
    oneof roadIdNil {
        int32 roadId = 12;
    }
}
```
go code:
```
var roadId *proto.Test_RoadIdNil
test.RoadIdNil = roadId                // now RoadIdNil is not nil, but contains "nil" Interface  
```
will produce json:
```
{
    "roadId": null
}
```
instead of panic:
`2018/04/04 18:07:28 http: panic serving [::1]:62625: reflect: call of reflect.Value.Field on zero Value
goroutine 6 [running]:
net/http.(*conn).serve.func1(0xc42009e8c0)
	/usr/local/Cellar/go/1.10.1/libexec/src/net/http/server.go:1726 +0xd0
panic(0x13e9e60, 0xc4202ab420)
	/usr/local/Cellar/go/1.10.1/libexec/src/runtime/panic.go:502 +0x229
reflect.Value.Field(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x14c9c40)
	/usr/local/Cellar/go/1.10.1/libexec/src/reflect/value.go:782 +0x11b
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalObject(0xc420095bc0, 0xc420171910, 0x14c6b20, 0xc4200ac480, 0x0, 0x0, 0x0, 0x0, 0xc420170870, 0x8)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:297 +0x58d
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalValue(0xc420095bc0, 0xc420171910, 0xc4202e5cc0, 0x146a3c0, 0xc420184130, 0x196, 0x0, 0x0, 0x0, 0x8)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:525 +0xbe5
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalValue(0xc420095bc0, 0xc420171910, 0xc4202e5cc0, 0x13bb940, 0xc4202743c0, 0x197, 0x0, 0x0, 0xc420170b60, 0xc4202e5cc0)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:476 +0x1125
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalField(0xc420095bc0, 0xc420171910, 0xc4202e5cc0, 0x13bb940, 0xc4202743c0, 0x197, 0x0, 0x0, 0x0, 0xc420189c38)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:446 +0x10b
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalObject(0xc420095bc0, 0xc420171910, 0x14c6ae0, 0xc4202743c0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:304 +0x494
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalValue(0xc420095bc0, 0xc420171910, 0xc4202ce280, 0x1420960, 0xc42000e1e8, 0x196, 0x0, 0x0, 0xc420171300, 0xc4202ce280)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:525 +0xbe5
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalField(0xc420095bc0, 0xc420171910, 0xc4202ce280, 0x1420960, 0xc42000e1e8, 0x196, 0x0, 0x0, 0x0, 0xc420189358)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:446 +0x10b
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).marshalObject(0xc420095bc0, 0xc420171910, 0x14c6aa0, 0xc42000e1e8, 0x0, 0x0, 0x0, 0x0, 0xc420171930, 0x1012478)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:304 +0x494
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).Marshal(0xc420095bc0, 0x14c0a20, 0xc4201bea80, 0x14c6aa0, 0xc42000e1e8, 0x14c6aa0, 0x1430c80)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:122 +0x9d
soap/vendor/github.com/golang/protobuf/jsonpb.(*Marshaler).MarshalToString(0xc420095bc0, 0x14c6aa0, 0xc42000e1e8, 0x14c6aa0, 0xc42000e1e8, 0x14208c0, 0xc42000e1e8)
	/Users/btstsyrendylykov/go/src/soap/vendor/github.com/golang/protobuf/jsonpb/jsonpb.go:128 +0x6e`