### PR TITLE
LICENSE: Move title to README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,4 @@
-Go support for Protocol Buffers - Google's data interchange format
-
 Copyright 2010 The Go Authors.  All rights reserved.
-https://github.com/golang/protobuf
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go support for Protocol Buffers
+# Go support for Protocol Buffers - Google's data interchange format
 
 [![Build Status](https://travis-ci.org/golang/protobuf.svg?branch=master)](https://travis-ci.org/golang/protobuf)
 [![GoDoc](https://godoc.org/github.com/golang/protobuf?status.svg)](https://godoc.org/github.com/golang/protobuf)


### PR DESCRIPTION
The first line of the LICENSE was a package title, which confuses
license checkers such as that run by GitHub. Move the title to
README.md, where it belongs.