### PR TITLE
More useful error message on setting extensions

### DIFF
--- a/proto/extensions.go
+++ b/proto/extensions.go
@@ -488,7 +488,7 @@ func SetExtension(pb Message, extension *ExtensionDesc, value interface{}) error
 	}
 	typ := reflect.TypeOf(extension.ExtensionType)
 	if typ != reflect.TypeOf(value) {
-		return errors.New("proto: bad extension value type")
+		return fmt.Errorf("proto: bad extension value type. want: %T, got: %T", extension.ExtensionType, value)
 	}
 	// nil extension values need to be caught early, because the
 	// encoder can't distinguish an ErrNil due to a nil extension

--- a/proto/extensions.go
+++ b/proto/extensions.go
@@ -488,7 +488,7 @@ func SetExtension(pb Message, extension *ExtensionDesc, value interface{}) error
 	}
 	typ := reflect.TypeOf(extension.ExtensionType)
 	if typ != reflect.TypeOf(value) {
-		return fmt.Errorf("proto: bad extension value type. want: %T, got: %T", extension.ExtensionType, value)
+		return fmt.Errorf("proto: bad extension value type. got: %T, want: %T", value, extension.ExtensionType)
 	}
 	// nil extension values need to be caught early, because the
 	// encoder can't distinguish an ErrNil due to a nil extension


### PR DESCRIPTION
Including the types that are mismatched, rather than just stating that there was a type mismatch makes the error easier to debug and fix.