### PR TITLE
jsonpb: avoid copying string-valued map-keys

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -1116,6 +1116,8 @@ func (s mapKeys) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s mapKeys) Less(i, j int) bool {
 	if k := s[i].Kind(); k == s[j].Kind() {
 		switch k {
+		case reflect.String:
+			return s[i].String() < s[j].String()
 		case reflect.Int32, reflect.Int64:
 			return s[i].Int() < s[j].Int()
 		case reflect.Uint32, reflect.Uint64:


### PR DESCRIPTION
Encoding large maps with string keys is very expensive.  Profiling indicated that the culprit was `github.com/golang/protobuf/jsonpb.mapKeys.Less` which is used to ensure that the ordering of the map keys are consistent since Go map iteration is random.

By adding a string-specific case we avoid the overhead of going through the fmt.Sprintf calls, which removes a lot of unnecessary allocations.

I suspect that this can be taken further - the requirement of ordered keys does not apply to the JSON rep, so I believe it could be be removed in this case (https://developers.google.com/protocol-buffers/docs/proto3#json).  Note: the "text format" rep does require ordering, so maybe this is why the JSON code inherited it...