### PR TITLE
protoc-gen-go: return response even if grpc service returns error

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -309,8 +309,7 @@ func (g *grpc) generateClientMethod(servName, fullServName, serviceDescVar strin
 		g.P("out := new(", outType, ")")
 		// TODO: Pass descExpr to Invoke.
 		g.P(`err := c.cc.Invoke(ctx, "`, sname, `", in, out, opts...)`)
-		g.P("if err != nil { return nil, err }")
-		g.P("return out, nil")
+		g.P("return out, err")
 		g.P("}")
 		g.P()
 		return

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -159,10 +159,7 @@ func NewDeprecatedServiceClient(cc *grpc.ClientConn) DeprecatedServiceClient {
 func (c *deprecatedServiceClient) DeprecatedCall(ctx context.Context, in *DeprecatedRequest, opts ...grpc.CallOption) (*DeprecatedResponse, error) {
 	out := new(DeprecatedResponse)
 	err := c.cc.Invoke(ctx, "/deprecated.DeprecatedService/DeprecatedCall", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	return out, err
 }
 
 // DeprecatedServiceServer is the server API for DeprecatedService service.

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -182,10 +182,7 @@ func NewTestClient(cc *grpc.ClientConn) TestClient {
 func (c *testClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
 	out := new(SimpleResponse)
 	err := c.cc.Invoke(ctx, "/grpc.testing.Test/UnaryCall", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	return out, err
 }
 
 func (c *testClient) Downstream(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (Test_DownstreamClient, error) {


### PR DESCRIPTION
Response may have information about error.