### PR TITLE
proto: revert strict erroring of deterministic and custom marshalers

### DIFF
--- a/proto/all_test.go
+++ b/proto/all_test.go
@@ -2303,25 +2303,6 @@ func TestInvalidUTF8(t *testing.T) {
 	}
 }
 
-type CustomRawMessage []byte
-
-func (m *CustomRawMessage) Marshal() ([]byte, error) {
-	return []byte(*m), nil
-}
-func (m *CustomRawMessage) Reset()         { *m = nil }
-func (m *CustomRawMessage) String() string { return fmt.Sprintf("%x", *m) }
-func (m *CustomRawMessage) ProtoMessage()  {}
-
-func TestDeterministicErrorOnCustomMarshaler(t *testing.T) {
-	in := CustomRawMessage{1, 2, 3}
-	var b1 Buffer
-	b1.SetDeterministic(true)
-	err := b1.Marshal(&in)
-	if err == nil || !strings.Contains(err.Error(), "deterministic") {
-		t.Fatalf("Marshal error:\ngot  %v\nwant deterministic not supported error", err)
-	}
-}
-
 // Benchmarks
 
 func testMsg() *GoTest {

--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -2715,11 +2715,6 @@ func Marshal(pb Message) ([]byte, error) {
 // a Buffer for most applications.
 func (p *Buffer) Marshal(pb Message) error {
 	var err error
-	if p.deterministic {
-		if _, ok := pb.(Marshaler); ok {
-			return fmt.Errorf("proto: deterministic not supported by the Marshal method of %T", pb)
-		}
-	}
 	if m, ok := pb.(newMarshaler); ok {
 		siz := m.XXX_Size()
 		p.grow(siz) // make sure buf has enough capacity


### PR DESCRIPTION
PR #650 added strict checking of the use of deterministic with custom marshalers
since it is impossible to know whether a custom marshalers actually do produce
deterministic output or not.

However, this check is breaking hundreds of targets that already rely on
determinism along with custom marshalers. In every case, the custom marshaler
already produced deterministic output, so it did not really matter.

If deterministic is specified *and* a custom marshaler is not actually
deterministic, then the output is obviously not deterministic,
and setting the flag was a lie. However, there is not much we can do with the
current API. A redesign of the proto API will resolve this tension.