### PR TITLE
protoc-gen-go: add blank lines between various enum functions

### DIFF
--- a/conformance/internal/conformance_proto/conformance.pb.go
+++ b/conformance/internal/conformance_proto/conformance.pb.go
@@ -37,6 +37,7 @@ var WireFormat_name = map[int32]string{
 	1: "PROTOBUF",
 	2: "JSON",
 }
+
 var WireFormat_value = map[string]int32{
 	"UNSPECIFIED": 0,
 	"PROTOBUF":    1,
@@ -46,6 +47,7 @@ var WireFormat_value = map[string]int32{
 func (x WireFormat) String() string {
 	return proto.EnumName(WireFormat_name, int32(x))
 }
+
 func (WireFormat) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{0}
 }
@@ -63,6 +65,7 @@ var ForeignEnum_name = map[int32]string{
 	1: "FOREIGN_BAR",
 	2: "FOREIGN_BAZ",
 }
+
 var ForeignEnum_value = map[string]int32{
 	"FOREIGN_FOO": 0,
 	"FOREIGN_BAR": 1,
@@ -72,6 +75,7 @@ var ForeignEnum_value = map[string]int32{
 func (x ForeignEnum) String() string {
 	return proto.EnumName(ForeignEnum_name, int32(x))
 }
+
 func (ForeignEnum) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{1}
 }
@@ -91,6 +95,7 @@ var TestAllTypes_NestedEnum_name = map[int32]string{
 	2:  "BAZ",
 	-1: "NEG",
 }
+
 var TestAllTypes_NestedEnum_value = map[string]int32{
 	"FOO": 0,
 	"BAR": 1,
@@ -101,6 +106,7 @@ var TestAllTypes_NestedEnum_value = map[string]int32{
 func (x TestAllTypes_NestedEnum) String() string {
 	return proto.EnumName(TestAllTypes_NestedEnum_name, int32(x))
 }
+
 func (TestAllTypes_NestedEnum) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{2, 0}
 }

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -31,6 +31,7 @@ var Numeral_name = map[int32]string{
 	1: "ARABIC",
 	2: "ROMAN",
 }
+
 var Numeral_value = map[string]int32{
 	"UNKNOWN": 0,
 	"ARABIC":  1,
@@ -40,6 +41,7 @@ var Numeral_value = map[string]int32{
 func (x Numeral) String() string {
 	return proto.EnumName(Numeral_name, int32(x))
 }
+
 func (Numeral) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e6c135db3023e377, []int{0}
 }

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -36,6 +36,7 @@ var Widget_Color_name = map[int32]string{
 	1: "GREEN",
 	2: "BLUE",
 }
+
 var Widget_Color_value = map[string]int32{
 	"RED":   0,
 	"GREEN": 1,
@@ -47,9 +48,11 @@ func (x Widget_Color) Enum() *Widget_Color {
 	*p = x
 	return p
 }
+
 func (x Widget_Color) String() string {
 	return proto.EnumName(Widget_Color_name, int32(x))
 }
+
 func (x *Widget_Color) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(Widget_Color_value, data, "Widget_Color")
 	if err != nil {
@@ -58,6 +61,7 @@ func (x *Widget_Color) UnmarshalJSON(data []byte) error {
 	*x = Widget_Color(value)
 	return nil
 }
+
 func (Widget_Color) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{3, 0}
 }

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -35,6 +35,7 @@ var Message_Humour_name = map[int32]string{
 	2: "SLAPSTICK",
 	3: "BILL_BAILEY",
 }
+
 var Message_Humour_value = map[string]int32{
 	"UNKNOWN":     0,
 	"PUNS":        1,
@@ -45,6 +46,7 @@ var Message_Humour_value = map[string]int32{
 func (x Message_Humour) String() string {
 	return proto.EnumName(Message_Humour_name, int32(x))
 }
+
 func (Message_Humour) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_1c50d9b824d4ac38, []int{0, 0}
 }

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -27,6 +27,7 @@ const (
 var FOO_name = map[int32]string{
 	1: "FOO1",
 }
+
 var FOO_value = map[string]int32{
 	"FOO1": 1,
 }
@@ -36,9 +37,11 @@ func (x FOO) Enum() *FOO {
 	*p = x
 	return p
 }
+
 func (x FOO) String() string {
 	return proto.EnumName(FOO_name, int32(x))
 }
+
 func (x *FOO) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(FOO_value, data, "FOO")
 	if err != nil {
@@ -47,6 +50,7 @@ func (x *FOO) UnmarshalJSON(data []byte) error {
 	*x = FOO(value)
 	return nil
 }
+
 func (FOO) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{0}
 }
@@ -89,6 +93,7 @@ var GoTest_KIND_name = map[int32]string{
 	11: "TABLE",
 	12: "FUNCTION",
 }
+
 var GoTest_KIND_value = map[string]int32{
 	"VOID":        0,
 	"BOOL":        1,
@@ -110,9 +115,11 @@ func (x GoTest_KIND) Enum() *GoTest_KIND {
 	*p = x
 	return p
 }
+
 func (x GoTest_KIND) String() string {
 	return proto.EnumName(GoTest_KIND_name, int32(x))
 }
+
 func (x *GoTest_KIND) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(GoTest_KIND_value, data, "GoTest_KIND")
 	if err != nil {
@@ -121,6 +128,7 @@ func (x *GoTest_KIND) UnmarshalJSON(data []byte) error {
 	*x = GoTest_KIND(value)
 	return nil
 }
+
 func (GoTest_KIND) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{2, 0}
 }
@@ -138,6 +146,7 @@ var MyMessage_Color_name = map[int32]string{
 	1: "GREEN",
 	2: "BLUE",
 }
+
 var MyMessage_Color_value = map[string]int32{
 	"RED":   0,
 	"GREEN": 1,
@@ -149,9 +158,11 @@ func (x MyMessage_Color) Enum() *MyMessage_Color {
 	*p = x
 	return p
 }
+
 func (x MyMessage_Color) String() string {
 	return proto.EnumName(MyMessage_Color_name, int32(x))
 }
+
 func (x *MyMessage_Color) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(MyMessage_Color_value, data, "MyMessage_Color")
 	if err != nil {
@@ -160,6 +171,7 @@ func (x *MyMessage_Color) UnmarshalJSON(data []byte) error {
 	*x = MyMessage_Color(value)
 	return nil
 }
+
 func (MyMessage_Color) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{13, 0}
 }
@@ -177,6 +189,7 @@ var DefaultsMessage_DefaultsEnum_name = map[int32]string{
 	1: "ONE",
 	2: "TWO",
 }
+
 var DefaultsMessage_DefaultsEnum_value = map[string]int32{
 	"ZERO": 0,
 	"ONE":  1,
@@ -188,9 +201,11 @@ func (x DefaultsMessage_DefaultsEnum) Enum() *DefaultsMessage_DefaultsEnum {
 	*p = x
 	return p
 }
+
 func (x DefaultsMessage_DefaultsEnum) String() string {
 	return proto.EnumName(DefaultsMessage_DefaultsEnum_name, int32(x))
 }
+
 func (x *DefaultsMessage_DefaultsEnum) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(DefaultsMessage_DefaultsEnum_value, data, "DefaultsMessage_DefaultsEnum")
 	if err != nil {
@@ -199,6 +214,7 @@ func (x *DefaultsMessage_DefaultsEnum) UnmarshalJSON(data []byte) error {
 	*x = DefaultsMessage_DefaultsEnum(value)
 	return nil
 }
+
 func (DefaultsMessage_DefaultsEnum) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{16, 0}
 }
@@ -216,6 +232,7 @@ var Defaults_Color_name = map[int32]string{
 	1: "GREEN",
 	2: "BLUE",
 }
+
 var Defaults_Color_value = map[string]int32{
 	"RED":   0,
 	"GREEN": 1,
@@ -227,9 +244,11 @@ func (x Defaults_Color) Enum() *Defaults_Color {
 	*p = x
 	return p
 }
+
 func (x Defaults_Color) String() string {
 	return proto.EnumName(Defaults_Color_name, int32(x))
 }
+
 func (x *Defaults_Color) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(Defaults_Color_value, data, "Defaults_Color")
 	if err != nil {
@@ -238,6 +257,7 @@ func (x *Defaults_Color) UnmarshalJSON(data []byte) error {
 	*x = Defaults_Color(value)
 	return nil
 }
+
 func (Defaults_Color) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{21, 0}
 }
@@ -251,6 +271,7 @@ const (
 var RepeatedEnum_Color_name = map[int32]string{
 	1: "RED",
 }
+
 var RepeatedEnum_Color_value = map[string]int32{
 	"RED": 1,
 }
@@ -260,9 +281,11 @@ func (x RepeatedEnum_Color) Enum() *RepeatedEnum_Color {
 	*p = x
 	return p
 }
+
 func (x RepeatedEnum_Color) String() string {
 	return proto.EnumName(RepeatedEnum_Color_name, int32(x))
 }
+
 func (x *RepeatedEnum_Color) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(RepeatedEnum_Color_value, data, "RepeatedEnum_Color")
 	if err != nil {
@@ -271,6 +294,7 @@ func (x *RepeatedEnum_Color) UnmarshalJSON(data []byte) error {
 	*x = RepeatedEnum_Color(value)
 	return nil
 }
+
 func (RepeatedEnum_Color) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{23, 0}
 }

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -72,6 +72,7 @@ var FieldDescriptorProto_Type_name = map[int32]string{
 	17: "TYPE_SINT32",
 	18: "TYPE_SINT64",
 }
+
 var FieldDescriptorProto_Type_value = map[string]int32{
 	"TYPE_DOUBLE":   1,
 	"TYPE_FLOAT":    2,
@@ -98,9 +99,11 @@ func (x FieldDescriptorProto_Type) Enum() *FieldDescriptorProto_Type {
 	*p = x
 	return p
 }
+
 func (x FieldDescriptorProto_Type) String() string {
 	return proto.EnumName(FieldDescriptorProto_Type_name, int32(x))
 }
+
 func (x *FieldDescriptorProto_Type) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(FieldDescriptorProto_Type_value, data, "FieldDescriptorProto_Type")
 	if err != nil {
@@ -109,6 +112,7 @@ func (x *FieldDescriptorProto_Type) UnmarshalJSON(data []byte) error {
 	*x = FieldDescriptorProto_Type(value)
 	return nil
 }
+
 func (FieldDescriptorProto_Type) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{4, 0}
 }
@@ -127,6 +131,7 @@ var FieldDescriptorProto_Label_name = map[int32]string{
 	2: "LABEL_REQUIRED",
 	3: "LABEL_REPEATED",
 }
+
 var FieldDescriptorProto_Label_value = map[string]int32{
 	"LABEL_OPTIONAL": 1,
 	"LABEL_REQUIRED": 2,
@@ -138,9 +143,11 @@ func (x FieldDescriptorProto_Label) Enum() *FieldDescriptorProto_Label {
 	*p = x
 	return p
 }
+
 func (x FieldDescriptorProto_Label) String() string {
 	return proto.EnumName(FieldDescriptorProto_Label_name, int32(x))
 }
+
 func (x *FieldDescriptorProto_Label) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(FieldDescriptorProto_Label_value, data, "FieldDescriptorProto_Label")
 	if err != nil {
@@ -149,6 +156,7 @@ func (x *FieldDescriptorProto_Label) UnmarshalJSON(data []byte) error {
 	*x = FieldDescriptorProto_Label(value)
 	return nil
 }
+
 func (FieldDescriptorProto_Label) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{4, 1}
 }
@@ -168,6 +176,7 @@ var FileOptions_OptimizeMode_name = map[int32]string{
 	2: "CODE_SIZE",
 	3: "LITE_RUNTIME",
 }
+
 var FileOptions_OptimizeMode_value = map[string]int32{
 	"SPEED":        1,
 	"CODE_SIZE":    2,
@@ -179,9 +188,11 @@ func (x FileOptions_OptimizeMode) Enum() *FileOptions_OptimizeMode {
 	*p = x
 	return p
 }
+
 func (x FileOptions_OptimizeMode) String() string {
 	return proto.EnumName(FileOptions_OptimizeMode_name, int32(x))
 }
+
 func (x *FileOptions_OptimizeMode) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(FileOptions_OptimizeMode_value, data, "FileOptions_OptimizeMode")
 	if err != nil {
@@ -190,6 +201,7 @@ func (x *FileOptions_OptimizeMode) UnmarshalJSON(data []byte) error {
 	*x = FileOptions_OptimizeMode(value)
 	return nil
 }
+
 func (FileOptions_OptimizeMode) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{10, 0}
 }
@@ -208,6 +220,7 @@ var FieldOptions_CType_name = map[int32]string{
 	1: "CORD",
 	2: "STRING_PIECE",
 }
+
 var FieldOptions_CType_value = map[string]int32{
 	"STRING":       0,
 	"CORD":         1,
@@ -219,9 +232,11 @@ func (x FieldOptions_CType) Enum() *FieldOptions_CType {
 	*p = x
 	return p
 }
+
 func (x FieldOptions_CType) String() string {
 	return proto.EnumName(FieldOptions_CType_name, int32(x))
 }
+
 func (x *FieldOptions_CType) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(FieldOptions_CType_value, data, "FieldOptions_CType")
 	if err != nil {
@@ -230,6 +245,7 @@ func (x *FieldOptions_CType) UnmarshalJSON(data []byte) error {
 	*x = FieldOptions_CType(value)
 	return nil
 }
+
 func (FieldOptions_CType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{12, 0}
 }
@@ -250,6 +266,7 @@ var FieldOptions_JSType_name = map[int32]string{
 	1: "JS_STRING",
 	2: "JS_NUMBER",
 }
+
 var FieldOptions_JSType_value = map[string]int32{
 	"JS_NORMAL": 0,
 	"JS_STRING": 1,
@@ -261,9 +278,11 @@ func (x FieldOptions_JSType) Enum() *FieldOptions_JSType {
 	*p = x
 	return p
 }
+
 func (x FieldOptions_JSType) String() string {
 	return proto.EnumName(FieldOptions_JSType_name, int32(x))
 }
+
 func (x *FieldOptions_JSType) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(FieldOptions_JSType_value, data, "FieldOptions_JSType")
 	if err != nil {
@@ -272,6 +291,7 @@ func (x *FieldOptions_JSType) UnmarshalJSON(data []byte) error {
 	*x = FieldOptions_JSType(value)
 	return nil
 }
+
 func (FieldOptions_JSType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{12, 1}
 }
@@ -292,6 +312,7 @@ var MethodOptions_IdempotencyLevel_name = map[int32]string{
 	1: "NO_SIDE_EFFECTS",
 	2: "IDEMPOTENT",
 }
+
 var MethodOptions_IdempotencyLevel_value = map[string]int32{
 	"IDEMPOTENCY_UNKNOWN": 0,
 	"NO_SIDE_EFFECTS":     1,
@@ -303,9 +324,11 @@ func (x MethodOptions_IdempotencyLevel) Enum() *MethodOptions_IdempotencyLevel {
 	*p = x
 	return p
 }
+
 func (x MethodOptions_IdempotencyLevel) String() string {
 	return proto.EnumName(MethodOptions_IdempotencyLevel_name, int32(x))
 }
+
 func (x *MethodOptions_IdempotencyLevel) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(MethodOptions_IdempotencyLevel_value, data, "MethodOptions_IdempotencyLevel")
 	if err != nil {
@@ -314,6 +337,7 @@ func (x *MethodOptions_IdempotencyLevel) UnmarshalJSON(data []byte) error {
 	*x = MethodOptions_IdempotencyLevel(value)
 	return nil
 }
+
 func (MethodOptions_IdempotencyLevel) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{17, 0}
 }

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1392,6 +1392,7 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 		g.file.addExport(enum, constOrVarSymbol{name, "const", ccTypeName})
 	}
 	g.P(")")
+	g.P()
 	g.P("var ", ccTypeName, "_name = map[int32]string{")
 	generated := make(map[int32]bool) // avoid duplicate values
 	for _, e := range enum.Value {
@@ -1403,11 +1404,13 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 		generated[*e.Number] = true
 	}
 	g.P("}")
+	g.P()
 	g.P("var ", ccTypeName, "_value = map[string]int32{")
 	for _, e := range enum.Value {
 		g.P(strconv.Quote(*e.Name), ": ", e.Number, ",")
 	}
 	g.P("}")
+	g.P()
 
 	if !enum.proto3() {
 		g.P("func (x ", ccTypeName, ") Enum() *", ccTypeName, " {")
@@ -1415,11 +1418,13 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 		g.P("*p = x")
 		g.P("return p")
 		g.P("}")
+		g.P()
 	}
 
 	g.P("func (x ", ccTypeName, ") String() string {")
 	g.P("return ", g.Pkg["proto"], ".EnumName(", ccTypeName, "_name, int32(x))")
 	g.P("}")
+	g.P()
 
 	if !enum.proto3() {
 		g.P("func (x *", ccTypeName, ") UnmarshalJSON(data []byte) error {")
@@ -1430,6 +1435,7 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 		g.P("*x = ", ccTypeName, "(value)")
 		g.P("return nil")
 		g.P("}")
+		g.P()
 	}
 
 	var indexes []string
@@ -1441,11 +1447,11 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 	g.P("func (", ccTypeName, ") EnumDescriptor() ([]byte, []int) {")
 	g.P("return ", g.file.VarName(), ", []int{", strings.Join(indexes, ", "), "}")
 	g.P("}")
+	g.P()
 	if enum.file.GetPackage() == "google.protobuf" && enum.GetName() == "NullValue" {
 		g.P("func (", ccTypeName, `) XXX_WellKnownType() string { return "`, enum.GetName(), `" }`)
+		g.P()
 	}
-
-	g.P()
 }
 
 // The tag is a string like "varint,2,opt,name=fieldname,def=7" that

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -37,6 +37,7 @@ const (
 var DeprecatedEnum_name = map[int32]string{
 	0: "DEPRECATED",
 }
+
 var DeprecatedEnum_value = map[string]int32{
 	"DEPRECATED": 0,
 }
@@ -44,6 +45,7 @@ var DeprecatedEnum_value = map[string]int32{
 func (x DeprecatedEnum) String() string {
 	return proto.EnumName(DeprecatedEnum_name, int32(x))
 }
+
 func (DeprecatedEnum) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_f64ba265cd7eae3f, []int{0}
 }

--- a/protoc-gen-go/testdata/import_public/sub/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/a.pb.go
@@ -27,6 +27,7 @@ const (
 var E_name = map[int32]string{
 	0: "ZERO",
 }
+
 var E_value = map[string]int32{
 	"ZERO": 0,
 }
@@ -34,6 +35,7 @@ var E_value = map[string]int32{
 func (x E) String() string {
 	return proto.EnumName(E_name, int32(x))
 }
+
 func (E) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_382f7805394b5c4e, []int{0}
 }

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -27,6 +27,7 @@ const (
 var E1_name = map[int32]string{
 	0: "E1_ZERO",
 }
+
 var E1_value = map[string]int32{
 	"E1_ZERO": 0,
 }
@@ -34,6 +35,7 @@ var E1_value = map[string]int32{
 func (x E1) String() string {
 	return proto.EnumName(E1_name, int32(x))
 }
+
 func (E1) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_c1091de3fa870a14, []int{0}
 }

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -31,6 +31,7 @@ var Multi2_Color_name = map[int32]string{
 	2: "GREEN",
 	3: "RED",
 }
+
 var Multi2_Color_value = map[string]int32{
 	"BLUE":  1,
 	"GREEN": 2,
@@ -42,9 +43,11 @@ func (x Multi2_Color) Enum() *Multi2_Color {
 	*p = x
 	return p
 }
+
 func (x Multi2_Color) String() string {
 	return proto.EnumName(Multi2_Color_name, int32(x))
 }
+
 func (x *Multi2_Color) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(Multi2_Color_value, data, "Multi2_Color")
 	if err != nil {
@@ -53,6 +56,7 @@ func (x *Multi2_Color) UnmarshalJSON(data []byte) error {
 	*x = Multi2_Color(value)
 	return nil
 }
+
 func (Multi2_Color) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_a2aebe588a0b2853, []int{0, 0}
 }

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -29,6 +29,7 @@ var Multi3_HatType_name = map[int32]string{
 	1: "FEDORA",
 	2: "FEZ",
 }
+
 var Multi3_HatType_value = map[string]int32{
 	"FEDORA": 1,
 	"FEZ":    2,
@@ -39,9 +40,11 @@ func (x Multi3_HatType) Enum() *Multi3_HatType {
 	*p = x
 	return p
 }
+
 func (x Multi3_HatType) String() string {
 	return proto.EnumName(Multi3_HatType_name, int32(x))
 }
+
 func (x *Multi3_HatType) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(Multi3_HatType_value, data, "Multi3_HatType")
 	if err != nil {
@@ -50,6 +53,7 @@ func (x *Multi3_HatType) UnmarshalJSON(data []byte) error {
 	*x = Multi3_HatType(value)
 	return nil
 }
+
 func (Multi3_HatType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_580398fc0bbeeaa7, []int{0, 0}
 }

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -35,6 +35,7 @@ var HatType_name = map[int32]string{
 	1: "FEDORA",
 	2: "FEZ",
 }
+
 var HatType_value = map[string]int32{
 	"FEDORA": 1,
 	"FEZ":    2,
@@ -45,9 +46,11 @@ func (x HatType) Enum() *HatType {
 	*p = x
 	return p
 }
+
 func (x HatType) String() string {
 	return proto.EnumName(HatType_name, int32(x))
 }
+
 func (x *HatType) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(HatType_value, data, "HatType")
 	if err != nil {
@@ -56,6 +59,7 @@ func (x *HatType) UnmarshalJSON(data []byte) error {
 	*x = HatType(value)
 	return nil
 }
+
 func (HatType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{0}
 }
@@ -74,6 +78,7 @@ var Days_name = map[int32]string{
 	2: "TUESDAY",
 	// Duplicate value: 1: "LUNDI",
 }
+
 var Days_value = map[string]int32{
 	"MONDAY":  1,
 	"TUESDAY": 2,
@@ -85,9 +90,11 @@ func (x Days) Enum() *Days {
 	*p = x
 	return p
 }
+
 func (x Days) String() string {
 	return proto.EnumName(Days_name, int32(x))
 }
+
 func (x *Days) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(Days_value, data, "Days")
 	if err != nil {
@@ -96,6 +103,7 @@ func (x *Days) UnmarshalJSON(data []byte) error {
 	*x = Days(value)
 	return nil
 }
+
 func (Days) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{1}
 }
@@ -113,6 +121,7 @@ var Request_Color_name = map[int32]string{
 	1: "GREEN",
 	2: "BLUE",
 }
+
 var Request_Color_value = map[string]int32{
 	"RED":   0,
 	"GREEN": 1,
@@ -124,9 +133,11 @@ func (x Request_Color) Enum() *Request_Color {
 	*p = x
 	return p
 }
+
 func (x Request_Color) String() string {
 	return proto.EnumName(Request_Color_name, int32(x))
 }
+
 func (x *Request_Color) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(Request_Color_value, data, "Request_Color")
 	if err != nil {
@@ -135,6 +146,7 @@ func (x *Request_Color) UnmarshalJSON(data []byte) error {
 	*x = Request_Color(value)
 	return nil
 }
+
 func (Request_Color) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{0, 0}
 }
@@ -150,6 +162,7 @@ var Reply_Entry_Game_name = map[int32]string{
 	1: "FOOTBALL",
 	2: "TENNIS",
 }
+
 var Reply_Entry_Game_value = map[string]int32{
 	"FOOTBALL": 1,
 	"TENNIS":   2,
@@ -160,9 +173,11 @@ func (x Reply_Entry_Game) Enum() *Reply_Entry_Game {
 	*p = x
 	return p
 }
+
 func (x Reply_Entry_Game) String() string {
 	return proto.EnumName(Reply_Entry_Game_name, int32(x))
 }
+
 func (x *Reply_Entry_Game) UnmarshalJSON(data []byte) error {
 	value, err := proto.UnmarshalJSONEnum(Reply_Entry_Game_value, data, "Reply_Entry_Game")
 	if err != nil {
@@ -171,6 +186,7 @@ func (x *Reply_Entry_Game) UnmarshalJSON(data []byte) error {
 	*x = Reply_Entry_Game(value)
 	return nil
 }
+
 func (Reply_Entry_Game) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{1, 0, 0}
 }

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -33,6 +33,7 @@ var Request_Flavour_name = map[int32]string{
 	2: "UMAMI",
 	3: "GOPHERLICIOUS",
 }
+
 var Request_Flavour_value = map[string]int32{
 	"SWEET":         0,
 	"SOUR":          1,
@@ -43,6 +44,7 @@ var Request_Flavour_value = map[string]int32{
 func (x Request_Flavour) String() string {
 	return proto.EnumName(Request_Flavour_name, int32(x))
 }
+
 func (Request_Flavour) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_ab04eb4084a521db, []int{0, 0}
 }

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -32,6 +32,7 @@ const (
 var NullValue_name = map[int32]string{
 	0: "NULL_VALUE",
 }
+
 var NullValue_value = map[string]int32{
 	"NULL_VALUE": 0,
 }
@@ -39,9 +40,11 @@ var NullValue_value = map[string]int32{
 func (x NullValue) String() string {
 	return proto.EnumName(NullValue_name, int32(x))
 }
+
 func (NullValue) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_df322afd6c9fb402, []int{0}
 }
+
 func (NullValue) XXX_WellKnownType() string { return "NullValue" }
 
 // `Struct` represents a structured data value, consisting of fields


### PR DESCRIPTION
Trivial change, but eliminates a source of minor diffs between the
current protoc-gen-go and the protogen-backed one.