### PR TITLE
jsonpb: error on scalar enum provided for repeated enums instead of panic

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -878,9 +878,10 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 			target.Set(reflect.New(targetType.Elem()))
 			target = target.Elem()
 		}
-		if targetType.Kind() == reflect.Int32 {
-			target.SetInt(int64(n))
+		if targetType.Kind() != reflect.Int32 {
+			return fmt.Errorf("invalid target %q for enum %s", targetType.Kind(), prop.Enum)
 		}
+		target.SetInt(int64(n))
 		return nil
 	}
 

--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -878,7 +878,9 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 			target.Set(reflect.New(targetType.Elem()))
 			target = target.Elem()
 		}
-		target.SetInt(int64(n))
+		if targetType.Kind() == reflect.Int32 {
+			target.SetInt(int64(n))
+		}
 		return nil
 	}
 

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -667,6 +667,8 @@ var unmarshalingTests = []struct {
 			proto3pb.Message_PUNS,
 			proto3pb.Message_SLAPSTICK,
 		}}},
+	{"repeated proto3 enum with non array input", Unmarshaler{}, `{"rFunny":"PUNS"}`,
+		&proto3pb.Message{RFunny: []proto3pb.Message_Humour{}}},
 	{"unquoted int64 object", Unmarshaler{}, `{"oInt64":-314}`, &pb.Simple{OInt64: proto.Int64(-314)}},
 	{"unquoted uint64 object", Unmarshaler{}, `{"oUint64":123}`, &pb.Simple{OUint64: proto.Uint64(123)}},
 	{"NaN", Unmarshaler{}, `{"oDouble":"NaN"}`, &pb.Simple{ODouble: proto.Float64(math.NaN())}},

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -667,8 +667,6 @@ var unmarshalingTests = []struct {
 			proto3pb.Message_PUNS,
 			proto3pb.Message_SLAPSTICK,
 		}}},
-	{"repeated proto3 enum with non array input", Unmarshaler{}, `{"rFunny":"PUNS"}`,
-		&proto3pb.Message{RFunny: []proto3pb.Message_Humour{}}},
 	{"unquoted int64 object", Unmarshaler{}, `{"oInt64":-314}`, &pb.Simple{OInt64: proto.Int64(-314)}},
 	{"unquoted uint64 object", Unmarshaler{}, `{"oUint64":123}`, &pb.Simple{OUint64: proto.Uint64(123)}},
 	{"NaN", Unmarshaler{}, `{"oDouble":"NaN"}`, &pb.Simple{ODouble: proto.Float64(math.NaN())}},
@@ -870,6 +868,7 @@ var unmarshalingShouldError = []struct {
 	{"Timestamp containing invalid character", `{"ts": "2014-05-13T16:53:20\U005a"}`, &pb.KnownTypes{}},
 	{"StringValue containing invalid character", `{"str": "\U00004E16\U0000754C"}`, &pb.KnownTypes{}},
 	{"StructValue containing invalid character", `{"str": "\U00004E16\U0000754C"}`, &stpb.Struct{}},
+	{"repeated proto3 enum with non array input", `{"rFunny":"PUNS"}`, &proto3pb.Message{RFunny: []proto3pb.Message_Humour{}}},
 }
 
 func TestUnmarshalingBadInput(t *testing.T) {


### PR DESCRIPTION
Ran into an issue where attempting to unmarshal valid json that contains a field with a single enum into a message that has a repeated enum field causes a panic. For example, try to unmarshal this:
```go
{
    "rFunny":"PUNS"
}
```
into a message that looks like this:
```go
type Message struct {
    RFunny []Message_Humour
}
```
This will cause a panic. I know the json is an invalid representation of the Message struct, but it shouldn't panic. I'm attempting to fix this issue by validating that the targetType is correct before setting the enum.