### PR TITLE
protoc-gen-go: export `oneof` interface types

### DIFF
--- a/conformance/internal/conformance_proto/conformance.pb.go
+++ b/conformance/internal/conformance_proto/conformance.pb.go
@@ -117,7 +117,7 @@ type ConformanceRequest struct {
 	// Types that are valid to be assigned to Payload:
 	//	*ConformanceRequest_ProtobufPayload
 	//	*ConformanceRequest_JsonPayload
-	Payload isConformanceRequest_Payload `protobuf_oneof:"payload"`
+	Payload IsConformanceRequest_Payload `protobuf_oneof:"payload"`
 	// Which format should the testee serialize its message to?
 	RequestedOutputFormat WireFormat `protobuf:"varint,3,opt,name=requested_output_format,json=requestedOutputFormat,enum=conformance.WireFormat" json:"requested_output_format,omitempty"`
 	XXX_NoUnkeyedLiteral  struct{}   `json:"-"`
@@ -149,7 +149,7 @@ func (m *ConformanceRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ConformanceRequest proto.InternalMessageInfo
 
-type isConformanceRequest_Payload interface {
+type IsConformanceRequest_Payload interface {
 	isConformanceRequest_Payload()
 }
 
@@ -163,7 +163,7 @@ type ConformanceRequest_JsonPayload struct {
 func (*ConformanceRequest_ProtobufPayload) isConformanceRequest_Payload() {}
 func (*ConformanceRequest_JsonPayload) isConformanceRequest_Payload()     {}
 
-func (m *ConformanceRequest) GetPayload() isConformanceRequest_Payload {
+func (m *ConformanceRequest) GetPayload() IsConformanceRequest_Payload {
 	if m != nil {
 		return m.Payload
 	}
@@ -266,7 +266,7 @@ type ConformanceResponse struct {
 	//	*ConformanceResponse_ProtobufPayload
 	//	*ConformanceResponse_JsonPayload
 	//	*ConformanceResponse_Skipped
-	Result               isConformanceResponse_Result `protobuf_oneof:"result"`
+	Result               IsConformanceResponse_Result `protobuf_oneof:"result"`
 	XXX_NoUnkeyedLiteral struct{}                     `json:"-"`
 	XXX_unrecognized     []byte                       `json:"-"`
 	XXX_sizecache        int32                        `json:"-"`
@@ -296,7 +296,7 @@ func (m *ConformanceResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ConformanceResponse proto.InternalMessageInfo
 
-type isConformanceResponse_Result interface {
+type IsConformanceResponse_Result interface {
 	isConformanceResponse_Result()
 }
 
@@ -326,7 +326,7 @@ func (*ConformanceResponse_ProtobufPayload) isConformanceResponse_Result() {}
 func (*ConformanceResponse_JsonPayload) isConformanceResponse_Result()     {}
 func (*ConformanceResponse_Skipped) isConformanceResponse_Result()         {}
 
-func (m *ConformanceResponse) GetResult() isConformanceResponse_Result {
+func (m *ConformanceResponse) GetResult() IsConformanceResponse_Result {
 	if m != nil {
 		return m.Result
 	}
@@ -574,7 +574,7 @@ type TestAllTypes struct {
 	//	*TestAllTypes_OneofNestedMessage
 	//	*TestAllTypes_OneofString
 	//	*TestAllTypes_OneofBytes
-	OneofField isTestAllTypes_OneofField `protobuf_oneof:"oneof_field"`
+	OneofField IsTestAllTypes_OneofField `protobuf_oneof:"oneof_field"`
 	// Well-known types
 	OptionalBoolWrapper   *wrappers.BoolValue     `protobuf:"bytes,201,opt,name=optional_bool_wrapper,json=optionalBoolWrapper" json:"optional_bool_wrapper,omitempty"`
 	OptionalInt32Wrapper  *wrappers.Int32Value    `protobuf:"bytes,202,opt,name=optional_int32_wrapper,json=optionalInt32Wrapper" json:"optional_int32_wrapper,omitempty"`
@@ -648,7 +648,7 @@ func (m *TestAllTypes) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_TestAllTypes proto.InternalMessageInfo
 
-type isTestAllTypes_OneofField interface {
+type IsTestAllTypes_OneofField interface {
 	isTestAllTypes_OneofField()
 }
 
@@ -670,7 +670,7 @@ func (*TestAllTypes_OneofNestedMessage) isTestAllTypes_OneofField() {}
 func (*TestAllTypes_OneofString) isTestAllTypes_OneofField()        {}
 func (*TestAllTypes_OneofBytes) isTestAllTypes_OneofField()         {}
 
-func (m *TestAllTypes) GetOneofField() isTestAllTypes_OneofField {
+func (m *TestAllTypes) GetOneofField() IsTestAllTypes_OneofField {
 	if m != nil {
 		return m.OneofField
 	}

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -511,7 +511,7 @@ type MsgWithOneof struct {
 	//	*MsgWithOneof_Country
 	//	*MsgWithOneof_HomeAddress
 	//	*MsgWithOneof_MsgWithRequired
-	Union                isMsgWithOneof_Union `protobuf_oneof:"union"`
+	Union                IsMsgWithOneof_Union `protobuf_oneof:"union"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`
@@ -541,7 +541,7 @@ func (m *MsgWithOneof) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgWithOneof proto.InternalMessageInfo
 
-type isMsgWithOneof_Union interface {
+type IsMsgWithOneof_Union interface {
 	isMsgWithOneof_Union()
 }
 
@@ -567,7 +567,7 @@ func (*MsgWithOneof_Country) isMsgWithOneof_Union()         {}
 func (*MsgWithOneof_HomeAddress) isMsgWithOneof_Union()     {}
 func (*MsgWithOneof_MsgWithRequired) isMsgWithOneof_Union() {}
 
-func (m *MsgWithOneof) GetUnion() isMsgWithOneof_Union {
+func (m *MsgWithOneof) GetUnion() IsMsgWithOneof_Union {
 	if m != nil {
 		return m.Union
 	}

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -3047,10 +3047,10 @@ type Oneof struct {
 	//	*Oneof_F_Message
 	//	*Oneof_FGroup
 	//	*Oneof_F_Largest_Tag
-	Union isOneof_Union `protobuf_oneof:"union"`
+	Union IsOneof_Union `protobuf_oneof:"union"`
 	// Types that are valid to be assigned to Tormato:
 	//	*Oneof_Value
-	Tormato              isOneof_Tormato `protobuf_oneof:"tormato"`
+	Tormato              IsOneof_Tormato `protobuf_oneof:"tormato"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
 	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
@@ -3080,10 +3080,10 @@ func (m *Oneof) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Oneof proto.InternalMessageInfo
 
-type isOneof_Union interface {
+type IsOneof_Union interface {
 	isOneof_Union()
 }
-type isOneof_Tormato interface {
+type IsOneof_Tormato interface {
 	isOneof_Tormato()
 }
 
@@ -3161,13 +3161,13 @@ func (*Oneof_FGroup) isOneof_Union()        {}
 func (*Oneof_F_Largest_Tag) isOneof_Union() {}
 func (*Oneof_Value) isOneof_Tormato()       {}
 
-func (m *Oneof) GetUnion() isOneof_Union {
+func (m *Oneof) GetUnion() IsOneof_Union {
 	if m != nil {
 		return m.Union
 	}
 	return nil
 }
-func (m *Oneof) GetTormato() isOneof_Tormato {
+func (m *Oneof) GetTormato() IsOneof_Tormato {
 	if m != nil {
 		return m.Tormato
 	}
@@ -3665,7 +3665,7 @@ type Communique struct {
 	//	*Communique_TempC
 	//	*Communique_Col
 	//	*Communique_Msg
-	Union                isCommunique_Union `protobuf_oneof:"union"`
+	Union                IsCommunique_Union `protobuf_oneof:"union"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -3695,7 +3695,7 @@ func (m *Communique) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Communique proto.InternalMessageInfo
 
-type isCommunique_Union interface {
+type IsCommunique_Union interface {
 	isCommunique_Union()
 }
 
@@ -3725,7 +3725,7 @@ func (*Communique_TempC) isCommunique_Union()  {}
 func (*Communique_Col) isCommunique_Union()    {}
 func (*Communique_Msg) isCommunique_Union()    {}
 
-func (m *Communique) GetUnion() isCommunique_Union {
+func (m *Communique) GetUnion() IsCommunique_Union {
 	if m != nil {
 		return m.Union
 	}

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -639,7 +639,7 @@ type Communique struct {
 	//	*Communique_Delta_
 	//	*Communique_Msg
 	//	*Communique_Somegroup
-	Union                isCommunique_Union `protobuf_oneof:"union"`
+	Union                IsCommunique_Union `protobuf_oneof:"union"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -669,7 +669,7 @@ func (m *Communique) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Communique proto.InternalMessageInfo
 
-type isCommunique_Union interface {
+type IsCommunique_Union interface {
 	isCommunique_Union()
 }
 
@@ -715,7 +715,7 @@ func (*Communique_Delta_) isCommunique_Union()    {}
 func (*Communique_Msg) isCommunique_Union()       {}
 func (*Communique_Somegroup) isCommunique_Union() {}
 
-func (m *Communique) GetUnion() isCommunique_Union {
+func (m *Communique) GetUnion() IsCommunique_Union {
 	if m != nil {
 		return m.Union
 	}

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -108,7 +108,7 @@ type Value struct {
 	//	*Value_BoolValue
 	//	*Value_StructValue
 	//	*Value_ListValue
-	Kind                 isValue_Kind `protobuf_oneof:"kind"`
+	Kind                 IsValue_Kind `protobuf_oneof:"kind"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -139,7 +139,7 @@ func (m *Value) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Value proto.InternalMessageInfo
 
-type isValue_Kind interface {
+type IsValue_Kind interface {
 	isValue_Kind()
 }
 
@@ -169,7 +169,7 @@ func (*Value_BoolValue) isValue_Kind()   {}
 func (*Value_StructValue) isValue_Kind() {}
 func (*Value_ListValue) isValue_Kind()   {}
 
-func (m *Value) GetKind() isValue_Kind {
+func (m *Value) GetKind() IsValue_Kind {
 	if m != nil {
 		return m.Kind
 	}


### PR DESCRIPTION
This pull request addresses #261 , which asks to export the generated `isX_Union` interface types.

This allows for manipulation methods which return `oneof` types, which can be helpful for writing `switch` statements. Exporting generated `oneof` interfaces enables the construction and return of union types, which can be useful for writing helper methods (among other things).

`make test` passes.

Resubmitting after #587 oddity.