### PR TITLE
ptypes: ran gofmt on any_test.go

### DIFF
--- a/ptypes/any_test.go
+++ b/ptypes/any_test.go
@@ -80,7 +80,6 @@ func TestIsDifferentUrlPrefixes(t *testing.T) {
 	}
 }
 
-
 func TestIsCornerCases(t *testing.T) {
 	m := &pb.FileDescriptorProto{}
 	if Is(nil, m) {


### PR DESCRIPTION

Just ran

	gofmt -w .

on the project root. That's all.

https://blog.golang.org/go-fmt-your-code

---
> I made this PR with a project going on over at https://github.com/rotblauer/gofmt-att, and it's definitely a work in progress. So if I got something wrong, or this is annoying at all, please file an issue over there and we'll sort it out.