### PR TITLE
proto: uniquify descriptor var based on filename alone

### DIFF
--- a/conformance/internal/conformance_proto/conformance.pb.go
+++ b/conformance/internal/conformance_proto/conformance.pb.go
@@ -47,7 +47,7 @@ func (x WireFormat) String() string {
 	return proto.EnumName(WireFormat_name, int32(x))
 }
 func (WireFormat) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{0}
+	return fileDescriptor_e7c910178d599565, []int{0}
 }
 
 type ForeignEnum int32
@@ -73,7 +73,7 @@ func (x ForeignEnum) String() string {
 	return proto.EnumName(ForeignEnum_name, int32(x))
 }
 func (ForeignEnum) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{1}
+	return fileDescriptor_e7c910178d599565, []int{1}
 }
 
 type TestAllTypes_NestedEnum int32
@@ -102,7 +102,7 @@ func (x TestAllTypes_NestedEnum) String() string {
 	return proto.EnumName(TestAllTypes_NestedEnum_name, int32(x))
 }
 func (TestAllTypes_NestedEnum) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{2, 0}
+	return fileDescriptor_e7c910178d599565, []int{2, 0}
 }
 
 // Represents a single test case's input.  The testee should:
@@ -129,7 +129,7 @@ func (m *ConformanceRequest) Reset()         { *m = ConformanceRequest{} }
 func (m *ConformanceRequest) String() string { return proto.CompactTextString(m) }
 func (*ConformanceRequest) ProtoMessage()    {}
 func (*ConformanceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{0}
+	return fileDescriptor_e7c910178d599565, []int{0}
 }
 func (m *ConformanceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConformanceRequest.Unmarshal(m, b)
@@ -278,7 +278,7 @@ func (m *ConformanceResponse) Reset()         { *m = ConformanceResponse{} }
 func (m *ConformanceResponse) String() string { return proto.CompactTextString(m) }
 func (*ConformanceResponse) ProtoMessage()    {}
 func (*ConformanceResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{1}
+	return fileDescriptor_e7c910178d599565, []int{1}
 }
 func (m *ConformanceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConformanceResponse.Unmarshal(m, b)
@@ -640,7 +640,7 @@ func (m *TestAllTypes) Reset()         { *m = TestAllTypes{} }
 func (m *TestAllTypes) String() string { return proto.CompactTextString(m) }
 func (*TestAllTypes) ProtoMessage()    {}
 func (*TestAllTypes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{2}
+	return fileDescriptor_e7c910178d599565, []int{2}
 }
 func (m *TestAllTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestAllTypes.Unmarshal(m, b)
@@ -1562,7 +1562,7 @@ func (m *TestAllTypes_NestedMessage) Reset()         { *m = TestAllTypes_NestedM
 func (m *TestAllTypes_NestedMessage) String() string { return proto.CompactTextString(m) }
 func (*TestAllTypes_NestedMessage) ProtoMessage()    {}
 func (*TestAllTypes_NestedMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{2, 0}
+	return fileDescriptor_e7c910178d599565, []int{2, 0}
 }
 func (m *TestAllTypes_NestedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestAllTypes_NestedMessage.Unmarshal(m, b)
@@ -1607,7 +1607,7 @@ func (m *ForeignMessage) Reset()         { *m = ForeignMessage{} }
 func (m *ForeignMessage) String() string { return proto.CompactTextString(m) }
 func (*ForeignMessage) ProtoMessage()    {}
 func (*ForeignMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_conformance_48ac832451f5d6c3, []int{3}
+	return fileDescriptor_e7c910178d599565, []int{3}
 }
 func (m *ForeignMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForeignMessage.Unmarshal(m, b)
@@ -1664,9 +1664,9 @@ func init() {
 	proto.RegisterEnum("conformance.TestAllTypes_NestedEnum", TestAllTypes_NestedEnum_name, TestAllTypes_NestedEnum_value)
 }
 
-func init() { proto.RegisterFile("conformance.proto", fileDescriptor_conformance_48ac832451f5d6c3) }
+func init() { proto.RegisterFile("conformance.proto", fileDescriptor_e7c910178d599565) }
 
-var fileDescriptor_conformance_48ac832451f5d6c3 = []byte{
+var fileDescriptor_e7c910178d599565 = []byte{
 	// 2600 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x5a, 0x5b, 0x73, 0x13, 0xc9,
 	0x15, 0xf6, 0x68, 0xc0, 0x36, 0x2d, 0xd9, 0x96, 0xdb, 0xb7, 0xc6, 0x50, 0xcb, 0x60, 0x96, 0x20,

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -41,7 +41,7 @@ func (x Numeral) String() string {
 	return proto.EnumName(Numeral_name, int32(x))
 }
 func (Numeral) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_more_test_objects_bef0d79b901f4c4a, []int{0}
+	return fileDescriptor_e6c135db3023e377, []int{0}
 }
 
 type Simple3 struct {
@@ -55,7 +55,7 @@ func (m *Simple3) Reset()         { *m = Simple3{} }
 func (m *Simple3) String() string { return proto.CompactTextString(m) }
 func (*Simple3) ProtoMessage()    {}
 func (*Simple3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_more_test_objects_bef0d79b901f4c4a, []int{0}
+	return fileDescriptor_e6c135db3023e377, []int{0}
 }
 func (m *Simple3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Simple3.Unmarshal(m, b)
@@ -93,7 +93,7 @@ func (m *SimpleSlice3) Reset()         { *m = SimpleSlice3{} }
 func (m *SimpleSlice3) String() string { return proto.CompactTextString(m) }
 func (*SimpleSlice3) ProtoMessage()    {}
 func (*SimpleSlice3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_more_test_objects_bef0d79b901f4c4a, []int{1}
+	return fileDescriptor_e6c135db3023e377, []int{1}
 }
 func (m *SimpleSlice3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleSlice3.Unmarshal(m, b)
@@ -131,7 +131,7 @@ func (m *SimpleMap3) Reset()         { *m = SimpleMap3{} }
 func (m *SimpleMap3) String() string { return proto.CompactTextString(m) }
 func (*SimpleMap3) ProtoMessage()    {}
 func (*SimpleMap3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_more_test_objects_bef0d79b901f4c4a, []int{2}
+	return fileDescriptor_e6c135db3023e377, []int{2}
 }
 func (m *SimpleMap3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleMap3.Unmarshal(m, b)
@@ -169,7 +169,7 @@ func (m *SimpleNull3) Reset()         { *m = SimpleNull3{} }
 func (m *SimpleNull3) String() string { return proto.CompactTextString(m) }
 func (*SimpleNull3) ProtoMessage()    {}
 func (*SimpleNull3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_more_test_objects_bef0d79b901f4c4a, []int{3}
+	return fileDescriptor_e6c135db3023e377, []int{3}
 }
 func (m *SimpleNull3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleNull3.Unmarshal(m, b)
@@ -216,7 +216,7 @@ func (m *Mappy) Reset()         { *m = Mappy{} }
 func (m *Mappy) String() string { return proto.CompactTextString(m) }
 func (*Mappy) ProtoMessage()    {}
 func (*Mappy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_more_test_objects_bef0d79b901f4c4a, []int{4}
+	return fileDescriptor_e6c135db3023e377, []int{4}
 }
 func (m *Mappy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Mappy.Unmarshal(m, b)
@@ -326,11 +326,9 @@ func init() {
 	proto.RegisterEnum("jsonpb.Numeral", Numeral_name, Numeral_value)
 }
 
-func init() {
-	proto.RegisterFile("more_test_objects.proto", fileDescriptor_more_test_objects_bef0d79b901f4c4a)
-}
+func init() { proto.RegisterFile("more_test_objects.proto", fileDescriptor_e6c135db3023e377) }
 
-var fileDescriptor_more_test_objects_bef0d79b901f4c4a = []byte{
+var fileDescriptor_e6c135db3023e377 = []byte{
 	// 526 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x94, 0xdd, 0x6b, 0xdb, 0x3c,
 	0x14, 0x87, 0x5f, 0x27, 0xf5, 0xd7, 0x49, 0xfb, 0x2e, 0x88, 0xb1, 0x99, 0xf4, 0x62, 0xc5, 0xb0,

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -59,7 +59,7 @@ func (x *Widget_Color) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Widget_Color) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{3, 0}
+	return fileDescriptor_e97c739a0ce14cc6, []int{3, 0}
 }
 
 // Test message for holding primitive types.
@@ -92,7 +92,7 @@ func (m *Simple) Reset()         { *m = Simple{} }
 func (m *Simple) String() string { return proto.CompactTextString(m) }
 func (*Simple) ProtoMessage()    {}
 func (*Simple) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{0}
+	return fileDescriptor_e97c739a0ce14cc6, []int{0}
 }
 func (m *Simple) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Simple.Unmarshal(m, b)
@@ -262,7 +262,7 @@ func (m *NonFinites) Reset()         { *m = NonFinites{} }
 func (m *NonFinites) String() string { return proto.CompactTextString(m) }
 func (*NonFinites) ProtoMessage()    {}
 func (*NonFinites) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{1}
+	return fileDescriptor_e97c739a0ce14cc6, []int{1}
 }
 func (m *NonFinites) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NonFinites.Unmarshal(m, b)
@@ -346,7 +346,7 @@ func (m *Repeats) Reset()         { *m = Repeats{} }
 func (m *Repeats) String() string { return proto.CompactTextString(m) }
 func (*Repeats) ProtoMessage()    {}
 func (*Repeats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{2}
+	return fileDescriptor_e97c739a0ce14cc6, []int{2}
 }
 func (m *Repeats) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Repeats.Unmarshal(m, b)
@@ -460,7 +460,7 @@ func (m *Widget) Reset()         { *m = Widget{} }
 func (m *Widget) String() string { return proto.CompactTextString(m) }
 func (*Widget) ProtoMessage()    {}
 func (*Widget) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{3}
+	return fileDescriptor_e97c739a0ce14cc6, []int{3}
 }
 func (m *Widget) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Widget.Unmarshal(m, b)
@@ -534,7 +534,7 @@ func (m *Maps) Reset()         { *m = Maps{} }
 func (m *Maps) String() string { return proto.CompactTextString(m) }
 func (*Maps) ProtoMessage()    {}
 func (*Maps) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{4}
+	return fileDescriptor_e97c739a0ce14cc6, []int{4}
 }
 func (m *Maps) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Maps.Unmarshal(m, b)
@@ -585,7 +585,7 @@ func (m *MsgWithOneof) Reset()         { *m = MsgWithOneof{} }
 func (m *MsgWithOneof) String() string { return proto.CompactTextString(m) }
 func (*MsgWithOneof) ProtoMessage()    {}
 func (*MsgWithOneof) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{5}
+	return fileDescriptor_e97c739a0ce14cc6, []int{5}
 }
 func (m *MsgWithOneof) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithOneof.Unmarshal(m, b)
@@ -807,7 +807,7 @@ func (m *Real) Reset()         { *m = Real{} }
 func (m *Real) String() string { return proto.CompactTextString(m) }
 func (*Real) ProtoMessage()    {}
 func (*Real) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{6}
+	return fileDescriptor_e97c739a0ce14cc6, []int{6}
 }
 
 var extRange_Real = []proto.ExtensionRange{
@@ -854,7 +854,7 @@ func (m *Complex) Reset()         { *m = Complex{} }
 func (m *Complex) String() string { return proto.CompactTextString(m) }
 func (*Complex) ProtoMessage()    {}
 func (*Complex) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{7}
+	return fileDescriptor_e97c739a0ce14cc6, []int{7}
 }
 
 var extRange_Complex = []proto.ExtensionRange{
@@ -923,7 +923,7 @@ func (m *KnownTypes) Reset()         { *m = KnownTypes{} }
 func (m *KnownTypes) String() string { return proto.CompactTextString(m) }
 func (*KnownTypes) ProtoMessage()    {}
 func (*KnownTypes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{8}
+	return fileDescriptor_e97c739a0ce14cc6, []int{8}
 }
 func (m *KnownTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_KnownTypes.Unmarshal(m, b)
@@ -1060,7 +1060,7 @@ func (m *MsgWithRequired) Reset()         { *m = MsgWithRequired{} }
 func (m *MsgWithRequired) String() string { return proto.CompactTextString(m) }
 func (*MsgWithRequired) ProtoMessage()    {}
 func (*MsgWithRequired) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{9}
+	return fileDescriptor_e97c739a0ce14cc6, []int{9}
 }
 func (m *MsgWithRequired) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequired.Unmarshal(m, b)
@@ -1100,7 +1100,7 @@ func (m *MsgWithIndirectRequired) Reset()         { *m = MsgWithIndirectRequired
 func (m *MsgWithIndirectRequired) String() string { return proto.CompactTextString(m) }
 func (*MsgWithIndirectRequired) ProtoMessage()    {}
 func (*MsgWithIndirectRequired) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{10}
+	return fileDescriptor_e97c739a0ce14cc6, []int{10}
 }
 func (m *MsgWithIndirectRequired) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithIndirectRequired.Unmarshal(m, b)
@@ -1152,7 +1152,7 @@ func (m *MsgWithRequiredBytes) Reset()         { *m = MsgWithRequiredBytes{} }
 func (m *MsgWithRequiredBytes) String() string { return proto.CompactTextString(m) }
 func (*MsgWithRequiredBytes) ProtoMessage()    {}
 func (*MsgWithRequiredBytes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{11}
+	return fileDescriptor_e97c739a0ce14cc6, []int{11}
 }
 func (m *MsgWithRequiredBytes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequiredBytes.Unmarshal(m, b)
@@ -1190,7 +1190,7 @@ func (m *MsgWithRequiredWKT) Reset()         { *m = MsgWithRequiredWKT{} }
 func (m *MsgWithRequiredWKT) String() string { return proto.CompactTextString(m) }
 func (*MsgWithRequiredWKT) ProtoMessage()    {}
 func (*MsgWithRequiredWKT) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_objects_a4d3e593ea3c686f, []int{12}
+	return fileDescriptor_e97c739a0ce14cc6, []int{12}
 }
 func (m *MsgWithRequiredWKT) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequiredWKT.Unmarshal(m, b)
@@ -1258,9 +1258,9 @@ func init() {
 	proto.RegisterExtension(E_Extm)
 }
 
-func init() { proto.RegisterFile("test_objects.proto", fileDescriptor_test_objects_a4d3e593ea3c686f) }
+func init() { proto.RegisterFile("test_objects.proto", fileDescriptor_e97c739a0ce14cc6) }
 
-var fileDescriptor_test_objects_a4d3e593ea3c686f = []byte{
+var fileDescriptor_e97c739a0ce14cc6 = []byte{
 	// 1460 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x56, 0xdd, 0x72, 0xdb, 0x44,
 	0x14, 0x8e, 0x24, 0xcb, 0xb6, 0x8e, 0xf3, 0xd7, 0x6d, 0xda, 0x2a, 0xa1, 0x14, 0x8d, 0x5b, 0x8a,

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -46,7 +46,7 @@ func (x Message_Humour) String() string {
 	return proto.EnumName(Message_Humour_name, int32(x))
 }
 func (Message_Humour) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_78ae00cd7e6e5e35, []int{0, 0}
+	return fileDescriptor_1c50d9b824d4ac38, []int{0, 0}
 }
 
 type Message struct {
@@ -78,7 +78,7 @@ func (m *Message) Reset()         { *m = Message{} }
 func (m *Message) String() string { return proto.CompactTextString(m) }
 func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_78ae00cd7e6e5e35, []int{0}
+	return fileDescriptor_1c50d9b824d4ac38, []int{0}
 }
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Message.Unmarshal(m, b)
@@ -243,7 +243,7 @@ func (m *Nested) Reset()         { *m = Nested{} }
 func (m *Nested) String() string { return proto.CompactTextString(m) }
 func (*Nested) ProtoMessage()    {}
 func (*Nested) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_78ae00cd7e6e5e35, []int{1}
+	return fileDescriptor_1c50d9b824d4ac38, []int{1}
 }
 func (m *Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Nested.Unmarshal(m, b)
@@ -288,7 +288,7 @@ func (m *MessageWithMap) Reset()         { *m = MessageWithMap{} }
 func (m *MessageWithMap) String() string { return proto.CompactTextString(m) }
 func (*MessageWithMap) ProtoMessage()    {}
 func (*MessageWithMap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_78ae00cd7e6e5e35, []int{2}
+	return fileDescriptor_1c50d9b824d4ac38, []int{2}
 }
 func (m *MessageWithMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageWithMap.Unmarshal(m, b)
@@ -326,7 +326,7 @@ func (m *IntMap) Reset()         { *m = IntMap{} }
 func (m *IntMap) String() string { return proto.CompactTextString(m) }
 func (*IntMap) ProtoMessage()    {}
 func (*IntMap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_78ae00cd7e6e5e35, []int{3}
+	return fileDescriptor_1c50d9b824d4ac38, []int{3}
 }
 func (m *IntMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_IntMap.Unmarshal(m, b)
@@ -364,7 +364,7 @@ func (m *IntMaps) Reset()         { *m = IntMaps{} }
 func (m *IntMaps) String() string { return proto.CompactTextString(m) }
 func (*IntMaps) ProtoMessage()    {}
 func (*IntMaps) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_78ae00cd7e6e5e35, []int{4}
+	return fileDescriptor_1c50d9b824d4ac38, []int{4}
 }
 func (m *IntMaps) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_IntMaps.Unmarshal(m, b)
@@ -408,7 +408,7 @@ func (m *TestUTF8) Reset()         { *m = TestUTF8{} }
 func (m *TestUTF8) String() string { return proto.CompactTextString(m) }
 func (*TestUTF8) ProtoMessage()    {}
 func (*TestUTF8) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_78ae00cd7e6e5e35, []int{5}
+	return fileDescriptor_1c50d9b824d4ac38, []int{5}
 }
 func (m *TestUTF8) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestUTF8.Unmarshal(m, b)
@@ -548,9 +548,9 @@ func init() {
 	proto.RegisterEnum("proto3_proto.Message_Humour", Message_Humour_name, Message_Humour_value)
 }
 
-func init() { proto.RegisterFile("proto3_proto/proto3.proto", fileDescriptor_proto3_78ae00cd7e6e5e35) }
+func init() { proto.RegisterFile("proto3_proto/proto3.proto", fileDescriptor_1c50d9b824d4ac38) }
 
-var fileDescriptor_proto3_78ae00cd7e6e5e35 = []byte{
+var fileDescriptor_1c50d9b824d4ac38 = []byte{
 	// 896 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x54, 0x6f, 0x6f, 0xdb, 0xb6,
 	0x13, 0xae, 0x2c, 0xff, 0x91, 0xcf, 0x76, 0xea, 0x1f, 0x7f, 0x6e, 0xc7, 0x7a, 0x1b, 0xa0, 0x79,

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -48,7 +48,7 @@ func (x *FOO) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FOO) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{0}
+	return fileDescriptor_8ca34d01332f1402, []int{0}
 }
 
 // An enum, for completeness.
@@ -122,7 +122,7 @@ func (x *GoTest_KIND) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (GoTest_KIND) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{2, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{2, 0}
 }
 
 type MyMessage_Color int32
@@ -161,7 +161,7 @@ func (x *MyMessage_Color) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (MyMessage_Color) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{13, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{13, 0}
 }
 
 type DefaultsMessage_DefaultsEnum int32
@@ -200,7 +200,7 @@ func (x *DefaultsMessage_DefaultsEnum) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (DefaultsMessage_DefaultsEnum) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{16, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{16, 0}
 }
 
 type Defaults_Color int32
@@ -239,7 +239,7 @@ func (x *Defaults_Color) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Defaults_Color) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{21, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{21, 0}
 }
 
 type RepeatedEnum_Color int32
@@ -272,7 +272,7 @@ func (x *RepeatedEnum_Color) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (RepeatedEnum_Color) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{23, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{23, 0}
 }
 
 type GoEnum struct {
@@ -286,7 +286,7 @@ func (m *GoEnum) Reset()         { *m = GoEnum{} }
 func (m *GoEnum) String() string { return proto.CompactTextString(m) }
 func (*GoEnum) ProtoMessage()    {}
 func (*GoEnum) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{0}
+	return fileDescriptor_8ca34d01332f1402, []int{0}
 }
 func (m *GoEnum) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoEnum.Unmarshal(m, b)
@@ -325,7 +325,7 @@ func (m *GoTestField) Reset()         { *m = GoTestField{} }
 func (m *GoTestField) String() string { return proto.CompactTextString(m) }
 func (*GoTestField) ProtoMessage()    {}
 func (*GoTestField) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{1}
+	return fileDescriptor_8ca34d01332f1402, []int{1}
 }
 func (m *GoTestField) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestField.Unmarshal(m, b)
@@ -458,7 +458,7 @@ func (m *GoTest) Reset()         { *m = GoTest{} }
 func (m *GoTest) String() string { return proto.CompactTextString(m) }
 func (*GoTest) ProtoMessage()    {}
 func (*GoTest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{2}
+	return fileDescriptor_8ca34d01332f1402, []int{2}
 }
 func (m *GoTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest.Unmarshal(m, b)
@@ -1082,7 +1082,7 @@ func (m *GoTest_RequiredGroup) Reset()         { *m = GoTest_RequiredGroup{} }
 func (m *GoTest_RequiredGroup) String() string { return proto.CompactTextString(m) }
 func (*GoTest_RequiredGroup) ProtoMessage()    {}
 func (*GoTest_RequiredGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{2, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{2, 0}
 }
 func (m *GoTest_RequiredGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_RequiredGroup.Unmarshal(m, b)
@@ -1120,7 +1120,7 @@ func (m *GoTest_RepeatedGroup) Reset()         { *m = GoTest_RepeatedGroup{} }
 func (m *GoTest_RepeatedGroup) String() string { return proto.CompactTextString(m) }
 func (*GoTest_RepeatedGroup) ProtoMessage()    {}
 func (*GoTest_RepeatedGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{2, 1}
+	return fileDescriptor_8ca34d01332f1402, []int{2, 1}
 }
 func (m *GoTest_RepeatedGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_RepeatedGroup.Unmarshal(m, b)
@@ -1158,7 +1158,7 @@ func (m *GoTest_OptionalGroup) Reset()         { *m = GoTest_OptionalGroup{} }
 func (m *GoTest_OptionalGroup) String() string { return proto.CompactTextString(m) }
 func (*GoTest_OptionalGroup) ProtoMessage()    {}
 func (*GoTest_OptionalGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{2, 2}
+	return fileDescriptor_8ca34d01332f1402, []int{2, 2}
 }
 func (m *GoTest_OptionalGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_OptionalGroup.Unmarshal(m, b)
@@ -1197,7 +1197,7 @@ func (m *GoTestRequiredGroupField) Reset()         { *m = GoTestRequiredGroupFie
 func (m *GoTestRequiredGroupField) String() string { return proto.CompactTextString(m) }
 func (*GoTestRequiredGroupField) ProtoMessage()    {}
 func (*GoTestRequiredGroupField) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{3}
+	return fileDescriptor_8ca34d01332f1402, []int{3}
 }
 func (m *GoTestRequiredGroupField) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestRequiredGroupField.Unmarshal(m, b)
@@ -1235,7 +1235,7 @@ func (m *GoTestRequiredGroupField_Group) Reset()         { *m = GoTestRequiredGr
 func (m *GoTestRequiredGroupField_Group) String() string { return proto.CompactTextString(m) }
 func (*GoTestRequiredGroupField_Group) ProtoMessage()    {}
 func (*GoTestRequiredGroupField_Group) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{3, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{3, 0}
 }
 func (m *GoTestRequiredGroupField_Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestRequiredGroupField_Group.Unmarshal(m, b)
@@ -1280,7 +1280,7 @@ func (m *GoSkipTest) Reset()         { *m = GoSkipTest{} }
 func (m *GoSkipTest) String() string { return proto.CompactTextString(m) }
 func (*GoSkipTest) ProtoMessage()    {}
 func (*GoSkipTest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{4}
+	return fileDescriptor_8ca34d01332f1402, []int{4}
 }
 func (m *GoSkipTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoSkipTest.Unmarshal(m, b)
@@ -1347,7 +1347,7 @@ func (m *GoSkipTest_SkipGroup) Reset()         { *m = GoSkipTest_SkipGroup{} }
 func (m *GoSkipTest_SkipGroup) String() string { return proto.CompactTextString(m) }
 func (*GoSkipTest_SkipGroup) ProtoMessage()    {}
 func (*GoSkipTest_SkipGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{4, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{4, 0}
 }
 func (m *GoSkipTest_SkipGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoSkipTest_SkipGroup.Unmarshal(m, b)
@@ -1394,7 +1394,7 @@ func (m *NonPackedTest) Reset()         { *m = NonPackedTest{} }
 func (m *NonPackedTest) String() string { return proto.CompactTextString(m) }
 func (*NonPackedTest) ProtoMessage()    {}
 func (*NonPackedTest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{5}
+	return fileDescriptor_8ca34d01332f1402, []int{5}
 }
 func (m *NonPackedTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NonPackedTest.Unmarshal(m, b)
@@ -1432,7 +1432,7 @@ func (m *PackedTest) Reset()         { *m = PackedTest{} }
 func (m *PackedTest) String() string { return proto.CompactTextString(m) }
 func (*PackedTest) ProtoMessage()    {}
 func (*PackedTest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{6}
+	return fileDescriptor_8ca34d01332f1402, []int{6}
 }
 func (m *PackedTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PackedTest.Unmarshal(m, b)
@@ -1471,7 +1471,7 @@ func (m *MaxTag) Reset()         { *m = MaxTag{} }
 func (m *MaxTag) String() string { return proto.CompactTextString(m) }
 func (*MaxTag) ProtoMessage()    {}
 func (*MaxTag) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{7}
+	return fileDescriptor_8ca34d01332f1402, []int{7}
 }
 func (m *MaxTag) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MaxTag.Unmarshal(m, b)
@@ -1510,7 +1510,7 @@ func (m *OldMessage) Reset()         { *m = OldMessage{} }
 func (m *OldMessage) String() string { return proto.CompactTextString(m) }
 func (*OldMessage) ProtoMessage()    {}
 func (*OldMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{8}
+	return fileDescriptor_8ca34d01332f1402, []int{8}
 }
 func (m *OldMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldMessage.Unmarshal(m, b)
@@ -1555,7 +1555,7 @@ func (m *OldMessage_Nested) Reset()         { *m = OldMessage_Nested{} }
 func (m *OldMessage_Nested) String() string { return proto.CompactTextString(m) }
 func (*OldMessage_Nested) ProtoMessage()    {}
 func (*OldMessage_Nested) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{8, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{8, 0}
 }
 func (m *OldMessage_Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldMessage_Nested.Unmarshal(m, b)
@@ -1597,7 +1597,7 @@ func (m *NewMessage) Reset()         { *m = NewMessage{} }
 func (m *NewMessage) String() string { return proto.CompactTextString(m) }
 func (*NewMessage) ProtoMessage()    {}
 func (*NewMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{9}
+	return fileDescriptor_8ca34d01332f1402, []int{9}
 }
 func (m *NewMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewMessage.Unmarshal(m, b)
@@ -1643,7 +1643,7 @@ func (m *NewMessage_Nested) Reset()         { *m = NewMessage_Nested{} }
 func (m *NewMessage_Nested) String() string { return proto.CompactTextString(m) }
 func (*NewMessage_Nested) ProtoMessage()    {}
 func (*NewMessage_Nested) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{9, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{9, 0}
 }
 func (m *NewMessage_Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewMessage_Nested.Unmarshal(m, b)
@@ -1690,7 +1690,7 @@ func (m *InnerMessage) Reset()         { *m = InnerMessage{} }
 func (m *InnerMessage) String() string { return proto.CompactTextString(m) }
 func (*InnerMessage) ProtoMessage()    {}
 func (*InnerMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{10}
+	return fileDescriptor_8ca34d01332f1402, []int{10}
 }
 func (m *InnerMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InnerMessage.Unmarshal(m, b)
@@ -1748,7 +1748,7 @@ func (m *OtherMessage) Reset()         { *m = OtherMessage{} }
 func (m *OtherMessage) String() string { return proto.CompactTextString(m) }
 func (*OtherMessage) ProtoMessage()    {}
 func (*OtherMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{11}
+	return fileDescriptor_8ca34d01332f1402, []int{11}
 }
 
 var extRange_OtherMessage = []proto.ExtensionRange{
@@ -1815,7 +1815,7 @@ func (m *RequiredInnerMessage) Reset()         { *m = RequiredInnerMessage{} }
 func (m *RequiredInnerMessage) String() string { return proto.CompactTextString(m) }
 func (*RequiredInnerMessage) ProtoMessage()    {}
 func (*RequiredInnerMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{12}
+	return fileDescriptor_8ca34d01332f1402, []int{12}
 }
 func (m *RequiredInnerMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RequiredInnerMessage.Unmarshal(m, b)
@@ -1866,7 +1866,7 @@ func (m *MyMessage) Reset()         { *m = MyMessage{} }
 func (m *MyMessage) String() string { return proto.CompactTextString(m) }
 func (*MyMessage) ProtoMessage()    {}
 func (*MyMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{13}
+	return fileDescriptor_8ca34d01332f1402, []int{13}
 }
 
 var extRange_MyMessage = []proto.ExtensionRange{
@@ -1989,7 +1989,7 @@ func (m *MyMessage_SomeGroup) Reset()         { *m = MyMessage_SomeGroup{} }
 func (m *MyMessage_SomeGroup) String() string { return proto.CompactTextString(m) }
 func (*MyMessage_SomeGroup) ProtoMessage()    {}
 func (*MyMessage_SomeGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{13, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{13, 0}
 }
 func (m *MyMessage_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MyMessage_SomeGroup.Unmarshal(m, b)
@@ -2028,7 +2028,7 @@ func (m *Ext) Reset()         { *m = Ext{} }
 func (m *Ext) String() string { return proto.CompactTextString(m) }
 func (*Ext) ProtoMessage()    {}
 func (*Ext) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{14}
+	return fileDescriptor_8ca34d01332f1402, []int{14}
 }
 func (m *Ext) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Ext.Unmarshal(m, b)
@@ -2102,7 +2102,7 @@ func (m *ComplexExtension) Reset()         { *m = ComplexExtension{} }
 func (m *ComplexExtension) String() string { return proto.CompactTextString(m) }
 func (*ComplexExtension) ProtoMessage()    {}
 func (*ComplexExtension) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{15}
+	return fileDescriptor_8ca34d01332f1402, []int{15}
 }
 func (m *ComplexExtension) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ComplexExtension.Unmarshal(m, b)
@@ -2154,7 +2154,7 @@ func (m *DefaultsMessage) Reset()         { *m = DefaultsMessage{} }
 func (m *DefaultsMessage) String() string { return proto.CompactTextString(m) }
 func (*DefaultsMessage) ProtoMessage()    {}
 func (*DefaultsMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{16}
+	return fileDescriptor_8ca34d01332f1402, []int{16}
 }
 
 var extRange_DefaultsMessage = []proto.ExtensionRange{
@@ -2193,7 +2193,7 @@ func (m *MyMessageSet) Reset()         { *m = MyMessageSet{} }
 func (m *MyMessageSet) String() string { return proto.CompactTextString(m) }
 func (*MyMessageSet) ProtoMessage()    {}
 func (*MyMessageSet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{17}
+	return fileDescriptor_8ca34d01332f1402, []int{17}
 }
 
 func (m *MyMessageSet) MarshalJSON() ([]byte, error) {
@@ -2238,7 +2238,7 @@ func (m *Empty) Reset()         { *m = Empty{} }
 func (m *Empty) String() string { return proto.CompactTextString(m) }
 func (*Empty) ProtoMessage()    {}
 func (*Empty) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{18}
+	return fileDescriptor_8ca34d01332f1402, []int{18}
 }
 func (m *Empty) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Empty.Unmarshal(m, b)
@@ -2269,7 +2269,7 @@ func (m *MessageList) Reset()         { *m = MessageList{} }
 func (m *MessageList) String() string { return proto.CompactTextString(m) }
 func (*MessageList) ProtoMessage()    {}
 func (*MessageList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{19}
+	return fileDescriptor_8ca34d01332f1402, []int{19}
 }
 func (m *MessageList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageList.Unmarshal(m, b)
@@ -2308,7 +2308,7 @@ func (m *MessageList_Message) Reset()         { *m = MessageList_Message{} }
 func (m *MessageList_Message) String() string { return proto.CompactTextString(m) }
 func (*MessageList_Message) ProtoMessage()    {}
 func (*MessageList_Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{19, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{19, 0}
 }
 func (m *MessageList_Message) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageList_Message.Unmarshal(m, b)
@@ -2354,7 +2354,7 @@ func (m *Strings) Reset()         { *m = Strings{} }
 func (m *Strings) String() string { return proto.CompactTextString(m) }
 func (*Strings) ProtoMessage()    {}
 func (*Strings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{20}
+	return fileDescriptor_8ca34d01332f1402, []int{20}
 }
 func (m *Strings) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Strings.Unmarshal(m, b)
@@ -2422,7 +2422,7 @@ func (m *Defaults) Reset()         { *m = Defaults{} }
 func (m *Defaults) String() string { return proto.CompactTextString(m) }
 func (*Defaults) ProtoMessage()    {}
 func (*Defaults) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{21}
+	return fileDescriptor_8ca34d01332f1402, []int{21}
 }
 func (m *Defaults) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Defaults.Unmarshal(m, b)
@@ -2607,7 +2607,7 @@ func (m *SubDefaults) Reset()         { *m = SubDefaults{} }
 func (m *SubDefaults) String() string { return proto.CompactTextString(m) }
 func (*SubDefaults) ProtoMessage()    {}
 func (*SubDefaults) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{22}
+	return fileDescriptor_8ca34d01332f1402, []int{22}
 }
 func (m *SubDefaults) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SubDefaults.Unmarshal(m, b)
@@ -2647,7 +2647,7 @@ func (m *RepeatedEnum) Reset()         { *m = RepeatedEnum{} }
 func (m *RepeatedEnum) String() string { return proto.CompactTextString(m) }
 func (*RepeatedEnum) ProtoMessage()    {}
 func (*RepeatedEnum) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{23}
+	return fileDescriptor_8ca34d01332f1402, []int{23}
 }
 func (m *RepeatedEnum) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepeatedEnum.Unmarshal(m, b)
@@ -2691,7 +2691,7 @@ func (m *MoreRepeated) Reset()         { *m = MoreRepeated{} }
 func (m *MoreRepeated) String() string { return proto.CompactTextString(m) }
 func (*MoreRepeated) ProtoMessage()    {}
 func (*MoreRepeated) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{24}
+	return fileDescriptor_8ca34d01332f1402, []int{24}
 }
 func (m *MoreRepeated) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MoreRepeated.Unmarshal(m, b)
@@ -2771,7 +2771,7 @@ func (m *GroupOld) Reset()         { *m = GroupOld{} }
 func (m *GroupOld) String() string { return proto.CompactTextString(m) }
 func (*GroupOld) ProtoMessage()    {}
 func (*GroupOld) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{25}
+	return fileDescriptor_8ca34d01332f1402, []int{25}
 }
 func (m *GroupOld) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupOld.Unmarshal(m, b)
@@ -2809,7 +2809,7 @@ func (m *GroupOld_G) Reset()         { *m = GroupOld_G{} }
 func (m *GroupOld_G) String() string { return proto.CompactTextString(m) }
 func (*GroupOld_G) ProtoMessage()    {}
 func (*GroupOld_G) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{25, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{25, 0}
 }
 func (m *GroupOld_G) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupOld_G.Unmarshal(m, b)
@@ -2847,7 +2847,7 @@ func (m *GroupNew) Reset()         { *m = GroupNew{} }
 func (m *GroupNew) String() string { return proto.CompactTextString(m) }
 func (*GroupNew) ProtoMessage()    {}
 func (*GroupNew) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{26}
+	return fileDescriptor_8ca34d01332f1402, []int{26}
 }
 func (m *GroupNew) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupNew.Unmarshal(m, b)
@@ -2886,7 +2886,7 @@ func (m *GroupNew_G) Reset()         { *m = GroupNew_G{} }
 func (m *GroupNew_G) String() string { return proto.CompactTextString(m) }
 func (*GroupNew_G) ProtoMessage()    {}
 func (*GroupNew_G) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{26, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{26, 0}
 }
 func (m *GroupNew_G) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupNew_G.Unmarshal(m, b)
@@ -2932,7 +2932,7 @@ func (m *FloatingPoint) Reset()         { *m = FloatingPoint{} }
 func (m *FloatingPoint) String() string { return proto.CompactTextString(m) }
 func (*FloatingPoint) ProtoMessage()    {}
 func (*FloatingPoint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{27}
+	return fileDescriptor_8ca34d01332f1402, []int{27}
 }
 func (m *FloatingPoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FloatingPoint.Unmarshal(m, b)
@@ -2980,7 +2980,7 @@ func (m *MessageWithMap) Reset()         { *m = MessageWithMap{} }
 func (m *MessageWithMap) String() string { return proto.CompactTextString(m) }
 func (*MessageWithMap) ProtoMessage()    {}
 func (*MessageWithMap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{28}
+	return fileDescriptor_8ca34d01332f1402, []int{28}
 }
 func (m *MessageWithMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageWithMap.Unmarshal(m, b)
@@ -3060,7 +3060,7 @@ func (m *Oneof) Reset()         { *m = Oneof{} }
 func (m *Oneof) String() string { return proto.CompactTextString(m) }
 func (*Oneof) ProtoMessage()    {}
 func (*Oneof) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{29}
+	return fileDescriptor_8ca34d01332f1402, []int{29}
 }
 func (m *Oneof) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Oneof.Unmarshal(m, b)
@@ -3663,7 +3663,7 @@ func (m *Oneof_F_Group) Reset()         { *m = Oneof_F_Group{} }
 func (m *Oneof_F_Group) String() string { return proto.CompactTextString(m) }
 func (*Oneof_F_Group) ProtoMessage()    {}
 func (*Oneof_F_Group) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{29, 0}
+	return fileDescriptor_8ca34d01332f1402, []int{29, 0}
 }
 func (m *Oneof_F_Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Oneof_F_Group.Unmarshal(m, b)
@@ -3711,7 +3711,7 @@ func (m *Communique) Reset()         { *m = Communique{} }
 func (m *Communique) String() string { return proto.CompactTextString(m) }
 func (*Communique) ProtoMessage()    {}
 func (*Communique) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{30}
+	return fileDescriptor_8ca34d01332f1402, []int{30}
 }
 func (m *Communique) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique.Unmarshal(m, b)
@@ -3971,7 +3971,7 @@ func (m *TestUTF8) Reset()         { *m = TestUTF8{} }
 func (m *TestUTF8) String() string { return proto.CompactTextString(m) }
 func (*TestUTF8) ProtoMessage()    {}
 func (*TestUTF8) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_ee9f66cbbebc227c, []int{31}
+	return fileDescriptor_8ca34d01332f1402, []int{31}
 }
 func (m *TestUTF8) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestUTF8.Unmarshal(m, b)
@@ -5007,9 +5007,9 @@ func init() {
 	proto.RegisterExtension(E_X250)
 }
 
-func init() { proto.RegisterFile("test_proto/test.proto", fileDescriptor_test_ee9f66cbbebc227c) }
+func init() { proto.RegisterFile("test_proto/test.proto", fileDescriptor_8ca34d01332f1402) }
 
-var fileDescriptor_test_ee9f66cbbebc227c = []byte{
+var fileDescriptor_8ca34d01332f1402 = []byte{
 	// 4795 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x5b, 0xd9, 0x73, 0x1b, 0x47,
 	0x7a, 0xd7, 0x0c, 0xee, 0x0f, 0x20, 0x31, 0x6c, 0xc9, 0x12, 0x44, 0x59, 0xd2, 0x08, 0x6b, 0xaf,

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -110,7 +110,7 @@ func (x *FieldDescriptorProto_Type) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FieldDescriptorProto_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{4, 0}
+	return fileDescriptor_e5baabe45344a177, []int{4, 0}
 }
 
 type FieldDescriptorProto_Label int32
@@ -150,7 +150,7 @@ func (x *FieldDescriptorProto_Label) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FieldDescriptorProto_Label) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{4, 1}
+	return fileDescriptor_e5baabe45344a177, []int{4, 1}
 }
 
 // Generated classes can be optimized for speed or code size.
@@ -191,7 +191,7 @@ func (x *FileOptions_OptimizeMode) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FileOptions_OptimizeMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{10, 0}
+	return fileDescriptor_e5baabe45344a177, []int{10, 0}
 }
 
 type FieldOptions_CType int32
@@ -231,7 +231,7 @@ func (x *FieldOptions_CType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FieldOptions_CType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{12, 0}
+	return fileDescriptor_e5baabe45344a177, []int{12, 0}
 }
 
 type FieldOptions_JSType int32
@@ -273,7 +273,7 @@ func (x *FieldOptions_JSType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (FieldOptions_JSType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{12, 1}
+	return fileDescriptor_e5baabe45344a177, []int{12, 1}
 }
 
 // Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
@@ -315,7 +315,7 @@ func (x *MethodOptions_IdempotencyLevel) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (MethodOptions_IdempotencyLevel) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{17, 0}
+	return fileDescriptor_e5baabe45344a177, []int{17, 0}
 }
 
 // The protocol compiler can output a FileDescriptorSet containing the .proto
@@ -331,7 +331,7 @@ func (m *FileDescriptorSet) Reset()         { *m = FileDescriptorSet{} }
 func (m *FileDescriptorSet) String() string { return proto.CompactTextString(m) }
 func (*FileDescriptorSet) ProtoMessage()    {}
 func (*FileDescriptorSet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{0}
+	return fileDescriptor_e5baabe45344a177, []int{0}
 }
 func (m *FileDescriptorSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FileDescriptorSet.Unmarshal(m, b)
@@ -392,7 +392,7 @@ func (m *FileDescriptorProto) Reset()         { *m = FileDescriptorProto{} }
 func (m *FileDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*FileDescriptorProto) ProtoMessage()    {}
 func (*FileDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{1}
+	return fileDescriptor_e5baabe45344a177, []int{1}
 }
 func (m *FileDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FileDescriptorProto.Unmarshal(m, b)
@@ -519,7 +519,7 @@ func (m *DescriptorProto) Reset()         { *m = DescriptorProto{} }
 func (m *DescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*DescriptorProto) ProtoMessage()    {}
 func (*DescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{2}
+	return fileDescriptor_e5baabe45344a177, []int{2}
 }
 func (m *DescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto.Unmarshal(m, b)
@@ -622,7 +622,7 @@ func (m *DescriptorProto_ExtensionRange) Reset()         { *m = DescriptorProto_
 func (m *DescriptorProto_ExtensionRange) String() string { return proto.CompactTextString(m) }
 func (*DescriptorProto_ExtensionRange) ProtoMessage()    {}
 func (*DescriptorProto_ExtensionRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{2, 0}
+	return fileDescriptor_e5baabe45344a177, []int{2, 0}
 }
 func (m *DescriptorProto_ExtensionRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto_ExtensionRange.Unmarshal(m, b)
@@ -678,7 +678,7 @@ func (m *DescriptorProto_ReservedRange) Reset()         { *m = DescriptorProto_R
 func (m *DescriptorProto_ReservedRange) String() string { return proto.CompactTextString(m) }
 func (*DescriptorProto_ReservedRange) ProtoMessage()    {}
 func (*DescriptorProto_ReservedRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{2, 1}
+	return fileDescriptor_e5baabe45344a177, []int{2, 1}
 }
 func (m *DescriptorProto_ReservedRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto_ReservedRange.Unmarshal(m, b)
@@ -725,7 +725,7 @@ func (m *ExtensionRangeOptions) Reset()         { *m = ExtensionRangeOptions{} }
 func (m *ExtensionRangeOptions) String() string { return proto.CompactTextString(m) }
 func (*ExtensionRangeOptions) ProtoMessage()    {}
 func (*ExtensionRangeOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{3}
+	return fileDescriptor_e5baabe45344a177, []int{3}
 }
 
 var extRange_ExtensionRangeOptions = []proto.ExtensionRange{
@@ -801,7 +801,7 @@ func (m *FieldDescriptorProto) Reset()         { *m = FieldDescriptorProto{} }
 func (m *FieldDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*FieldDescriptorProto) ProtoMessage()    {}
 func (*FieldDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{4}
+	return fileDescriptor_e5baabe45344a177, []int{4}
 }
 func (m *FieldDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FieldDescriptorProto.Unmarshal(m, b)
@@ -904,7 +904,7 @@ func (m *OneofDescriptorProto) Reset()         { *m = OneofDescriptorProto{} }
 func (m *OneofDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*OneofDescriptorProto) ProtoMessage()    {}
 func (*OneofDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{5}
+	return fileDescriptor_e5baabe45344a177, []int{5}
 }
 func (m *OneofDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OneofDescriptorProto.Unmarshal(m, b)
@@ -959,7 +959,7 @@ func (m *EnumDescriptorProto) Reset()         { *m = EnumDescriptorProto{} }
 func (m *EnumDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*EnumDescriptorProto) ProtoMessage()    {}
 func (*EnumDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{6}
+	return fileDescriptor_e5baabe45344a177, []int{6}
 }
 func (m *EnumDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumDescriptorProto.Unmarshal(m, b)
@@ -1032,7 +1032,7 @@ func (m *EnumDescriptorProto_EnumReservedRange) Reset()         { *m = EnumDescr
 func (m *EnumDescriptorProto_EnumReservedRange) String() string { return proto.CompactTextString(m) }
 func (*EnumDescriptorProto_EnumReservedRange) ProtoMessage()    {}
 func (*EnumDescriptorProto_EnumReservedRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{6, 0}
+	return fileDescriptor_e5baabe45344a177, []int{6, 0}
 }
 func (m *EnumDescriptorProto_EnumReservedRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumDescriptorProto_EnumReservedRange.Unmarshal(m, b)
@@ -1080,7 +1080,7 @@ func (m *EnumValueDescriptorProto) Reset()         { *m = EnumValueDescriptorPro
 func (m *EnumValueDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*EnumValueDescriptorProto) ProtoMessage()    {}
 func (*EnumValueDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{7}
+	return fileDescriptor_e5baabe45344a177, []int{7}
 }
 func (m *EnumValueDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumValueDescriptorProto.Unmarshal(m, b)
@@ -1135,7 +1135,7 @@ func (m *ServiceDescriptorProto) Reset()         { *m = ServiceDescriptorProto{}
 func (m *ServiceDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*ServiceDescriptorProto) ProtoMessage()    {}
 func (*ServiceDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{8}
+	return fileDescriptor_e5baabe45344a177, []int{8}
 }
 func (m *ServiceDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ServiceDescriptorProto.Unmarshal(m, b)
@@ -1197,7 +1197,7 @@ func (m *MethodDescriptorProto) Reset()         { *m = MethodDescriptorProto{} }
 func (m *MethodDescriptorProto) String() string { return proto.CompactTextString(m) }
 func (*MethodDescriptorProto) ProtoMessage()    {}
 func (*MethodDescriptorProto) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{9}
+	return fileDescriptor_e5baabe45344a177, []int{9}
 }
 func (m *MethodDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MethodDescriptorProto.Unmarshal(m, b)
@@ -1349,7 +1349,7 @@ func (m *FileOptions) Reset()         { *m = FileOptions{} }
 func (m *FileOptions) String() string { return proto.CompactTextString(m) }
 func (*FileOptions) ProtoMessage()    {}
 func (*FileOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{10}
+	return fileDescriptor_e5baabe45344a177, []int{10}
 }
 
 var extRange_FileOptions = []proto.ExtensionRange{
@@ -1584,7 +1584,7 @@ func (m *MessageOptions) Reset()         { *m = MessageOptions{} }
 func (m *MessageOptions) String() string { return proto.CompactTextString(m) }
 func (*MessageOptions) ProtoMessage()    {}
 func (*MessageOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{11}
+	return fileDescriptor_e5baabe45344a177, []int{11}
 }
 
 var extRange_MessageOptions = []proto.ExtensionRange{
@@ -1723,7 +1723,7 @@ func (m *FieldOptions) Reset()         { *m = FieldOptions{} }
 func (m *FieldOptions) String() string { return proto.CompactTextString(m) }
 func (*FieldOptions) ProtoMessage()    {}
 func (*FieldOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{12}
+	return fileDescriptor_e5baabe45344a177, []int{12}
 }
 
 var extRange_FieldOptions = []proto.ExtensionRange{
@@ -1819,7 +1819,7 @@ func (m *OneofOptions) Reset()         { *m = OneofOptions{} }
 func (m *OneofOptions) String() string { return proto.CompactTextString(m) }
 func (*OneofOptions) ProtoMessage()    {}
 func (*OneofOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{13}
+	return fileDescriptor_e5baabe45344a177, []int{13}
 }
 
 var extRange_OneofOptions = []proto.ExtensionRange{
@@ -1875,7 +1875,7 @@ func (m *EnumOptions) Reset()         { *m = EnumOptions{} }
 func (m *EnumOptions) String() string { return proto.CompactTextString(m) }
 func (*EnumOptions) ProtoMessage()    {}
 func (*EnumOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{14}
+	return fileDescriptor_e5baabe45344a177, []int{14}
 }
 
 var extRange_EnumOptions = []proto.ExtensionRange{
@@ -1944,7 +1944,7 @@ func (m *EnumValueOptions) Reset()         { *m = EnumValueOptions{} }
 func (m *EnumValueOptions) String() string { return proto.CompactTextString(m) }
 func (*EnumValueOptions) ProtoMessage()    {}
 func (*EnumValueOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{15}
+	return fileDescriptor_e5baabe45344a177, []int{15}
 }
 
 var extRange_EnumValueOptions = []proto.ExtensionRange{
@@ -2006,7 +2006,7 @@ func (m *ServiceOptions) Reset()         { *m = ServiceOptions{} }
 func (m *ServiceOptions) String() string { return proto.CompactTextString(m) }
 func (*ServiceOptions) ProtoMessage()    {}
 func (*ServiceOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{16}
+	return fileDescriptor_e5baabe45344a177, []int{16}
 }
 
 var extRange_ServiceOptions = []proto.ExtensionRange{
@@ -2069,7 +2069,7 @@ func (m *MethodOptions) Reset()         { *m = MethodOptions{} }
 func (m *MethodOptions) String() string { return proto.CompactTextString(m) }
 func (*MethodOptions) ProtoMessage()    {}
 func (*MethodOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{17}
+	return fileDescriptor_e5baabe45344a177, []int{17}
 }
 
 var extRange_MethodOptions = []proto.ExtensionRange{
@@ -2146,7 +2146,7 @@ func (m *UninterpretedOption) Reset()         { *m = UninterpretedOption{} }
 func (m *UninterpretedOption) String() string { return proto.CompactTextString(m) }
 func (*UninterpretedOption) ProtoMessage()    {}
 func (*UninterpretedOption) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{18}
+	return fileDescriptor_e5baabe45344a177, []int{18}
 }
 func (m *UninterpretedOption) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UninterpretedOption.Unmarshal(m, b)
@@ -2232,7 +2232,7 @@ func (m *UninterpretedOption_NamePart) Reset()         { *m = UninterpretedOptio
 func (m *UninterpretedOption_NamePart) String() string { return proto.CompactTextString(m) }
 func (*UninterpretedOption_NamePart) ProtoMessage()    {}
 func (*UninterpretedOption_NamePart) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{18, 0}
+	return fileDescriptor_e5baabe45344a177, []int{18, 0}
 }
 func (m *UninterpretedOption_NamePart) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UninterpretedOption_NamePart.Unmarshal(m, b)
@@ -2322,7 +2322,7 @@ func (m *SourceCodeInfo) Reset()         { *m = SourceCodeInfo{} }
 func (m *SourceCodeInfo) String() string { return proto.CompactTextString(m) }
 func (*SourceCodeInfo) ProtoMessage()    {}
 func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{19}
+	return fileDescriptor_e5baabe45344a177, []int{19}
 }
 func (m *SourceCodeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SourceCodeInfo.Unmarshal(m, b)
@@ -2439,7 +2439,7 @@ func (m *SourceCodeInfo_Location) Reset()         { *m = SourceCodeInfo_Location
 func (m *SourceCodeInfo_Location) String() string { return proto.CompactTextString(m) }
 func (*SourceCodeInfo_Location) ProtoMessage()    {}
 func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{19, 0}
+	return fileDescriptor_e5baabe45344a177, []int{19, 0}
 }
 func (m *SourceCodeInfo_Location) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SourceCodeInfo_Location.Unmarshal(m, b)
@@ -2510,7 +2510,7 @@ func (m *GeneratedCodeInfo) Reset()         { *m = GeneratedCodeInfo{} }
 func (m *GeneratedCodeInfo) String() string { return proto.CompactTextString(m) }
 func (*GeneratedCodeInfo) ProtoMessage()    {}
 func (*GeneratedCodeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{20}
+	return fileDescriptor_e5baabe45344a177, []int{20}
 }
 func (m *GeneratedCodeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GeneratedCodeInfo.Unmarshal(m, b)
@@ -2559,7 +2559,7 @@ func (m *GeneratedCodeInfo_Annotation) Reset()         { *m = GeneratedCodeInfo_
 func (m *GeneratedCodeInfo_Annotation) String() string { return proto.CompactTextString(m) }
 func (*GeneratedCodeInfo_Annotation) ProtoMessage()    {}
 func (*GeneratedCodeInfo_Annotation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_descriptor_4df4cb5f42392df6, []int{20, 0}
+	return fileDescriptor_e5baabe45344a177, []int{20, 0}
 }
 func (m *GeneratedCodeInfo_Annotation) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GeneratedCodeInfo_Annotation.Unmarshal(m, b)
@@ -2643,11 +2643,9 @@ func init() {
 	proto.RegisterEnum("google.protobuf.MethodOptions_IdempotencyLevel", MethodOptions_IdempotencyLevel_name, MethodOptions_IdempotencyLevel_value)
 }
 
-func init() {
-	proto.RegisterFile("google/protobuf/descriptor.proto", fileDescriptor_descriptor_4df4cb5f42392df6)
-}
+func init() { proto.RegisterFile("google/protobuf/descriptor.proto", fileDescriptor_e5baabe45344a177) }
 
-var fileDescriptor_descriptor_4df4cb5f42392df6 = []byte{
+var fileDescriptor_e5baabe45344a177 = []byte{
 	// 2555 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x59, 0xdd, 0x6e, 0x1b, 0xc7,
 	0xf5, 0xcf, 0xf2, 0x4b, 0xe4, 0x21, 0x45, 0x8d, 0x46, 0x8a, 0xbd, 0x56, 0x3e, 0x2c, 0x33, 0x1f,

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -45,7 +45,7 @@ func (x DeprecatedEnum) String() string {
 	return proto.EnumName(DeprecatedEnum_name, int32(x))
 }
 func (DeprecatedEnum) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_deprecated_9e1889ba21817fad, []int{0}
+	return fileDescriptor_f64ba265cd7eae3f, []int{0}
 }
 
 // DeprecatedRequest is a request to DeprecatedCall.
@@ -61,7 +61,7 @@ func (m *DeprecatedRequest) Reset()         { *m = DeprecatedRequest{} }
 func (m *DeprecatedRequest) String() string { return proto.CompactTextString(m) }
 func (*DeprecatedRequest) ProtoMessage()    {}
 func (*DeprecatedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_deprecated_9e1889ba21817fad, []int{0}
+	return fileDescriptor_f64ba265cd7eae3f, []int{0}
 }
 func (m *DeprecatedRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedRequest.Unmarshal(m, b)
@@ -94,7 +94,7 @@ func (m *DeprecatedResponse) Reset()         { *m = DeprecatedResponse{} }
 func (m *DeprecatedResponse) String() string { return proto.CompactTextString(m) }
 func (*DeprecatedResponse) ProtoMessage()    {}
 func (*DeprecatedResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_deprecated_9e1889ba21817fad, []int{1}
+	return fileDescriptor_f64ba265cd7eae3f, []int{1}
 }
 func (m *DeprecatedResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedResponse.Unmarshal(m, b)
@@ -209,11 +209,9 @@ var _DeprecatedService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "deprecated/deprecated.proto",
 }
 
-func init() {
-	proto.RegisterFile("deprecated/deprecated.proto", fileDescriptor_deprecated_9e1889ba21817fad)
-}
+func init() { proto.RegisterFile("deprecated/deprecated.proto", fileDescriptor_f64ba265cd7eae3f) }
 
-var fileDescriptor_deprecated_9e1889ba21817fad = []byte{
+var fileDescriptor_f64ba265cd7eae3f = []byte{
 	// 248 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4e, 0x49, 0x2d, 0x28,
 	0x4a, 0x4d, 0x4e, 0x2c, 0x49, 0x4d, 0xd1, 0x47, 0x30, 0xf5, 0x0a, 0x8a, 0xf2, 0x4b, 0xf2, 0x85,

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -30,7 +30,7 @@ func (m *BaseMessage) Reset()         { *m = BaseMessage{} }
 func (m *BaseMessage) String() string { return proto.CompactTextString(m) }
 func (*BaseMessage) ProtoMessage()    {}
 func (*BaseMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_base_41d3c712c9fc37fc, []int{0}
+	return fileDescriptor_2fbd53bac0b7ca8a, []int{0}
 }
 
 var extRange_BaseMessage = []proto.ExtensionRange{
@@ -78,7 +78,7 @@ func (m *OldStyleMessage) Reset()         { *m = OldStyleMessage{} }
 func (m *OldStyleMessage) String() string { return proto.CompactTextString(m) }
 func (*OldStyleMessage) ProtoMessage()    {}
 func (*OldStyleMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_base_41d3c712c9fc37fc, []int{1}
+	return fileDescriptor_2fbd53bac0b7ca8a, []int{1}
 }
 
 func (m *OldStyleMessage) MarshalJSON() ([]byte, error) {
@@ -119,10 +119,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("extension_base/extension_base.proto", fileDescriptor_extension_base_41d3c712c9fc37fc)
+	proto.RegisterFile("extension_base/extension_base.proto", fileDescriptor_2fbd53bac0b7ca8a)
 }
 
-var fileDescriptor_extension_base_41d3c712c9fc37fc = []byte{
+var fileDescriptor_2fbd53bac0b7ca8a = []byte{
 	// 179 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x4e, 0xad, 0x28, 0x49,
 	0xcd, 0x2b, 0xce, 0xcc, 0xcf, 0x8b, 0x4f, 0x4a, 0x2c, 0x4e, 0xd5, 0x47, 0xe5, 0xea, 0x15, 0x14,

--- a/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
+++ b/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
@@ -29,7 +29,7 @@ func (m *ExtraMessage) Reset()         { *m = ExtraMessage{} }
 func (m *ExtraMessage) String() string { return proto.CompactTextString(m) }
 func (*ExtraMessage) ProtoMessage()    {}
 func (*ExtraMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_extra_83adf2410f49f816, []int{0}
+	return fileDescriptor_fce75f5a63502cd5, []int{0}
 }
 func (m *ExtraMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExtraMessage.Unmarshal(m, b)
@@ -61,10 +61,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("extension_extra/extension_extra.proto", fileDescriptor_extension_extra_83adf2410f49f816)
+	proto.RegisterFile("extension_extra/extension_extra.proto", fileDescriptor_fce75f5a63502cd5)
 }
 
-var fileDescriptor_extension_extra_83adf2410f49f816 = []byte{
+var fileDescriptor_fce75f5a63502cd5 = []byte{
 	// 133 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x4d, 0xad, 0x28, 0x49,
 	0xcd, 0x2b, 0xce, 0xcc, 0xcf, 0x8b, 0x4f, 0xad, 0x28, 0x29, 0x4a, 0xd4, 0x47, 0xe3, 0xeb, 0x15,

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -32,7 +32,7 @@ func (m *UserMessage) Reset()         { *m = UserMessage{} }
 func (m *UserMessage) String() string { return proto.CompactTextString(m) }
 func (*UserMessage) ProtoMessage()    {}
 func (*UserMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{0}
+	return fileDescriptor_359ba8abf543ca10, []int{0}
 }
 func (m *UserMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UserMessage.Unmarshal(m, b)
@@ -78,7 +78,7 @@ func (m *LoudMessage) Reset()         { *m = LoudMessage{} }
 func (m *LoudMessage) String() string { return proto.CompactTextString(m) }
 func (*LoudMessage) ProtoMessage()    {}
 func (*LoudMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{1}
+	return fileDescriptor_359ba8abf543ca10, []int{1}
 }
 
 var extRange_LoudMessage = []proto.ExtensionRange{
@@ -126,7 +126,7 @@ func (m *LoginMessage) Reset()         { *m = LoginMessage{} }
 func (m *LoginMessage) String() string { return proto.CompactTextString(m) }
 func (*LoginMessage) ProtoMessage()    {}
 func (*LoginMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{2}
+	return fileDescriptor_359ba8abf543ca10, []int{2}
 }
 func (m *LoginMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoginMessage.Unmarshal(m, b)
@@ -166,7 +166,7 @@ func (m *Detail) Reset()         { *m = Detail{} }
 func (m *Detail) String() string { return proto.CompactTextString(m) }
 func (*Detail) ProtoMessage()    {}
 func (*Detail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{3}
+	return fileDescriptor_359ba8abf543ca10, []int{3}
 }
 func (m *Detail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Detail.Unmarshal(m, b)
@@ -205,7 +205,7 @@ func (m *Announcement) Reset()         { *m = Announcement{} }
 func (m *Announcement) String() string { return proto.CompactTextString(m) }
 func (*Announcement) ProtoMessage()    {}
 func (*Announcement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{4}
+	return fileDescriptor_359ba8abf543ca10, []int{4}
 }
 func (m *Announcement) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Announcement.Unmarshal(m, b)
@@ -254,7 +254,7 @@ func (m *OldStyleParcel) Reset()         { *m = OldStyleParcel{} }
 func (m *OldStyleParcel) String() string { return proto.CompactTextString(m) }
 func (*OldStyleParcel) ProtoMessage()    {}
 func (*OldStyleParcel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_extension_user_af41b5e0bdfb7846, []int{5}
+	return fileDescriptor_359ba8abf543ca10, []int{5}
 }
 func (m *OldStyleParcel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldStyleParcel.Unmarshal(m, b)
@@ -362,10 +362,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("extension_user/extension_user.proto", fileDescriptor_extension_user_af41b5e0bdfb7846)
+	proto.RegisterFile("extension_user/extension_user.proto", fileDescriptor_359ba8abf543ca10)
 }
 
-var fileDescriptor_extension_user_af41b5e0bdfb7846 = []byte{
+var fileDescriptor_359ba8abf543ca10 = []byte{
 	// 492 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0x51, 0x6f, 0x94, 0x40,
 	0x10, 0x0e, 0x6d, 0x8f, 0x5e, 0x87, 0x6b, 0xad, 0xa8, 0xcd, 0xa5, 0x6a, 0x25, 0x18, 0x13, 0x62,

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -33,7 +33,7 @@ func (m *SimpleRequest) Reset()         { *m = SimpleRequest{} }
 func (m *SimpleRequest) String() string { return proto.CompactTextString(m) }
 func (*SimpleRequest) ProtoMessage()    {}
 func (*SimpleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_grpc_65bf3902e49ee873, []int{0}
+	return fileDescriptor_81ea47a3f88c2082, []int{0}
 }
 func (m *SimpleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleRequest.Unmarshal(m, b)
@@ -63,7 +63,7 @@ func (m *SimpleResponse) Reset()         { *m = SimpleResponse{} }
 func (m *SimpleResponse) String() string { return proto.CompactTextString(m) }
 func (*SimpleResponse) ProtoMessage()    {}
 func (*SimpleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_grpc_65bf3902e49ee873, []int{1}
+	return fileDescriptor_81ea47a3f88c2082, []int{1}
 }
 func (m *SimpleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleResponse.Unmarshal(m, b)
@@ -93,7 +93,7 @@ func (m *StreamMsg) Reset()         { *m = StreamMsg{} }
 func (m *StreamMsg) String() string { return proto.CompactTextString(m) }
 func (*StreamMsg) ProtoMessage()    {}
 func (*StreamMsg) Descriptor() ([]byte, []int) {
-	return fileDescriptor_grpc_65bf3902e49ee873, []int{2}
+	return fileDescriptor_81ea47a3f88c2082, []int{2}
 }
 func (m *StreamMsg) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg.Unmarshal(m, b)
@@ -123,7 +123,7 @@ func (m *StreamMsg2) Reset()         { *m = StreamMsg2{} }
 func (m *StreamMsg2) String() string { return proto.CompactTextString(m) }
 func (*StreamMsg2) ProtoMessage()    {}
 func (*StreamMsg2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_grpc_65bf3902e49ee873, []int{3}
+	return fileDescriptor_81ea47a3f88c2082, []int{3}
 }
 func (m *StreamMsg2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg2.Unmarshal(m, b)
@@ -421,9 +421,9 @@ var _Test_serviceDesc = grpc.ServiceDesc{
 	Metadata: "grpc/grpc.proto",
 }
 
-func init() { proto.RegisterFile("grpc/grpc.proto", fileDescriptor_grpc_65bf3902e49ee873) }
+func init() { proto.RegisterFile("grpc/grpc.proto", fileDescriptor_81ea47a3f88c2082) }
 
-var fileDescriptor_grpc_65bf3902e49ee873 = []byte{
+var fileDescriptor_81ea47a3f88c2082 = []byte{
 	// 244 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x4f, 0x2f, 0x2a, 0x48,
 	0xd6, 0x07, 0x11, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x3c, 0x60, 0x76, 0x49, 0x6a, 0x71,

--- a/protoc-gen-go/testdata/import_public/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/a.pb.go
@@ -45,7 +45,7 @@ func (m *Public) Reset()         { *m = Public{} }
 func (m *Public) String() string { return proto.CompactTextString(m) }
 func (*Public) ProtoMessage()    {}
 func (*Public) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a_c0314c022b7c17d8, []int{0}
+	return fileDescriptor_73b7577c95fa6b70, []int{0}
 }
 func (m *Public) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Public.Unmarshal(m, b)
@@ -90,9 +90,9 @@ func init() {
 	proto.RegisterType((*Public)(nil), "goproto.test.import_public.Public")
 }
 
-func init() { proto.RegisterFile("import_public/a.proto", fileDescriptor_a_c0314c022b7c17d8) }
+func init() { proto.RegisterFile("import_public/a.proto", fileDescriptor_73b7577c95fa6b70) }
 
-var fileDescriptor_a_c0314c022b7c17d8 = []byte{
+var fileDescriptor_73b7577c95fa6b70 = []byte{
 	// 200 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xcd, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x89, 0x2f, 0x28, 0x4d, 0xca, 0xc9, 0x4c, 0xd6, 0x4f, 0xd4, 0x2b, 0x28, 0xca, 0x2f,

--- a/protoc-gen-go/testdata/import_public/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/b.pb.go
@@ -31,7 +31,7 @@ func (m *Local) Reset()         { *m = Local{} }
 func (m *Local) String() string { return proto.CompactTextString(m) }
 func (*Local) ProtoMessage()    {}
 func (*Local) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b_7f20a805fad67bd0, []int{0}
+	return fileDescriptor_84995586b3d09710, []int{0}
 }
 func (m *Local) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Local.Unmarshal(m, b)
@@ -69,9 +69,9 @@ func init() {
 	proto.RegisterType((*Local)(nil), "goproto.test.import_public.Local")
 }
 
-func init() { proto.RegisterFile("import_public/b.proto", fileDescriptor_b_7f20a805fad67bd0) }
+func init() { proto.RegisterFile("import_public/b.proto", fileDescriptor_84995586b3d09710) }
 
-var fileDescriptor_b_7f20a805fad67bd0 = []byte{
+var fileDescriptor_84995586b3d09710 = []byte{
 	// 174 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xcd, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x89, 0x2f, 0x28, 0x4d, 0xca, 0xc9, 0x4c, 0xd6, 0x4f, 0xd2, 0x2b, 0x28, 0xca, 0x2f,

--- a/protoc-gen-go/testdata/import_public/sub/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/a.pb.go
@@ -35,7 +35,7 @@ func (x E) String() string {
 	return proto.EnumName(E_name, int32(x))
 }
 func (E) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_a_91ca0264a534463a, []int{0}
+	return fileDescriptor_382f7805394b5c4e, []int{0}
 }
 
 type M struct {
@@ -50,7 +50,7 @@ func (m *M) Reset()         { *m = M{} }
 func (m *M) String() string { return proto.CompactTextString(m) }
 func (*M) ProtoMessage()    {}
 func (*M) Descriptor() ([]byte, []int) {
-	return fileDescriptor_a_91ca0264a534463a, []int{0}
+	return fileDescriptor_382f7805394b5c4e, []int{0}
 }
 func (m *M) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M.Unmarshal(m, b)
@@ -82,9 +82,9 @@ func init() {
 	proto.RegisterEnum("goproto.test.import_public.sub.E", E_name, E_value)
 }
 
-func init() { proto.RegisterFile("import_public/sub/a.proto", fileDescriptor_a_91ca0264a534463a) }
+func init() { proto.RegisterFile("import_public/sub/a.proto", fileDescriptor_382f7805394b5c4e) }
 
-var fileDescriptor_a_91ca0264a534463a = []byte{
+var fileDescriptor_382f7805394b5c4e = []byte{
 	// 172 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x89, 0x2f, 0x28, 0x4d, 0xca, 0xc9, 0x4c, 0xd6, 0x2f, 0x2e, 0x4d, 0xd2, 0x4f, 0xd4,

--- a/protoc-gen-go/testdata/import_public/sub/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/b.pb.go
@@ -28,7 +28,7 @@ func (m *M2) Reset()         { *m = M2{} }
 func (m *M2) String() string { return proto.CompactTextString(m) }
 func (*M2) ProtoMessage()    {}
 func (*M2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b_eba25180453d86b4, []int{0}
+	return fileDescriptor_fc66afda3d7c2232, []int{0}
 }
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
@@ -52,9 +52,9 @@ func init() {
 	proto.RegisterType((*M2)(nil), "goproto.test.import_public.sub.M2")
 }
 
-func init() { proto.RegisterFile("import_public/sub/b.proto", fileDescriptor_b_eba25180453d86b4) }
+func init() { proto.RegisterFile("import_public/sub/b.proto", fileDescriptor_fc66afda3d7c2232) }
 
-var fileDescriptor_b_eba25180453d86b4 = []byte{
+var fileDescriptor_fc66afda3d7c2232 = []byte{
 	// 127 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x89, 0x2f, 0x28, 0x4d, 0xca, 0xc9, 0x4c, 0xd6, 0x2f, 0x2e, 0x4d, 0xd2, 0x4f, 0xd2,

--- a/protoc-gen-go/testdata/imports/fmt/m.pb.go
+++ b/protoc-gen-go/testdata/imports/fmt/m.pb.go
@@ -28,7 +28,7 @@ func (m *M) Reset()         { *m = M{} }
 func (m *M) String() string { return proto.CompactTextString(m) }
 func (*M) ProtoMessage()    {}
 func (*M) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m_867dd34c461422b8, []int{0}
+	return fileDescriptor_72c126fcd452e392, []int{0}
 }
 func (m *M) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M.Unmarshal(m, b)
@@ -52,9 +52,9 @@ func init() {
 	proto.RegisterType((*M)(nil), "fmt.M")
 }
 
-func init() { proto.RegisterFile("imports/fmt/m.proto", fileDescriptor_m_867dd34c461422b8) }
+func init() { proto.RegisterFile("imports/fmt/m.proto", fileDescriptor_72c126fcd452e392) }
 
-var fileDescriptor_m_867dd34c461422b8 = []byte{
+var fileDescriptor_72c126fcd452e392 = []byte{
 	// 109 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xce, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x4f, 0xcb, 0x2d, 0xd1, 0xcf, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17,

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -35,7 +35,7 @@ func (x E1) String() string {
 	return proto.EnumName(E1_name, int32(x))
 }
 func (E1) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_m1_56a2598431d21e61, []int{0}
+	return fileDescriptor_c1091de3fa870a14, []int{0}
 }
 
 type M1 struct {
@@ -48,7 +48,7 @@ func (m *M1) Reset()         { *m = M1{} }
 func (m *M1) String() string { return proto.CompactTextString(m) }
 func (*M1) ProtoMessage()    {}
 func (*M1) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m1_56a2598431d21e61, []int{0}
+	return fileDescriptor_c1091de3fa870a14, []int{0}
 }
 func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
@@ -79,7 +79,7 @@ func (m *M1_1) Reset()         { *m = M1_1{} }
 func (m *M1_1) String() string { return proto.CompactTextString(m) }
 func (*M1_1) ProtoMessage()    {}
 func (*M1_1) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m1_56a2598431d21e61, []int{1}
+	return fileDescriptor_c1091de3fa870a14, []int{1}
 }
 func (m *M1_1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1_1.Unmarshal(m, b)
@@ -112,9 +112,9 @@ func init() {
 	proto.RegisterEnum("test.a.E1", E1_name, E1_value)
 }
 
-func init() { proto.RegisterFile("imports/test_a_1/m1.proto", fileDescriptor_m1_56a2598431d21e61) }
+func init() { proto.RegisterFile("imports/test_a_1/m1.proto", fileDescriptor_c1091de3fa870a14) }
 
-var fileDescriptor_m1_56a2598431d21e61 = []byte{
+var fileDescriptor_c1091de3fa870a14 = []byte{
 	// 165 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd4, 0xcf, 0x35, 0xd4,

--- a/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
@@ -28,7 +28,7 @@ func (m *M2) Reset()         { *m = M2{} }
 func (m *M2) String() string { return proto.CompactTextString(m) }
 func (*M2) ProtoMessage()    {}
 func (*M2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m2_ccd6356c045a9ac3, []int{0}
+	return fileDescriptor_20cf27515c0d621c, []int{0}
 }
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
@@ -52,9 +52,9 @@ func init() {
 	proto.RegisterType((*M2)(nil), "test.a.M2")
 }
 
-func init() { proto.RegisterFile("imports/test_a_1/m2.proto", fileDescriptor_m2_ccd6356c045a9ac3) }
+func init() { proto.RegisterFile("imports/test_a_1/m2.proto", fileDescriptor_20cf27515c0d621c) }
 
-var fileDescriptor_m2_ccd6356c045a9ac3 = []byte{
+var fileDescriptor_20cf27515c0d621c = []byte{
 	// 114 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd4, 0xcf, 0x35, 0xd2,

--- a/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
@@ -28,7 +28,7 @@ func (m *M3) Reset()         { *m = M3{} }
 func (m *M3) String() string { return proto.CompactTextString(m) }
 func (*M3) ProtoMessage()    {}
 func (*M3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m3_de310e87d08d4216, []int{0}
+	return fileDescriptor_ff9d8f834875c9c5, []int{0}
 }
 func (m *M3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M3.Unmarshal(m, b)
@@ -52,9 +52,9 @@ func init() {
 	proto.RegisterType((*M3)(nil), "test.a.M3")
 }
 
-func init() { proto.RegisterFile("imports/test_a_2/m3.proto", fileDescriptor_m3_de310e87d08d4216) }
+func init() { proto.RegisterFile("imports/test_a_2/m3.proto", fileDescriptor_ff9d8f834875c9c5) }
 
-var fileDescriptor_m3_de310e87d08d4216 = []byte{
+var fileDescriptor_ff9d8f834875c9c5 = []byte{
 	// 114 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd2, 0xcf, 0x35, 0xd6,

--- a/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
@@ -28,7 +28,7 @@ func (m *M4) Reset()         { *m = M4{} }
 func (m *M4) String() string { return proto.CompactTextString(m) }
 func (*M4) ProtoMessage()    {}
 func (*M4) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m4_da12b386229f3791, []int{0}
+	return fileDescriptor_fdd24f82f6c5a786, []int{0}
 }
 func (m *M4) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M4.Unmarshal(m, b)
@@ -52,9 +52,9 @@ func init() {
 	proto.RegisterType((*M4)(nil), "test.a.M4")
 }
 
-func init() { proto.RegisterFile("imports/test_a_2/m4.proto", fileDescriptor_m4_da12b386229f3791) }
+func init() { proto.RegisterFile("imports/test_a_2/m4.proto", fileDescriptor_fdd24f82f6c5a786) }
 
-var fileDescriptor_m4_da12b386229f3791 = []byte{
+var fileDescriptor_fdd24f82f6c5a786 = []byte{
 	// 114 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8c, 0x37, 0xd2, 0xcf, 0x35, 0xd1,

--- a/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
@@ -28,7 +28,7 @@ func (m *M1) Reset()         { *m = M1{} }
 func (m *M1) String() string { return proto.CompactTextString(m) }
 func (*M1) ProtoMessage()    {}
 func (*M1) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m1_aff127b054aec649, []int{0}
+	return fileDescriptor_7f49573d035512a8, []int{0}
 }
 func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
@@ -52,9 +52,9 @@ func init() {
 	proto.RegisterType((*M1)(nil), "test.b.part1.M1")
 }
 
-func init() { proto.RegisterFile("imports/test_b_1/m1.proto", fileDescriptor_m1_aff127b054aec649) }
+func init() { proto.RegisterFile("imports/test_b_1/m1.proto", fileDescriptor_7f49573d035512a8) }
 
-var fileDescriptor_m1_aff127b054aec649 = []byte{
+var fileDescriptor_7f49573d035512a8 = []byte{
 	// 125 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8a, 0x37, 0xd4, 0xcf, 0x35, 0xd4,

--- a/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
@@ -28,7 +28,7 @@ func (m *M2) Reset()         { *m = M2{} }
 func (m *M2) String() string { return proto.CompactTextString(m) }
 func (*M2) ProtoMessage()    {}
 func (*M2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_m2_0c59cab35ba1b0d8, []int{0}
+	return fileDescriptor_a1becddceeb586f2, []int{0}
 }
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
@@ -52,9 +52,9 @@ func init() {
 	proto.RegisterType((*M2)(nil), "test.b.part2.M2")
 }
 
-func init() { proto.RegisterFile("imports/test_b_1/m2.proto", fileDescriptor_m2_0c59cab35ba1b0d8) }
+func init() { proto.RegisterFile("imports/test_b_1/m2.proto", fileDescriptor_a1becddceeb586f2) }
 
-var fileDescriptor_m2_0c59cab35ba1b0d8 = []byte{
+var fileDescriptor_a1becddceeb586f2 = []byte{
 	// 125 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcc, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x4f, 0x8a, 0x37, 0xd4, 0xcf, 0x35, 0xd2,

--- a/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
@@ -30,7 +30,7 @@ func (m *A1M1) Reset()         { *m = A1M1{} }
 func (m *A1M1) String() string { return proto.CompactTextString(m) }
 func (*A1M1) ProtoMessage()    {}
 func (*A1M1) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_import_a1m1_d7f2b5c638a69f6e, []int{0}
+	return fileDescriptor_3b904a47327455f3, []int{0}
 }
 func (m *A1M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M1.Unmarshal(m, b)
@@ -61,11 +61,9 @@ func init() {
 	proto.RegisterType((*A1M1)(nil), "test.A1M1")
 }
 
-func init() {
-	proto.RegisterFile("imports/test_import_a1m1.proto", fileDescriptor_test_import_a1m1_d7f2b5c638a69f6e)
-}
+func init() { proto.RegisterFile("imports/test_import_a1m1.proto", fileDescriptor_3b904a47327455f3) }
 
-var fileDescriptor_test_import_a1m1_d7f2b5c638a69f6e = []byte{
+var fileDescriptor_3b904a47327455f3 = []byte{
 	// 149 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcb, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x87, 0x70, 0xe2, 0x13, 0x0d, 0x73, 0x0d,

--- a/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
@@ -30,7 +30,7 @@ func (m *A1M2) Reset()         { *m = A1M2{} }
 func (m *A1M2) String() string { return proto.CompactTextString(m) }
 func (*A1M2) ProtoMessage()    {}
 func (*A1M2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_import_a1m2_9a3281ce9464e116, []int{0}
+	return fileDescriptor_bdb27b114687957d, []int{0}
 }
 func (m *A1M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M2.Unmarshal(m, b)
@@ -61,11 +61,9 @@ func init() {
 	proto.RegisterType((*A1M2)(nil), "test.A1M2")
 }
 
-func init() {
-	proto.RegisterFile("imports/test_import_a1m2.proto", fileDescriptor_test_import_a1m2_9a3281ce9464e116)
-}
+func init() { proto.RegisterFile("imports/test_import_a1m2.proto", fileDescriptor_bdb27b114687957d) }
 
-var fileDescriptor_test_import_a1m2_9a3281ce9464e116 = []byte{
+var fileDescriptor_bdb27b114687957d = []byte{
 	// 149 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcb, 0xcc, 0x2d, 0xc8,
 	0x2f, 0x2a, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e, 0x89, 0x87, 0x70, 0xe2, 0x13, 0x0d, 0x73, 0x8d,

--- a/protoc-gen-go/testdata/imports/test_import_all.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_all.pb.go
@@ -39,7 +39,7 @@ func (m *All) Reset()         { *m = All{} }
 func (m *All) String() string { return proto.CompactTextString(m) }
 func (*All) ProtoMessage()    {}
 func (*All) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_import_all_b41dc4592e4a4f3b, []int{0}
+	return fileDescriptor_324466f0afc16f77, []int{0}
 }
 func (m *All) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_All.Unmarshal(m, b)
@@ -112,11 +112,9 @@ func init() {
 	proto.RegisterType((*All)(nil), "test.All")
 }
 
-func init() {
-	proto.RegisterFile("imports/test_import_all.proto", fileDescriptor_test_import_all_b41dc4592e4a4f3b)
-}
+func init() { proto.RegisterFile("imports/test_import_all.proto", fileDescriptor_324466f0afc16f77) }
 
-var fileDescriptor_test_import_all_b41dc4592e4a4f3b = []byte{
+var fileDescriptor_324466f0afc16f77 = []byte{
 	// 258 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0xd0, 0xb1, 0x4e, 0xc3, 0x30,
 	0x10, 0x06, 0x60, 0x15, 0x97, 0x20, 0x99, 0x05, 0x85, 0xc5, 0x20, 0x90, 0x50, 0x27, 0x96, 0xda,

--- a/protoc-gen-go/testdata/multi/multi1.pb.go
+++ b/protoc-gen-go/testdata/multi/multi1.pb.go
@@ -31,7 +31,7 @@ func (m *Multi1) Reset()         { *m = Multi1{} }
 func (m *Multi1) String() string { return proto.CompactTextString(m) }
 func (*Multi1) ProtoMessage()    {}
 func (*Multi1) Descriptor() ([]byte, []int) {
-	return fileDescriptor_multi1_08e50c6822e808b8, []int{0}
+	return fileDescriptor_e0bffc140cd1b1d9, []int{0}
 }
 func (m *Multi1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi1.Unmarshal(m, b)
@@ -76,9 +76,9 @@ func init() {
 	proto.RegisterType((*Multi1)(nil), "multitest.Multi1")
 }
 
-func init() { proto.RegisterFile("multi/multi1.proto", fileDescriptor_multi1_08e50c6822e808b8) }
+func init() { proto.RegisterFile("multi/multi1.proto", fileDescriptor_e0bffc140cd1b1d9) }
 
-var fileDescriptor_multi1_08e50c6822e808b8 = []byte{
+var fileDescriptor_e0bffc140cd1b1d9 = []byte{
 	// 200 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xca, 0x2d, 0xcd, 0x29,
 	0xc9, 0xd4, 0x07, 0x93, 0x86, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x9c, 0x60, 0x5e, 0x49,

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -54,7 +54,7 @@ func (x *Multi2_Color) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Multi2_Color) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_multi2_c47490ad66d93e67, []int{0, 0}
+	return fileDescriptor_a2aebe588a0b2853, []int{0, 0}
 }
 
 type Multi2 struct {
@@ -69,7 +69,7 @@ func (m *Multi2) Reset()         { *m = Multi2{} }
 func (m *Multi2) String() string { return proto.CompactTextString(m) }
 func (*Multi2) ProtoMessage()    {}
 func (*Multi2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_multi2_c47490ad66d93e67, []int{0}
+	return fileDescriptor_a2aebe588a0b2853, []int{0}
 }
 func (m *Multi2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi2.Unmarshal(m, b)
@@ -108,9 +108,9 @@ func init() {
 	proto.RegisterEnum("multitest.Multi2_Color", Multi2_Color_name, Multi2_Color_value)
 }
 
-func init() { proto.RegisterFile("multi/multi2.proto", fileDescriptor_multi2_c47490ad66d93e67) }
+func init() { proto.RegisterFile("multi/multi2.proto", fileDescriptor_a2aebe588a0b2853) }
 
-var fileDescriptor_multi2_c47490ad66d93e67 = []byte{
+var fileDescriptor_a2aebe588a0b2853 = []byte{
 	// 202 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xca, 0x2d, 0xcd, 0x29,
 	0xc9, 0xd4, 0x07, 0x93, 0x46, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x9c, 0x60, 0x5e, 0x49,

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -51,7 +51,7 @@ func (x *Multi3_HatType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Multi3_HatType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_multi3_d55a72b4628b7875, []int{0, 0}
+	return fileDescriptor_580398fc0bbeeaa7, []int{0, 0}
 }
 
 type Multi3 struct {
@@ -65,7 +65,7 @@ func (m *Multi3) Reset()         { *m = Multi3{} }
 func (m *Multi3) String() string { return proto.CompactTextString(m) }
 func (*Multi3) ProtoMessage()    {}
 func (*Multi3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_multi3_d55a72b4628b7875, []int{0}
+	return fileDescriptor_580398fc0bbeeaa7, []int{0}
 }
 func (m *Multi3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi3.Unmarshal(m, b)
@@ -97,9 +97,9 @@ func init() {
 	proto.RegisterEnum("multitest.Multi3_HatType", Multi3_HatType_name, Multi3_HatType_value)
 }
 
-func init() { proto.RegisterFile("multi/multi3.proto", fileDescriptor_multi3_d55a72b4628b7875) }
+func init() { proto.RegisterFile("multi/multi3.proto", fileDescriptor_580398fc0bbeeaa7) }
 
-var fileDescriptor_multi3_d55a72b4628b7875 = []byte{
+var fileDescriptor_580398fc0bbeeaa7 = []byte{
 	// 170 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0xca, 0x2d, 0xcd, 0x29,
 	0xc9, 0xd4, 0x07, 0x93, 0xc6, 0x7a, 0x05, 0x45, 0xf9, 0x25, 0xf9, 0x42, 0x9c, 0x60, 0x5e, 0x49,

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -57,7 +57,7 @@ func (x *HatType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (HatType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{0}
+	return fileDescriptor_2c9b60a40d5131b9, []int{0}
 }
 
 // This enum represents days of the week.
@@ -97,7 +97,7 @@ func (x *Days) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Days) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{1}
+	return fileDescriptor_2c9b60a40d5131b9, []int{1}
 }
 
 type Request_Color int32
@@ -136,7 +136,7 @@ func (x *Request_Color) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Request_Color) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{0, 0}
+	return fileDescriptor_2c9b60a40d5131b9, []int{0, 0}
 }
 
 type Reply_Entry_Game int32
@@ -172,7 +172,7 @@ func (x *Reply_Entry_Game) UnmarshalJSON(data []byte) error {
 	return nil
 }
 func (Reply_Entry_Game) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{1, 0, 0}
+	return fileDescriptor_2c9b60a40d5131b9, []int{1, 0, 0}
 }
 
 // This is a message that might be sent somewhere.
@@ -200,7 +200,7 @@ func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{0}
+	return fileDescriptor_2c9b60a40d5131b9, []int{0}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
@@ -298,7 +298,7 @@ func (m *Request_SomeGroup) Reset()         { *m = Request_SomeGroup{} }
 func (m *Request_SomeGroup) String() string { return proto.CompactTextString(m) }
 func (*Request_SomeGroup) ProtoMessage()    {}
 func (*Request_SomeGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{0, 0}
+	return fileDescriptor_2c9b60a40d5131b9, []int{0, 0}
 }
 func (m *Request_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request_SomeGroup.Unmarshal(m, b)
@@ -338,7 +338,7 @@ func (m *Reply) Reset()         { *m = Reply{} }
 func (m *Reply) String() string { return proto.CompactTextString(m) }
 func (*Reply) ProtoMessage()    {}
 func (*Reply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{1}
+	return fileDescriptor_2c9b60a40d5131b9, []int{1}
 }
 
 var extRange_Reply = []proto.ExtensionRange{
@@ -393,7 +393,7 @@ func (m *Reply_Entry) Reset()         { *m = Reply_Entry{} }
 func (m *Reply_Entry) String() string { return proto.CompactTextString(m) }
 func (*Reply_Entry) ProtoMessage()    {}
 func (*Reply_Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{1, 0}
+	return fileDescriptor_2c9b60a40d5131b9, []int{1, 0}
 }
 func (m *Reply_Entry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Reply_Entry.Unmarshal(m, b)
@@ -448,7 +448,7 @@ func (m *OtherBase) Reset()         { *m = OtherBase{} }
 func (m *OtherBase) String() string { return proto.CompactTextString(m) }
 func (*OtherBase) ProtoMessage()    {}
 func (*OtherBase) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{2}
+	return fileDescriptor_2c9b60a40d5131b9, []int{2}
 }
 
 var extRange_OtherBase = []proto.ExtensionRange{
@@ -493,7 +493,7 @@ func (m *ReplyExtensions) Reset()         { *m = ReplyExtensions{} }
 func (m *ReplyExtensions) String() string { return proto.CompactTextString(m) }
 func (*ReplyExtensions) ProtoMessage()    {}
 func (*ReplyExtensions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{3}
+	return fileDescriptor_2c9b60a40d5131b9, []int{3}
 }
 func (m *ReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReplyExtensions.Unmarshal(m, b)
@@ -551,7 +551,7 @@ func (m *OtherReplyExtensions) Reset()         { *m = OtherReplyExtensions{} }
 func (m *OtherReplyExtensions) String() string { return proto.CompactTextString(m) }
 func (*OtherReplyExtensions) ProtoMessage()    {}
 func (*OtherReplyExtensions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{4}
+	return fileDescriptor_2c9b60a40d5131b9, []int{4}
 }
 func (m *OtherReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherReplyExtensions.Unmarshal(m, b)
@@ -589,7 +589,7 @@ func (m *OldReply) Reset()         { *m = OldReply{} }
 func (m *OldReply) String() string { return proto.CompactTextString(m) }
 func (*OldReply) ProtoMessage()    {}
 func (*OldReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{5}
+	return fileDescriptor_2c9b60a40d5131b9, []int{5}
 }
 
 func (m *OldReply) MarshalJSON() ([]byte, error) {
@@ -649,7 +649,7 @@ func (m *Communique) Reset()         { *m = Communique{} }
 func (m *Communique) String() string { return proto.CompactTextString(m) }
 func (*Communique) ProtoMessage()    {}
 func (*Communique) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{6}
+	return fileDescriptor_2c9b60a40d5131b9, []int{6}
 }
 func (m *Communique) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique.Unmarshal(m, b)
@@ -1020,7 +1020,7 @@ func (m *Communique_SomeGroup) Reset()         { *m = Communique_SomeGroup{} }
 func (m *Communique_SomeGroup) String() string { return proto.CompactTextString(m) }
 func (*Communique_SomeGroup) ProtoMessage()    {}
 func (*Communique_SomeGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{6, 0}
+	return fileDescriptor_2c9b60a40d5131b9, []int{6, 0}
 }
 func (m *Communique_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_SomeGroup.Unmarshal(m, b)
@@ -1057,7 +1057,7 @@ func (m *Communique_Delta) Reset()         { *m = Communique_Delta{} }
 func (m *Communique_Delta) String() string { return proto.CompactTextString(m) }
 func (*Communique_Delta) ProtoMessage()    {}
 func (*Communique_Delta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_test_2309d445eee26af7, []int{6, 1}
+	return fileDescriptor_2c9b60a40d5131b9, []int{6, 1}
 }
 func (m *Communique_Delta) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_Delta.Unmarshal(m, b)
@@ -1120,9 +1120,9 @@ func init() {
 	proto.RegisterExtension(E_Donut)
 }
 
-func init() { proto.RegisterFile("my_test/test.proto", fileDescriptor_test_2309d445eee26af7) }
+func init() { proto.RegisterFile("my_test/test.proto", fileDescriptor_2c9b60a40d5131b9) }
 
-var fileDescriptor_test_2309d445eee26af7 = []byte{
+var fileDescriptor_2c9b60a40d5131b9 = []byte{
 	// 1033 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x55, 0xdd, 0x6e, 0xe3, 0x44,
 	0x14, 0xce, 0xd8, 0x71, 0x7e, 0x4e, 0x42, 0x6b, 0x46, 0x55, 0x6b, 0x05, 0xed, 0xd6, 0x04, 0x8a,

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -44,7 +44,7 @@ func (x Request_Flavour) String() string {
 	return proto.EnumName(Request_Flavour_name, int32(x))
 }
 func (Request_Flavour) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_a752e09251f17e01, []int{0, 0}
+	return fileDescriptor_ab04eb4084a521db, []int{0, 0}
 }
 
 type Request struct {
@@ -62,7 +62,7 @@ func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_a752e09251f17e01, []int{0}
+	return fileDescriptor_ab04eb4084a521db, []int{0}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
@@ -129,7 +129,7 @@ func (m *Book) Reset()         { *m = Book{} }
 func (m *Book) String() string { return proto.CompactTextString(m) }
 func (*Book) ProtoMessage()    {}
 func (*Book) Descriptor() ([]byte, []int) {
-	return fileDescriptor_proto3_a752e09251f17e01, []int{1}
+	return fileDescriptor_ab04eb4084a521db, []int{1}
 }
 func (m *Book) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Book.Unmarshal(m, b)
@@ -169,9 +169,9 @@ func init() {
 	proto.RegisterEnum("proto3.Request_Flavour", Request_Flavour_name, Request_Flavour_value)
 }
 
-func init() { proto.RegisterFile("proto3/proto3.proto", fileDescriptor_proto3_a752e09251f17e01) }
+func init() { proto.RegisterFile("proto3/proto3.proto", fileDescriptor_ab04eb4084a521db) }
 
-var fileDescriptor_proto3_a752e09251f17e01 = []byte{
+var fileDescriptor_ab04eb4084a521db = []byte{
 	// 306 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x3c, 0x90, 0xcf, 0x4e, 0xf2, 0x40,
 	0x14, 0xc5, 0x99, 0xfe, 0xf9, 0x80, 0xfb, 0xa1, 0x19, 0xaf, 0x26, 0x8e, 0x1b, 0x33, 0x61, 0xd5,

--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -133,7 +133,7 @@ func (m *Any) Reset()         { *m = Any{} }
 func (m *Any) String() string { return proto.CompactTextString(m) }
 func (*Any) ProtoMessage()    {}
 func (*Any) Descriptor() ([]byte, []int) {
-	return fileDescriptor_any_744b9ca530f228db, []int{0}
+	return fileDescriptor_b53526c13ae22eb4, []int{0}
 }
 func (*Any) XXX_WellKnownType() string { return "Any" }
 func (m *Any) XXX_Unmarshal(b []byte) error {
@@ -172,9 +172,9 @@ func init() {
 	proto.RegisterType((*Any)(nil), "google.protobuf.Any")
 }
 
-func init() { proto.RegisterFile("google/protobuf/any.proto", fileDescriptor_any_744b9ca530f228db) }
+func init() { proto.RegisterFile("google/protobuf/any.proto", fileDescriptor_b53526c13ae22eb4) }
 
-var fileDescriptor_any_744b9ca530f228db = []byte{
+var fileDescriptor_b53526c13ae22eb4 = []byte{
 	// 185 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4c, 0xcf, 0xcf, 0x4f,
 	0xcf, 0x49, 0xd5, 0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0x2a, 0x4d, 0xd3, 0x4f, 0xcc, 0xab, 0xd4,

--- a/ptypes/duration/duration.pb.go
+++ b/ptypes/duration/duration.pb.go
@@ -99,7 +99,7 @@ func (m *Duration) Reset()         { *m = Duration{} }
 func (m *Duration) String() string { return proto.CompactTextString(m) }
 func (*Duration) ProtoMessage()    {}
 func (*Duration) Descriptor() ([]byte, []int) {
-	return fileDescriptor_duration_e7d612259e3f0613, []int{0}
+	return fileDescriptor_23597b2ebd7ac6c5, []int{0}
 }
 func (*Duration) XXX_WellKnownType() string { return "Duration" }
 func (m *Duration) XXX_Unmarshal(b []byte) error {
@@ -138,11 +138,9 @@ func init() {
 	proto.RegisterType((*Duration)(nil), "google.protobuf.Duration")
 }
 
-func init() {
-	proto.RegisterFile("google/protobuf/duration.proto", fileDescriptor_duration_e7d612259e3f0613)
-}
+func init() { proto.RegisterFile("google/protobuf/duration.proto", fileDescriptor_23597b2ebd7ac6c5) }
 
-var fileDescriptor_duration_e7d612259e3f0613 = []byte{
+var fileDescriptor_23597b2ebd7ac6c5 = []byte{
 	// 190 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4b, 0xcf, 0xcf, 0x4f,
 	0xcf, 0x49, 0xd5, 0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0x2a, 0x4d, 0xd3, 0x4f, 0x29, 0x2d, 0x4a,

--- a/ptypes/empty/empty.pb.go
+++ b/ptypes/empty/empty.pb.go
@@ -37,7 +37,7 @@ func (m *Empty) Reset()         { *m = Empty{} }
 func (m *Empty) String() string { return proto.CompactTextString(m) }
 func (*Empty) ProtoMessage()    {}
 func (*Empty) Descriptor() ([]byte, []int) {
-	return fileDescriptor_empty_39e6d6db0632e5b2, []int{0}
+	return fileDescriptor_900544acb223d5b8, []int{0}
 }
 func (*Empty) XXX_WellKnownType() string { return "Empty" }
 func (m *Empty) XXX_Unmarshal(b []byte) error {
@@ -62,9 +62,9 @@ func init() {
 	proto.RegisterType((*Empty)(nil), "google.protobuf.Empty")
 }
 
-func init() { proto.RegisterFile("google/protobuf/empty.proto", fileDescriptor_empty_39e6d6db0632e5b2) }
+func init() { proto.RegisterFile("google/protobuf/empty.proto", fileDescriptor_900544acb223d5b8) }
 
-var fileDescriptor_empty_39e6d6db0632e5b2 = []byte{
+var fileDescriptor_900544acb223d5b8 = []byte{
 	// 148 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4e, 0xcf, 0xcf, 0x4f,
 	0xcf, 0x49, 0xd5, 0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0x2a, 0x4d, 0xd3, 0x4f, 0xcd, 0x2d, 0x28,

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -40,7 +40,7 @@ func (x NullValue) String() string {
 	return proto.EnumName(NullValue_name, int32(x))
 }
 func (NullValue) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_struct_3a5a94e0c7801b27, []int{0}
+	return fileDescriptor_df322afd6c9fb402, []int{0}
 }
 func (NullValue) XXX_WellKnownType() string { return "NullValue" }
 
@@ -64,7 +64,7 @@ func (m *Struct) Reset()         { *m = Struct{} }
 func (m *Struct) String() string { return proto.CompactTextString(m) }
 func (*Struct) ProtoMessage()    {}
 func (*Struct) Descriptor() ([]byte, []int) {
-	return fileDescriptor_struct_3a5a94e0c7801b27, []int{0}
+	return fileDescriptor_df322afd6c9fb402, []int{0}
 }
 func (*Struct) XXX_WellKnownType() string { return "Struct" }
 func (m *Struct) XXX_Unmarshal(b []byte) error {
@@ -118,7 +118,7 @@ func (m *Value) Reset()         { *m = Value{} }
 func (m *Value) String() string { return proto.CompactTextString(m) }
 func (*Value) ProtoMessage()    {}
 func (*Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_struct_3a5a94e0c7801b27, []int{1}
+	return fileDescriptor_df322afd6c9fb402, []int{1}
 }
 func (*Value) XXX_WellKnownType() string { return "Value" }
 func (m *Value) XXX_Unmarshal(b []byte) error {
@@ -378,7 +378,7 @@ func (m *ListValue) Reset()         { *m = ListValue{} }
 func (m *ListValue) String() string { return proto.CompactTextString(m) }
 func (*ListValue) ProtoMessage()    {}
 func (*ListValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_struct_3a5a94e0c7801b27, []int{2}
+	return fileDescriptor_df322afd6c9fb402, []int{2}
 }
 func (*ListValue) XXX_WellKnownType() string { return "ListValue" }
 func (m *ListValue) XXX_Unmarshal(b []byte) error {
@@ -414,11 +414,9 @@ func init() {
 	proto.RegisterEnum("google.protobuf.NullValue", NullValue_name, NullValue_value)
 }
 
-func init() {
-	proto.RegisterFile("google/protobuf/struct.proto", fileDescriptor_struct_3a5a94e0c7801b27)
-}
+func init() { proto.RegisterFile("google/protobuf/struct.proto", fileDescriptor_df322afd6c9fb402) }
 
-var fileDescriptor_struct_3a5a94e0c7801b27 = []byte{
+var fileDescriptor_df322afd6c9fb402 = []byte{
 	// 417 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x92, 0x41, 0x8b, 0xd3, 0x40,
 	0x14, 0xc7, 0x3b, 0xc9, 0x36, 0x98, 0x17, 0x59, 0x97, 0x11, 0xb4, 0xac, 0xa2, 0xa1, 0x7b, 0x09,

--- a/ptypes/timestamp/timestamp.pb.go
+++ b/ptypes/timestamp/timestamp.pb.go
@@ -115,7 +115,7 @@ func (m *Timestamp) Reset()         { *m = Timestamp{} }
 func (m *Timestamp) String() string { return proto.CompactTextString(m) }
 func (*Timestamp) ProtoMessage()    {}
 func (*Timestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_timestamp_b826e8e5fba671a8, []int{0}
+	return fileDescriptor_292007bbfe81227e, []int{0}
 }
 func (*Timestamp) XXX_WellKnownType() string { return "Timestamp" }
 func (m *Timestamp) XXX_Unmarshal(b []byte) error {
@@ -154,11 +154,9 @@ func init() {
 	proto.RegisterType((*Timestamp)(nil), "google.protobuf.Timestamp")
 }
 
-func init() {
-	proto.RegisterFile("google/protobuf/timestamp.proto", fileDescriptor_timestamp_b826e8e5fba671a8)
-}
+func init() { proto.RegisterFile("google/protobuf/timestamp.proto", fileDescriptor_292007bbfe81227e) }
 
-var fileDescriptor_timestamp_b826e8e5fba671a8 = []byte{
+var fileDescriptor_292007bbfe81227e = []byte{
 	// 191 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4f, 0xcf, 0xcf, 0x4f,
 	0xcf, 0x49, 0xd5, 0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0x2a, 0x4d, 0xd3, 0x2f, 0xc9, 0xcc, 0x4d,

--- a/ptypes/wrappers/wrappers.pb.go
+++ b/ptypes/wrappers/wrappers.pb.go
@@ -33,7 +33,7 @@ func (m *DoubleValue) Reset()         { *m = DoubleValue{} }
 func (m *DoubleValue) String() string { return proto.CompactTextString(m) }
 func (*DoubleValue) ProtoMessage()    {}
 func (*DoubleValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{0}
+	return fileDescriptor_5377b62bda767935, []int{0}
 }
 func (*DoubleValue) XXX_WellKnownType() string { return "DoubleValue" }
 func (m *DoubleValue) XXX_Unmarshal(b []byte) error {
@@ -76,7 +76,7 @@ func (m *FloatValue) Reset()         { *m = FloatValue{} }
 func (m *FloatValue) String() string { return proto.CompactTextString(m) }
 func (*FloatValue) ProtoMessage()    {}
 func (*FloatValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{1}
+	return fileDescriptor_5377b62bda767935, []int{1}
 }
 func (*FloatValue) XXX_WellKnownType() string { return "FloatValue" }
 func (m *FloatValue) XXX_Unmarshal(b []byte) error {
@@ -119,7 +119,7 @@ func (m *Int64Value) Reset()         { *m = Int64Value{} }
 func (m *Int64Value) String() string { return proto.CompactTextString(m) }
 func (*Int64Value) ProtoMessage()    {}
 func (*Int64Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{2}
+	return fileDescriptor_5377b62bda767935, []int{2}
 }
 func (*Int64Value) XXX_WellKnownType() string { return "Int64Value" }
 func (m *Int64Value) XXX_Unmarshal(b []byte) error {
@@ -162,7 +162,7 @@ func (m *UInt64Value) Reset()         { *m = UInt64Value{} }
 func (m *UInt64Value) String() string { return proto.CompactTextString(m) }
 func (*UInt64Value) ProtoMessage()    {}
 func (*UInt64Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{3}
+	return fileDescriptor_5377b62bda767935, []int{3}
 }
 func (*UInt64Value) XXX_WellKnownType() string { return "UInt64Value" }
 func (m *UInt64Value) XXX_Unmarshal(b []byte) error {
@@ -205,7 +205,7 @@ func (m *Int32Value) Reset()         { *m = Int32Value{} }
 func (m *Int32Value) String() string { return proto.CompactTextString(m) }
 func (*Int32Value) ProtoMessage()    {}
 func (*Int32Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{4}
+	return fileDescriptor_5377b62bda767935, []int{4}
 }
 func (*Int32Value) XXX_WellKnownType() string { return "Int32Value" }
 func (m *Int32Value) XXX_Unmarshal(b []byte) error {
@@ -248,7 +248,7 @@ func (m *UInt32Value) Reset()         { *m = UInt32Value{} }
 func (m *UInt32Value) String() string { return proto.CompactTextString(m) }
 func (*UInt32Value) ProtoMessage()    {}
 func (*UInt32Value) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{5}
+	return fileDescriptor_5377b62bda767935, []int{5}
 }
 func (*UInt32Value) XXX_WellKnownType() string { return "UInt32Value" }
 func (m *UInt32Value) XXX_Unmarshal(b []byte) error {
@@ -291,7 +291,7 @@ func (m *BoolValue) Reset()         { *m = BoolValue{} }
 func (m *BoolValue) String() string { return proto.CompactTextString(m) }
 func (*BoolValue) ProtoMessage()    {}
 func (*BoolValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{6}
+	return fileDescriptor_5377b62bda767935, []int{6}
 }
 func (*BoolValue) XXX_WellKnownType() string { return "BoolValue" }
 func (m *BoolValue) XXX_Unmarshal(b []byte) error {
@@ -334,7 +334,7 @@ func (m *StringValue) Reset()         { *m = StringValue{} }
 func (m *StringValue) String() string { return proto.CompactTextString(m) }
 func (*StringValue) ProtoMessage()    {}
 func (*StringValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{7}
+	return fileDescriptor_5377b62bda767935, []int{7}
 }
 func (*StringValue) XXX_WellKnownType() string { return "StringValue" }
 func (m *StringValue) XXX_Unmarshal(b []byte) error {
@@ -377,7 +377,7 @@ func (m *BytesValue) Reset()         { *m = BytesValue{} }
 func (m *BytesValue) String() string { return proto.CompactTextString(m) }
 func (*BytesValue) ProtoMessage()    {}
 func (*BytesValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_wrappers_16c7c35c009f3253, []int{8}
+	return fileDescriptor_5377b62bda767935, []int{8}
 }
 func (*BytesValue) XXX_WellKnownType() string { return "BytesValue" }
 func (m *BytesValue) XXX_Unmarshal(b []byte) error {
@@ -417,11 +417,9 @@ func init() {
 	proto.RegisterType((*BytesValue)(nil), "google.protobuf.BytesValue")
 }
 
-func init() {
-	proto.RegisterFile("google/protobuf/wrappers.proto", fileDescriptor_wrappers_16c7c35c009f3253)
-}
+func init() { proto.RegisterFile("google/protobuf/wrappers.proto", fileDescriptor_5377b62bda767935) }
 
-var fileDescriptor_wrappers_16c7c35c009f3253 = []byte{
+var fileDescriptor_5377b62bda767935 = []byte{
 	// 259 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4b, 0xcf, 0xcf, 0x4f,
 	0xcf, 0x49, 0xd5, 0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x4f, 0x2a, 0x4d, 0xd3, 0x2f, 0x2f, 0x4a, 0x2c,


### PR DESCRIPTION
The generated per-file var containing the file's FileDescriptorProto
needs to be unique across all files in a package.

Change the var name from:

  fileDescriptor_<file basename>_<hash of descriptor>

to:

  fileDescriptor_<hash of filename>

There's no need for the name of the var to change every time the
descriptor contents change (although this is harmless). The filename
alone suffices to make the var unique.