### PR TITLE
Add tag flag to export message tag comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ parameter list separated from the output directory by a colon:
 - `Mfoo/bar.proto=quux/shme` - declares that foo/bar.proto is
   associated with Go package quux/shme.  This is subject to the
   import_prefix parameter.
-- `tag=true` - specifies wheter export tag comment.
+- `tag=true` - specifies whether export tag comment.
 
 The following parameters are deprecated and should not be used:
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ parameter list separated from the output directory by a colon:
 - `Mfoo/bar.proto=quux/shme` - declares that foo/bar.proto is
   associated with Go package quux/shme.  This is subject to the
   import_prefix parameter.
+- `tag=true` - specifies wheter export tag comment.
 
 The following parameters are deprecated and should not be used:
 

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2632,7 +2632,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		if g.tag {
 			tagre := regexp.MustCompile("`(\\w.+)`")
 			if tt := tagre.FindStringSubmatch(tc); len(tt) >= 1 {
-				tag = tag + " " + tt[1]
+				tag = tag + " " + getStructTag(tt[1])
 			}
 		}
 		rf := simpleField{
@@ -2712,6 +2712,23 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		g.addInitf("%s.RegisterMapType((%s)(nil), %q)", g.Pkg["proto"], mapFieldTypes[k], fullName)
 	}
 
+}
+
+func getStructTag(comment string) string {
+	parts := make([]string, 0)
+	re := regexp.MustCompile("^\\w.*:\"\\S+\"$")
+
+	for _, t := range strings.Fields(comment) {
+		if strings.HasPrefix(t, "json:") || strings.HasPrefix(t, "protobuf:") {
+			continue
+		}
+		if !re.MatchString(t) {
+			continue
+		}
+		parts = append(parts, t)
+	}
+
+	return strings.Join(parts, " ")
 }
 
 type byTypeName []*descriptor.FieldDescriptorProto

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2630,9 +2630,8 @@ func (g *Generator) generateMessage(message *Descriptor) {
 			c += "\n"
 		}
 		if g.tag {
-			tagre := regexp.MustCompile("`(\\w.+)`")
-			if tt := tagre.FindStringSubmatch(tc); len(tt) >= 1 {
-				tag = tag + " " + getStructTag(tt[1])
+			if t := getStructTag(tc); t != "" {
+				tag = tag + " " + t
 			}
 		}
 		rf := simpleField{
@@ -2715,16 +2714,21 @@ func (g *Generator) generateMessage(message *Descriptor) {
 }
 
 func getStructTag(comment string) string {
-	parts := make([]string, 0)
-	re := regexp.MustCompile("^\\w.*:\"\\S+\"$")
+	// only support first tag comment
+	comment = regexp.MustCompile("`([^`]+)`").FindString(comment)
 
-	for _, t := range strings.Fields(comment) {
+	if comment == "" {
+		return ""
+	}
+
+	parts := make([]string, 0)
+	re := regexp.MustCompile("\\w.*?:\"[^\"]+?\"")
+
+	for _, t := range re.FindAllString(comment, len(comment)) {
 		if strings.HasPrefix(t, "json:") || strings.HasPrefix(t, "protobuf:") {
 			continue
 		}
-		if !re.MatchString(t) {
-			continue
-		}
+
 		parts = append(parts, t)
 	}
 

--- a/protoc-gen-go/generator/tag_test.go
+++ b/protoc-gen-go/generator/tag_test.go
@@ -1,0 +1,62 @@
+// Go support for Protocol Buffers - Google's data interchange format
+//
+// Copyright 2013 The Go Authors.  All rights reserved.
+// https://github.com/golang/protobuf
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package generator
+
+import (
+	"testing"
+)
+
+func TestGetStructTag(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		// skip json/protobuf
+		{"`json:\"mid,omitempty\"`", ""},
+		{"`protobuf:\"varint,1,opt,name=mid,proto3\"`", ""},
+		{"`json:\"mid,omitempty\",foo:\"foo\"`", "foo:\"foo\""},
+
+		// common tags
+		{"`validator:\"oneof=red green\"`", "validator:\"oneof=red green\""},
+		{"` \t\nfoo:\"foo,a=1\" \t\t bar:\"bar,b=2\" \t\n`", "foo:\"foo,a=1\" bar:\"bar,b=2\""},
+		{"`foo_foo:\"foo,a=1\"bar-bar:\"bar,b=2\"`", "foo_foo:\"foo,a=1\" bar-bar:\"bar,b=2\""},
+
+		// only process first
+		{"`foo:\"foo\" bar:\"bar\"` xxx `baz:\"baz\"`", "foo:\"foo\" bar:\"bar\""},
+	}
+	for _, tc := range tests {
+		s := getStructTag(tc.in)
+		if s != tc.out {
+			t.Errorf("tag comment (%q) = %q; should have been %q", tc.in, s, tc.out)
+		}
+	}
+}


### PR DESCRIPTION
Some golang packages use struct tag to store infomation. For example, using [go-playground/validator](https://godoc.org/gopkg.in/go-playground/validator.v9), you can define a validate rule like this

```golang
type Test struct {
	Field `validate:"max=10,min=1"`
}
```

It will be great convenient if struct generated by protoc-gen-go according to proto has these tags.

This PR promotes a simple way to achieve this goal.

First, we introduce a so called **struct tag comment** like
```proto
message User {
    int32 uid = 1 // `validator:"gt=0"`
}
```

When we generate the *.pb.go, we enable the tag flag by `--go_out=tag=true:path`, wewill get 
```golang
type User struct {
    Uid int32 `protobuf:"varint,1,opt,name=uid,proto3" json:"mid,omitempty validator:gt=0"
}
```

So other packages could read the right struct tag.

----

There are some other solution like [gogo](https://github.com/gogo/protobuf) using the protobuf extension. But this PR is a more lightweight one.