### PR TITLE
generator: expose FileDescriptor.PackageName again

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -278,6 +278,11 @@ type FileDescriptor struct {
 	proto3 bool // whether to generate proto3 code for this file
 }
 
+// PackageName is the package name we'll use in the generated code to refer to this file.
+func (d *FileDescriptor) PackageName() GoPackageName {
+	return d.packageName
+}
+
 // VarName is the variable name we'll use in the generated code to refer
 // to the compressed bytes of this descriptor. It is not exported, so
 // it is only valid inside the generated package.


### PR DESCRIPTION
A public method `PackageName()` in `generator.FileDescriptor` was removed between v1.0.0 and v1.1.0 in https://github.com/golang/protobuf/pull/543.

In v1.0.0:
https://github.com/golang/protobuf/blob/v1.0.0/protoc-gen-go/generator/generator.go#L264-L265

We rely on the method for some protobuf plugins, and is unable to upgrade as a result. If the removal is intentional, please advise on what is the best way to query the package name of a file descriptor.

Thanks a lot!