### PR TITLE
grpc: fix and improve interface comments for client/server types

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -166,7 +166,8 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 
 	// Client interface.
 	if deprecated {
-		g.P("\n" + deprecationComment)
+		g.P("//")
+		g.P(deprecationComment)
 	}
 	g.P("type ", servName, "Client interface {")
 	for i, method := range service.Method {
@@ -208,14 +209,13 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 		g.generateClientMethod(servName, fullServName, serviceDescVar, method, descExpr)
 	}
 
-	g.P("// Server API for ", servName, " service")
-	g.P()
-
 	// Server interface.
+	serverType := servName + "Server"
+	g.P("// ", serverType, " is the server API for ", servName, " service.")
 	if deprecated {
+		g.P("//")
 		g.P(deprecationComment)
 	}
-	serverType := servName + "Server"
 	g.P("type ", serverType, " interface {")
 	for i, method := range service.Method {
 		g.gen.PrintComments(fmt.Sprintf("%s,2,%d", path, i)) // 2 means method in a service.

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -139,7 +139,7 @@ const _ = grpc.SupportPackageIsVersion4
 // DeprecatedServiceClient is the client API for DeprecatedService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
-
+//
 // Deprecated: Do not use.
 type DeprecatedServiceClient interface {
 	// DeprecatedCall takes a DeprecatedRequest and returns a DeprecatedResponse.
@@ -165,8 +165,8 @@ func (c *deprecatedServiceClient) DeprecatedCall(ctx context.Context, in *Deprec
 	return out, nil
 }
 
-// Server API for DeprecatedService service
-
+// DeprecatedServiceServer is the server API for DeprecatedService service.
+//
 // Deprecated: Do not use.
 type DeprecatedServiceServer interface {
 	// DeprecatedCall takes a DeprecatedRequest and returns a DeprecatedResponse.

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -285,8 +285,7 @@ func (x *testBidiClient) Recv() (*StreamMsg2, error) {
 	return m, nil
 }
 
-// Server API for Test service
-
+// TestServer is the server API for Test service.
 type TestServer interface {
 	UnaryCall(context.Context, *SimpleRequest) (*SimpleResponse, error)
 	// This RPC streams from the server only.


### PR DESCRIPTION
32a84b2 added a newline that resulted in the interface doc comment
becoming detached from the interface type definition. However, both it
and the corresponding server comment were inconsistent, so this change
makes them all consistent and well-rendered in godoc.