### PR TITLE
protoc-gen-go: use consistent receiver name for messages

### DIFF
--- a/conformance/internal/conformance_proto/conformance.pb.go
+++ b/conformance/internal/conformance_proto/conformance.pb.go
@@ -143,8 +143,8 @@ func (m *ConformanceRequest) XXX_Unmarshal(b []byte) error {
 func (m *ConformanceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ConformanceRequest.Marshal(b, m, deterministic)
 }
-func (dst *ConformanceRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ConformanceRequest.Merge(dst, src)
+func (m *ConformanceRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ConformanceRequest.Merge(m, src)
 }
 func (m *ConformanceRequest) XXX_Size() int {
 	return xxx_messageInfo_ConformanceRequest.Size(m)
@@ -292,8 +292,8 @@ func (m *ConformanceResponse) XXX_Unmarshal(b []byte) error {
 func (m *ConformanceResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ConformanceResponse.Marshal(b, m, deterministic)
 }
-func (dst *ConformanceResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ConformanceResponse.Merge(dst, src)
+func (m *ConformanceResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ConformanceResponse.Merge(m, src)
 }
 func (m *ConformanceResponse) XXX_Size() int {
 	return xxx_messageInfo_ConformanceResponse.Size(m)
@@ -654,8 +654,8 @@ func (m *TestAllTypes) XXX_Unmarshal(b []byte) error {
 func (m *TestAllTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TestAllTypes.Marshal(b, m, deterministic)
 }
-func (dst *TestAllTypes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TestAllTypes.Merge(dst, src)
+func (m *TestAllTypes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TestAllTypes.Merge(m, src)
 }
 func (m *TestAllTypes) XXX_Size() int {
 	return xxx_messageInfo_TestAllTypes.Size(m)
@@ -1576,8 +1576,8 @@ func (m *TestAllTypes_NestedMessage) XXX_Unmarshal(b []byte) error {
 func (m *TestAllTypes_NestedMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TestAllTypes_NestedMessage.Marshal(b, m, deterministic)
 }
-func (dst *TestAllTypes_NestedMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TestAllTypes_NestedMessage.Merge(dst, src)
+func (m *TestAllTypes_NestedMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TestAllTypes_NestedMessage.Merge(m, src)
 }
 func (m *TestAllTypes_NestedMessage) XXX_Size() int {
 	return xxx_messageInfo_TestAllTypes_NestedMessage.Size(m)
@@ -1621,8 +1621,8 @@ func (m *ForeignMessage) XXX_Unmarshal(b []byte) error {
 func (m *ForeignMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ForeignMessage.Marshal(b, m, deterministic)
 }
-func (dst *ForeignMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ForeignMessage.Merge(dst, src)
+func (m *ForeignMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ForeignMessage.Merge(m, src)
 }
 func (m *ForeignMessage) XXX_Size() int {
 	return xxx_messageInfo_ForeignMessage.Size(m)

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -65,8 +65,8 @@ func (m *Simple3) XXX_Unmarshal(b []byte) error {
 func (m *Simple3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Simple3.Marshal(b, m, deterministic)
 }
-func (dst *Simple3) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Simple3.Merge(dst, src)
+func (m *Simple3) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Simple3.Merge(m, src)
 }
 func (m *Simple3) XXX_Size() int {
 	return xxx_messageInfo_Simple3.Size(m)
@@ -103,8 +103,8 @@ func (m *SimpleSlice3) XXX_Unmarshal(b []byte) error {
 func (m *SimpleSlice3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleSlice3.Marshal(b, m, deterministic)
 }
-func (dst *SimpleSlice3) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SimpleSlice3.Merge(dst, src)
+func (m *SimpleSlice3) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SimpleSlice3.Merge(m, src)
 }
 func (m *SimpleSlice3) XXX_Size() int {
 	return xxx_messageInfo_SimpleSlice3.Size(m)
@@ -141,8 +141,8 @@ func (m *SimpleMap3) XXX_Unmarshal(b []byte) error {
 func (m *SimpleMap3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleMap3.Marshal(b, m, deterministic)
 }
-func (dst *SimpleMap3) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SimpleMap3.Merge(dst, src)
+func (m *SimpleMap3) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SimpleMap3.Merge(m, src)
 }
 func (m *SimpleMap3) XXX_Size() int {
 	return xxx_messageInfo_SimpleMap3.Size(m)
@@ -179,8 +179,8 @@ func (m *SimpleNull3) XXX_Unmarshal(b []byte) error {
 func (m *SimpleNull3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleNull3.Marshal(b, m, deterministic)
 }
-func (dst *SimpleNull3) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SimpleNull3.Merge(dst, src)
+func (m *SimpleNull3) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SimpleNull3.Merge(m, src)
 }
 func (m *SimpleNull3) XXX_Size() int {
 	return xxx_messageInfo_SimpleNull3.Size(m)
@@ -226,8 +226,8 @@ func (m *Mappy) XXX_Unmarshal(b []byte) error {
 func (m *Mappy) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Mappy.Marshal(b, m, deterministic)
 }
-func (dst *Mappy) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Mappy.Merge(dst, src)
+func (m *Mappy) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Mappy.Merge(m, src)
 }
 func (m *Mappy) XXX_Size() int {
 	return xxx_messageInfo_Mappy.Size(m)

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -104,8 +104,8 @@ func (m *Simple) XXX_Unmarshal(b []byte) error {
 func (m *Simple) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Simple.Marshal(b, m, deterministic)
 }
-func (dst *Simple) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Simple.Merge(dst, src)
+func (m *Simple) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Simple.Merge(m, src)
 }
 func (m *Simple) XXX_Size() int {
 	return xxx_messageInfo_Simple.Size(m)
@@ -274,8 +274,8 @@ func (m *NonFinites) XXX_Unmarshal(b []byte) error {
 func (m *NonFinites) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NonFinites.Marshal(b, m, deterministic)
 }
-func (dst *NonFinites) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_NonFinites.Merge(dst, src)
+func (m *NonFinites) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NonFinites.Merge(m, src)
 }
 func (m *NonFinites) XXX_Size() int {
 	return xxx_messageInfo_NonFinites.Size(m)
@@ -358,8 +358,8 @@ func (m *Repeats) XXX_Unmarshal(b []byte) error {
 func (m *Repeats) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Repeats.Marshal(b, m, deterministic)
 }
-func (dst *Repeats) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Repeats.Merge(dst, src)
+func (m *Repeats) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Repeats.Merge(m, src)
 }
 func (m *Repeats) XXX_Size() int {
 	return xxx_messageInfo_Repeats.Size(m)
@@ -472,8 +472,8 @@ func (m *Widget) XXX_Unmarshal(b []byte) error {
 func (m *Widget) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Widget.Marshal(b, m, deterministic)
 }
-func (dst *Widget) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Widget.Merge(dst, src)
+func (m *Widget) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Widget.Merge(m, src)
 }
 func (m *Widget) XXX_Size() int {
 	return xxx_messageInfo_Widget.Size(m)
@@ -546,8 +546,8 @@ func (m *Maps) XXX_Unmarshal(b []byte) error {
 func (m *Maps) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Maps.Marshal(b, m, deterministic)
 }
-func (dst *Maps) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Maps.Merge(dst, src)
+func (m *Maps) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Maps.Merge(m, src)
 }
 func (m *Maps) XXX_Size() int {
 	return xxx_messageInfo_Maps.Size(m)
@@ -597,8 +597,8 @@ func (m *MsgWithOneof) XXX_Unmarshal(b []byte) error {
 func (m *MsgWithOneof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithOneof.Marshal(b, m, deterministic)
 }
-func (dst *MsgWithOneof) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgWithOneof.Merge(dst, src)
+func (m *MsgWithOneof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithOneof.Merge(m, src)
 }
 func (m *MsgWithOneof) XXX_Size() int {
 	return xxx_messageInfo_MsgWithOneof.Size(m)
@@ -827,8 +827,8 @@ func (m *Real) XXX_Unmarshal(b []byte) error {
 func (m *Real) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Real.Marshal(b, m, deterministic)
 }
-func (dst *Real) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Real.Merge(dst, src)
+func (m *Real) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Real.Merge(m, src)
 }
 func (m *Real) XXX_Size() int {
 	return xxx_messageInfo_Real.Size(m)
@@ -874,8 +874,8 @@ func (m *Complex) XXX_Unmarshal(b []byte) error {
 func (m *Complex) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Complex.Marshal(b, m, deterministic)
 }
-func (dst *Complex) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Complex.Merge(dst, src)
+func (m *Complex) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Complex.Merge(m, src)
 }
 func (m *Complex) XXX_Size() int {
 	return xxx_messageInfo_Complex.Size(m)
@@ -935,8 +935,8 @@ func (m *KnownTypes) XXX_Unmarshal(b []byte) error {
 func (m *KnownTypes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_KnownTypes.Marshal(b, m, deterministic)
 }
-func (dst *KnownTypes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_KnownTypes.Merge(dst, src)
+func (m *KnownTypes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_KnownTypes.Merge(m, src)
 }
 func (m *KnownTypes) XXX_Size() int {
 	return xxx_messageInfo_KnownTypes.Size(m)
@@ -1072,8 +1072,8 @@ func (m *MsgWithRequired) XXX_Unmarshal(b []byte) error {
 func (m *MsgWithRequired) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithRequired.Marshal(b, m, deterministic)
 }
-func (dst *MsgWithRequired) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgWithRequired.Merge(dst, src)
+func (m *MsgWithRequired) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithRequired.Merge(m, src)
 }
 func (m *MsgWithRequired) XXX_Size() int {
 	return xxx_messageInfo_MsgWithRequired.Size(m)
@@ -1112,8 +1112,8 @@ func (m *MsgWithIndirectRequired) XXX_Unmarshal(b []byte) error {
 func (m *MsgWithIndirectRequired) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithIndirectRequired.Marshal(b, m, deterministic)
 }
-func (dst *MsgWithIndirectRequired) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgWithIndirectRequired.Merge(dst, src)
+func (m *MsgWithIndirectRequired) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithIndirectRequired.Merge(m, src)
 }
 func (m *MsgWithIndirectRequired) XXX_Size() int {
 	return xxx_messageInfo_MsgWithIndirectRequired.Size(m)
@@ -1164,8 +1164,8 @@ func (m *MsgWithRequiredBytes) XXX_Unmarshal(b []byte) error {
 func (m *MsgWithRequiredBytes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithRequiredBytes.Marshal(b, m, deterministic)
 }
-func (dst *MsgWithRequiredBytes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgWithRequiredBytes.Merge(dst, src)
+func (m *MsgWithRequiredBytes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithRequiredBytes.Merge(m, src)
 }
 func (m *MsgWithRequiredBytes) XXX_Size() int {
 	return xxx_messageInfo_MsgWithRequiredBytes.Size(m)
@@ -1202,8 +1202,8 @@ func (m *MsgWithRequiredWKT) XXX_Unmarshal(b []byte) error {
 func (m *MsgWithRequiredWKT) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MsgWithRequiredWKT.Marshal(b, m, deterministic)
 }
-func (dst *MsgWithRequiredWKT) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MsgWithRequiredWKT.Merge(dst, src)
+func (m *MsgWithRequiredWKT) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithRequiredWKT.Merge(m, src)
 }
 func (m *MsgWithRequiredWKT) XXX_Size() int {
 	return xxx_messageInfo_MsgWithRequiredWKT.Size(m)

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -88,8 +88,8 @@ func (m *Message) XXX_Unmarshal(b []byte) error {
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Message.Marshal(b, m, deterministic)
 }
-func (dst *Message) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message.Merge(dst, src)
+func (m *Message) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message.Merge(m, src)
 }
 func (m *Message) XXX_Size() int {
 	return xxx_messageInfo_Message.Size(m)
@@ -253,8 +253,8 @@ func (m *Nested) XXX_Unmarshal(b []byte) error {
 func (m *Nested) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Nested.Marshal(b, m, deterministic)
 }
-func (dst *Nested) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Nested.Merge(dst, src)
+func (m *Nested) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Nested.Merge(m, src)
 }
 func (m *Nested) XXX_Size() int {
 	return xxx_messageInfo_Nested.Size(m)
@@ -298,8 +298,8 @@ func (m *MessageWithMap) XXX_Unmarshal(b []byte) error {
 func (m *MessageWithMap) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageWithMap.Marshal(b, m, deterministic)
 }
-func (dst *MessageWithMap) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MessageWithMap.Merge(dst, src)
+func (m *MessageWithMap) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MessageWithMap.Merge(m, src)
 }
 func (m *MessageWithMap) XXX_Size() int {
 	return xxx_messageInfo_MessageWithMap.Size(m)
@@ -336,8 +336,8 @@ func (m *IntMap) XXX_Unmarshal(b []byte) error {
 func (m *IntMap) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_IntMap.Marshal(b, m, deterministic)
 }
-func (dst *IntMap) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_IntMap.Merge(dst, src)
+func (m *IntMap) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_IntMap.Merge(m, src)
 }
 func (m *IntMap) XXX_Size() int {
 	return xxx_messageInfo_IntMap.Size(m)
@@ -374,8 +374,8 @@ func (m *IntMaps) XXX_Unmarshal(b []byte) error {
 func (m *IntMaps) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_IntMaps.Marshal(b, m, deterministic)
 }
-func (dst *IntMaps) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_IntMaps.Merge(dst, src)
+func (m *IntMaps) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_IntMaps.Merge(m, src)
 }
 func (m *IntMaps) XXX_Size() int {
 	return xxx_messageInfo_IntMaps.Size(m)
@@ -418,8 +418,8 @@ func (m *TestUTF8) XXX_Unmarshal(b []byte) error {
 func (m *TestUTF8) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TestUTF8.Marshal(b, m, deterministic)
 }
-func (dst *TestUTF8) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TestUTF8.Merge(dst, src)
+func (m *TestUTF8) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TestUTF8.Merge(m, src)
 }
 func (m *TestUTF8) XXX_Size() int {
 	return xxx_messageInfo_TestUTF8.Size(m)

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -318,8 +318,8 @@ func (m *GoEnum) XXX_Unmarshal(b []byte) error {
 func (m *GoEnum) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoEnum.Marshal(b, m, deterministic)
 }
-func (dst *GoEnum) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoEnum.Merge(dst, src)
+func (m *GoEnum) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoEnum.Merge(m, src)
 }
 func (m *GoEnum) XXX_Size() int {
 	return xxx_messageInfo_GoEnum.Size(m)
@@ -357,8 +357,8 @@ func (m *GoTestField) XXX_Unmarshal(b []byte) error {
 func (m *GoTestField) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTestField.Marshal(b, m, deterministic)
 }
-func (dst *GoTestField) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoTestField.Merge(dst, src)
+func (m *GoTestField) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoTestField.Merge(m, src)
 }
 func (m *GoTestField) XXX_Size() int {
 	return xxx_messageInfo_GoTestField.Size(m)
@@ -490,8 +490,8 @@ func (m *GoTest) XXX_Unmarshal(b []byte) error {
 func (m *GoTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest.Marshal(b, m, deterministic)
 }
-func (dst *GoTest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoTest.Merge(dst, src)
+func (m *GoTest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoTest.Merge(m, src)
 }
 func (m *GoTest) XXX_Size() int {
 	return xxx_messageInfo_GoTest.Size(m)
@@ -1114,8 +1114,8 @@ func (m *GoTest_RequiredGroup) XXX_Unmarshal(b []byte) error {
 func (m *GoTest_RequiredGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest_RequiredGroup.Marshal(b, m, deterministic)
 }
-func (dst *GoTest_RequiredGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoTest_RequiredGroup.Merge(dst, src)
+func (m *GoTest_RequiredGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoTest_RequiredGroup.Merge(m, src)
 }
 func (m *GoTest_RequiredGroup) XXX_Size() int {
 	return xxx_messageInfo_GoTest_RequiredGroup.Size(m)
@@ -1152,8 +1152,8 @@ func (m *GoTest_RepeatedGroup) XXX_Unmarshal(b []byte) error {
 func (m *GoTest_RepeatedGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest_RepeatedGroup.Marshal(b, m, deterministic)
 }
-func (dst *GoTest_RepeatedGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoTest_RepeatedGroup.Merge(dst, src)
+func (m *GoTest_RepeatedGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoTest_RepeatedGroup.Merge(m, src)
 }
 func (m *GoTest_RepeatedGroup) XXX_Size() int {
 	return xxx_messageInfo_GoTest_RepeatedGroup.Size(m)
@@ -1190,8 +1190,8 @@ func (m *GoTest_OptionalGroup) XXX_Unmarshal(b []byte) error {
 func (m *GoTest_OptionalGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTest_OptionalGroup.Marshal(b, m, deterministic)
 }
-func (dst *GoTest_OptionalGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoTest_OptionalGroup.Merge(dst, src)
+func (m *GoTest_OptionalGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoTest_OptionalGroup.Merge(m, src)
 }
 func (m *GoTest_OptionalGroup) XXX_Size() int {
 	return xxx_messageInfo_GoTest_OptionalGroup.Size(m)
@@ -1229,8 +1229,8 @@ func (m *GoTestRequiredGroupField) XXX_Unmarshal(b []byte) error {
 func (m *GoTestRequiredGroupField) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTestRequiredGroupField.Marshal(b, m, deterministic)
 }
-func (dst *GoTestRequiredGroupField) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoTestRequiredGroupField.Merge(dst, src)
+func (m *GoTestRequiredGroupField) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoTestRequiredGroupField.Merge(m, src)
 }
 func (m *GoTestRequiredGroupField) XXX_Size() int {
 	return xxx_messageInfo_GoTestRequiredGroupField.Size(m)
@@ -1267,8 +1267,8 @@ func (m *GoTestRequiredGroupField_Group) XXX_Unmarshal(b []byte) error {
 func (m *GoTestRequiredGroupField_Group) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoTestRequiredGroupField_Group.Marshal(b, m, deterministic)
 }
-func (dst *GoTestRequiredGroupField_Group) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoTestRequiredGroupField_Group.Merge(dst, src)
+func (m *GoTestRequiredGroupField_Group) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoTestRequiredGroupField_Group.Merge(m, src)
 }
 func (m *GoTestRequiredGroupField_Group) XXX_Size() int {
 	return xxx_messageInfo_GoTestRequiredGroupField_Group.Size(m)
@@ -1312,8 +1312,8 @@ func (m *GoSkipTest) XXX_Unmarshal(b []byte) error {
 func (m *GoSkipTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoSkipTest.Marshal(b, m, deterministic)
 }
-func (dst *GoSkipTest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoSkipTest.Merge(dst, src)
+func (m *GoSkipTest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoSkipTest.Merge(m, src)
 }
 func (m *GoSkipTest) XXX_Size() int {
 	return xxx_messageInfo_GoSkipTest.Size(m)
@@ -1379,8 +1379,8 @@ func (m *GoSkipTest_SkipGroup) XXX_Unmarshal(b []byte) error {
 func (m *GoSkipTest_SkipGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GoSkipTest_SkipGroup.Marshal(b, m, deterministic)
 }
-func (dst *GoSkipTest_SkipGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GoSkipTest_SkipGroup.Merge(dst, src)
+func (m *GoSkipTest_SkipGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GoSkipTest_SkipGroup.Merge(m, src)
 }
 func (m *GoSkipTest_SkipGroup) XXX_Size() int {
 	return xxx_messageInfo_GoSkipTest_SkipGroup.Size(m)
@@ -1426,8 +1426,8 @@ func (m *NonPackedTest) XXX_Unmarshal(b []byte) error {
 func (m *NonPackedTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NonPackedTest.Marshal(b, m, deterministic)
 }
-func (dst *NonPackedTest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_NonPackedTest.Merge(dst, src)
+func (m *NonPackedTest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NonPackedTest.Merge(m, src)
 }
 func (m *NonPackedTest) XXX_Size() int {
 	return xxx_messageInfo_NonPackedTest.Size(m)
@@ -1464,8 +1464,8 @@ func (m *PackedTest) XXX_Unmarshal(b []byte) error {
 func (m *PackedTest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PackedTest.Marshal(b, m, deterministic)
 }
-func (dst *PackedTest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PackedTest.Merge(dst, src)
+func (m *PackedTest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PackedTest.Merge(m, src)
 }
 func (m *PackedTest) XXX_Size() int {
 	return xxx_messageInfo_PackedTest.Size(m)
@@ -1503,8 +1503,8 @@ func (m *MaxTag) XXX_Unmarshal(b []byte) error {
 func (m *MaxTag) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MaxTag.Marshal(b, m, deterministic)
 }
-func (dst *MaxTag) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MaxTag.Merge(dst, src)
+func (m *MaxTag) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MaxTag.Merge(m, src)
 }
 func (m *MaxTag) XXX_Size() int {
 	return xxx_messageInfo_MaxTag.Size(m)
@@ -1542,8 +1542,8 @@ func (m *OldMessage) XXX_Unmarshal(b []byte) error {
 func (m *OldMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldMessage.Marshal(b, m, deterministic)
 }
-func (dst *OldMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OldMessage.Merge(dst, src)
+func (m *OldMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OldMessage.Merge(m, src)
 }
 func (m *OldMessage) XXX_Size() int {
 	return xxx_messageInfo_OldMessage.Size(m)
@@ -1587,8 +1587,8 @@ func (m *OldMessage_Nested) XXX_Unmarshal(b []byte) error {
 func (m *OldMessage_Nested) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldMessage_Nested.Marshal(b, m, deterministic)
 }
-func (dst *OldMessage_Nested) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OldMessage_Nested.Merge(dst, src)
+func (m *OldMessage_Nested) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OldMessage_Nested.Merge(m, src)
 }
 func (m *OldMessage_Nested) XXX_Size() int {
 	return xxx_messageInfo_OldMessage_Nested.Size(m)
@@ -1629,8 +1629,8 @@ func (m *NewMessage) XXX_Unmarshal(b []byte) error {
 func (m *NewMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NewMessage.Marshal(b, m, deterministic)
 }
-func (dst *NewMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_NewMessage.Merge(dst, src)
+func (m *NewMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NewMessage.Merge(m, src)
 }
 func (m *NewMessage) XXX_Size() int {
 	return xxx_messageInfo_NewMessage.Size(m)
@@ -1675,8 +1675,8 @@ func (m *NewMessage_Nested) XXX_Unmarshal(b []byte) error {
 func (m *NewMessage_Nested) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_NewMessage_Nested.Marshal(b, m, deterministic)
 }
-func (dst *NewMessage_Nested) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_NewMessage_Nested.Merge(dst, src)
+func (m *NewMessage_Nested) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NewMessage_Nested.Merge(m, src)
 }
 func (m *NewMessage_Nested) XXX_Size() int {
 	return xxx_messageInfo_NewMessage_Nested.Size(m)
@@ -1722,8 +1722,8 @@ func (m *InnerMessage) XXX_Unmarshal(b []byte) error {
 func (m *InnerMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_InnerMessage.Marshal(b, m, deterministic)
 }
-func (dst *InnerMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InnerMessage.Merge(dst, src)
+func (m *InnerMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_InnerMessage.Merge(m, src)
 }
 func (m *InnerMessage) XXX_Size() int {
 	return xxx_messageInfo_InnerMessage.Size(m)
@@ -1788,8 +1788,8 @@ func (m *OtherMessage) XXX_Unmarshal(b []byte) error {
 func (m *OtherMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OtherMessage.Marshal(b, m, deterministic)
 }
-func (dst *OtherMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OtherMessage.Merge(dst, src)
+func (m *OtherMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OtherMessage.Merge(m, src)
 }
 func (m *OtherMessage) XXX_Size() int {
 	return xxx_messageInfo_OtherMessage.Size(m)
@@ -1847,8 +1847,8 @@ func (m *RequiredInnerMessage) XXX_Unmarshal(b []byte) error {
 func (m *RequiredInnerMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RequiredInnerMessage.Marshal(b, m, deterministic)
 }
-func (dst *RequiredInnerMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RequiredInnerMessage.Merge(dst, src)
+func (m *RequiredInnerMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RequiredInnerMessage.Merge(m, src)
 }
 func (m *RequiredInnerMessage) XXX_Size() int {
 	return xxx_messageInfo_RequiredInnerMessage.Size(m)
@@ -1906,8 +1906,8 @@ func (m *MyMessage) XXX_Unmarshal(b []byte) error {
 func (m *MyMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MyMessage.Marshal(b, m, deterministic)
 }
-func (dst *MyMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MyMessage.Merge(dst, src)
+func (m *MyMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MyMessage.Merge(m, src)
 }
 func (m *MyMessage) XXX_Size() int {
 	return xxx_messageInfo_MyMessage.Size(m)
@@ -2021,8 +2021,8 @@ func (m *MyMessage_SomeGroup) XXX_Unmarshal(b []byte) error {
 func (m *MyMessage_SomeGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MyMessage_SomeGroup.Marshal(b, m, deterministic)
 }
-func (dst *MyMessage_SomeGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MyMessage_SomeGroup.Merge(dst, src)
+func (m *MyMessage_SomeGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MyMessage_SomeGroup.Merge(m, src)
 }
 func (m *MyMessage_SomeGroup) XXX_Size() int {
 	return xxx_messageInfo_MyMessage_SomeGroup.Size(m)
@@ -2060,8 +2060,8 @@ func (m *Ext) XXX_Unmarshal(b []byte) error {
 func (m *Ext) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Ext.Marshal(b, m, deterministic)
 }
-func (dst *Ext) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Ext.Merge(dst, src)
+func (m *Ext) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Ext.Merge(m, src)
 }
 func (m *Ext) XXX_Size() int {
 	return xxx_messageInfo_Ext.Size(m)
@@ -2134,8 +2134,8 @@ func (m *ComplexExtension) XXX_Unmarshal(b []byte) error {
 func (m *ComplexExtension) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ComplexExtension.Marshal(b, m, deterministic)
 }
-func (dst *ComplexExtension) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ComplexExtension.Merge(dst, src)
+func (m *ComplexExtension) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ComplexExtension.Merge(m, src)
 }
 func (m *ComplexExtension) XXX_Size() int {
 	return xxx_messageInfo_ComplexExtension.Size(m)
@@ -2194,8 +2194,8 @@ func (m *DefaultsMessage) XXX_Unmarshal(b []byte) error {
 func (m *DefaultsMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DefaultsMessage.Marshal(b, m, deterministic)
 }
-func (dst *DefaultsMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DefaultsMessage.Merge(dst, src)
+func (m *DefaultsMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DefaultsMessage.Merge(m, src)
 }
 func (m *DefaultsMessage) XXX_Size() int {
 	return xxx_messageInfo_DefaultsMessage.Size(m)
@@ -2240,8 +2240,8 @@ func (m *MyMessageSet) XXX_Unmarshal(b []byte) error {
 func (m *MyMessageSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MyMessageSet.Marshal(b, m, deterministic)
 }
-func (dst *MyMessageSet) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MyMessageSet.Merge(dst, src)
+func (m *MyMessageSet) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MyMessageSet.Merge(m, src)
 }
 func (m *MyMessageSet) XXX_Size() int {
 	return xxx_messageInfo_MyMessageSet.Size(m)
@@ -2270,8 +2270,8 @@ func (m *Empty) XXX_Unmarshal(b []byte) error {
 func (m *Empty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Empty.Marshal(b, m, deterministic)
 }
-func (dst *Empty) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Empty.Merge(dst, src)
+func (m *Empty) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Empty.Merge(m, src)
 }
 func (m *Empty) XXX_Size() int {
 	return xxx_messageInfo_Empty.Size(m)
@@ -2301,8 +2301,8 @@ func (m *MessageList) XXX_Unmarshal(b []byte) error {
 func (m *MessageList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageList.Marshal(b, m, deterministic)
 }
-func (dst *MessageList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MessageList.Merge(dst, src)
+func (m *MessageList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MessageList.Merge(m, src)
 }
 func (m *MessageList) XXX_Size() int {
 	return xxx_messageInfo_MessageList.Size(m)
@@ -2340,8 +2340,8 @@ func (m *MessageList_Message) XXX_Unmarshal(b []byte) error {
 func (m *MessageList_Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageList_Message.Marshal(b, m, deterministic)
 }
-func (dst *MessageList_Message) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MessageList_Message.Merge(dst, src)
+func (m *MessageList_Message) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MessageList_Message.Merge(m, src)
 }
 func (m *MessageList_Message) XXX_Size() int {
 	return xxx_messageInfo_MessageList_Message.Size(m)
@@ -2386,8 +2386,8 @@ func (m *Strings) XXX_Unmarshal(b []byte) error {
 func (m *Strings) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Strings.Marshal(b, m, deterministic)
 }
-func (dst *Strings) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Strings.Merge(dst, src)
+func (m *Strings) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Strings.Merge(m, src)
 }
 func (m *Strings) XXX_Size() int {
 	return xxx_messageInfo_Strings.Size(m)
@@ -2454,8 +2454,8 @@ func (m *Defaults) XXX_Unmarshal(b []byte) error {
 func (m *Defaults) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Defaults.Marshal(b, m, deterministic)
 }
-func (dst *Defaults) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Defaults.Merge(dst, src)
+func (m *Defaults) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Defaults.Merge(m, src)
 }
 func (m *Defaults) XXX_Size() int {
 	return xxx_messageInfo_Defaults.Size(m)
@@ -2639,8 +2639,8 @@ func (m *SubDefaults) XXX_Unmarshal(b []byte) error {
 func (m *SubDefaults) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SubDefaults.Marshal(b, m, deterministic)
 }
-func (dst *SubDefaults) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SubDefaults.Merge(dst, src)
+func (m *SubDefaults) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SubDefaults.Merge(m, src)
 }
 func (m *SubDefaults) XXX_Size() int {
 	return xxx_messageInfo_SubDefaults.Size(m)
@@ -2679,8 +2679,8 @@ func (m *RepeatedEnum) XXX_Unmarshal(b []byte) error {
 func (m *RepeatedEnum) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RepeatedEnum.Marshal(b, m, deterministic)
 }
-func (dst *RepeatedEnum) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RepeatedEnum.Merge(dst, src)
+func (m *RepeatedEnum) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RepeatedEnum.Merge(m, src)
 }
 func (m *RepeatedEnum) XXX_Size() int {
 	return xxx_messageInfo_RepeatedEnum.Size(m)
@@ -2723,8 +2723,8 @@ func (m *MoreRepeated) XXX_Unmarshal(b []byte) error {
 func (m *MoreRepeated) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MoreRepeated.Marshal(b, m, deterministic)
 }
-func (dst *MoreRepeated) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MoreRepeated.Merge(dst, src)
+func (m *MoreRepeated) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MoreRepeated.Merge(m, src)
 }
 func (m *MoreRepeated) XXX_Size() int {
 	return xxx_messageInfo_MoreRepeated.Size(m)
@@ -2803,8 +2803,8 @@ func (m *GroupOld) XXX_Unmarshal(b []byte) error {
 func (m *GroupOld) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupOld.Marshal(b, m, deterministic)
 }
-func (dst *GroupOld) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GroupOld.Merge(dst, src)
+func (m *GroupOld) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GroupOld.Merge(m, src)
 }
 func (m *GroupOld) XXX_Size() int {
 	return xxx_messageInfo_GroupOld.Size(m)
@@ -2841,8 +2841,8 @@ func (m *GroupOld_G) XXX_Unmarshal(b []byte) error {
 func (m *GroupOld_G) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupOld_G.Marshal(b, m, deterministic)
 }
-func (dst *GroupOld_G) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GroupOld_G.Merge(dst, src)
+func (m *GroupOld_G) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GroupOld_G.Merge(m, src)
 }
 func (m *GroupOld_G) XXX_Size() int {
 	return xxx_messageInfo_GroupOld_G.Size(m)
@@ -2879,8 +2879,8 @@ func (m *GroupNew) XXX_Unmarshal(b []byte) error {
 func (m *GroupNew) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupNew.Marshal(b, m, deterministic)
 }
-func (dst *GroupNew) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GroupNew.Merge(dst, src)
+func (m *GroupNew) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GroupNew.Merge(m, src)
 }
 func (m *GroupNew) XXX_Size() int {
 	return xxx_messageInfo_GroupNew.Size(m)
@@ -2918,8 +2918,8 @@ func (m *GroupNew_G) XXX_Unmarshal(b []byte) error {
 func (m *GroupNew_G) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GroupNew_G.Marshal(b, m, deterministic)
 }
-func (dst *GroupNew_G) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GroupNew_G.Merge(dst, src)
+func (m *GroupNew_G) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GroupNew_G.Merge(m, src)
 }
 func (m *GroupNew_G) XXX_Size() int {
 	return xxx_messageInfo_GroupNew_G.Size(m)
@@ -2964,8 +2964,8 @@ func (m *FloatingPoint) XXX_Unmarshal(b []byte) error {
 func (m *FloatingPoint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FloatingPoint.Marshal(b, m, deterministic)
 }
-func (dst *FloatingPoint) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FloatingPoint.Merge(dst, src)
+func (m *FloatingPoint) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FloatingPoint.Merge(m, src)
 }
 func (m *FloatingPoint) XXX_Size() int {
 	return xxx_messageInfo_FloatingPoint.Size(m)
@@ -3012,8 +3012,8 @@ func (m *MessageWithMap) XXX_Unmarshal(b []byte) error {
 func (m *MessageWithMap) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageWithMap.Marshal(b, m, deterministic)
 }
-func (dst *MessageWithMap) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MessageWithMap.Merge(dst, src)
+func (m *MessageWithMap) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MessageWithMap.Merge(m, src)
 }
 func (m *MessageWithMap) XXX_Size() int {
 	return xxx_messageInfo_MessageWithMap.Size(m)
@@ -3092,8 +3092,8 @@ func (m *Oneof) XXX_Unmarshal(b []byte) error {
 func (m *Oneof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Oneof.Marshal(b, m, deterministic)
 }
-func (dst *Oneof) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Oneof.Merge(dst, src)
+func (m *Oneof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Oneof.Merge(m, src)
 }
 func (m *Oneof) XXX_Size() int {
 	return xxx_messageInfo_Oneof.Size(m)
@@ -3695,8 +3695,8 @@ func (m *Oneof_F_Group) XXX_Unmarshal(b []byte) error {
 func (m *Oneof_F_Group) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Oneof_F_Group.Marshal(b, m, deterministic)
 }
-func (dst *Oneof_F_Group) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Oneof_F_Group.Merge(dst, src)
+func (m *Oneof_F_Group) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Oneof_F_Group.Merge(m, src)
 }
 func (m *Oneof_F_Group) XXX_Size() int {
 	return xxx_messageInfo_Oneof_F_Group.Size(m)
@@ -3743,8 +3743,8 @@ func (m *Communique) XXX_Unmarshal(b []byte) error {
 func (m *Communique) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique.Marshal(b, m, deterministic)
 }
-func (dst *Communique) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Communique.Merge(dst, src)
+func (m *Communique) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Communique.Merge(m, src)
 }
 func (m *Communique) XXX_Size() int {
 	return xxx_messageInfo_Communique.Size(m)
@@ -4003,8 +4003,8 @@ func (m *TestUTF8) XXX_Unmarshal(b []byte) error {
 func (m *TestUTF8) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TestUTF8.Marshal(b, m, deterministic)
 }
-func (dst *TestUTF8) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TestUTF8.Merge(dst, src)
+func (m *TestUTF8) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TestUTF8.Merge(m, src)
 }
 func (m *TestUTF8) XXX_Size() int {
 	return xxx_messageInfo_TestUTF8.Size(m)

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -363,8 +363,8 @@ func (m *FileDescriptorSet) XXX_Unmarshal(b []byte) error {
 func (m *FileDescriptorSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FileDescriptorSet.Marshal(b, m, deterministic)
 }
-func (dst *FileDescriptorSet) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileDescriptorSet.Merge(dst, src)
+func (m *FileDescriptorSet) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FileDescriptorSet.Merge(m, src)
 }
 func (m *FileDescriptorSet) XXX_Size() int {
 	return xxx_messageInfo_FileDescriptorSet.Size(m)
@@ -424,8 +424,8 @@ func (m *FileDescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *FileDescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FileDescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *FileDescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileDescriptorProto.Merge(dst, src)
+func (m *FileDescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FileDescriptorProto.Merge(m, src)
 }
 func (m *FileDescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_FileDescriptorProto.Size(m)
@@ -551,8 +551,8 @@ func (m *DescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *DescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *DescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DescriptorProto.Merge(dst, src)
+func (m *DescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DescriptorProto.Merge(m, src)
 }
 func (m *DescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_DescriptorProto.Size(m)
@@ -654,8 +654,8 @@ func (m *DescriptorProto_ExtensionRange) XXX_Unmarshal(b []byte) error {
 func (m *DescriptorProto_ExtensionRange) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DescriptorProto_ExtensionRange.Marshal(b, m, deterministic)
 }
-func (dst *DescriptorProto_ExtensionRange) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DescriptorProto_ExtensionRange.Merge(dst, src)
+func (m *DescriptorProto_ExtensionRange) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DescriptorProto_ExtensionRange.Merge(m, src)
 }
 func (m *DescriptorProto_ExtensionRange) XXX_Size() int {
 	return xxx_messageInfo_DescriptorProto_ExtensionRange.Size(m)
@@ -710,8 +710,8 @@ func (m *DescriptorProto_ReservedRange) XXX_Unmarshal(b []byte) error {
 func (m *DescriptorProto_ReservedRange) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DescriptorProto_ReservedRange.Marshal(b, m, deterministic)
 }
-func (dst *DescriptorProto_ReservedRange) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DescriptorProto_ReservedRange.Merge(dst, src)
+func (m *DescriptorProto_ReservedRange) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DescriptorProto_ReservedRange.Merge(m, src)
 }
 func (m *DescriptorProto_ReservedRange) XXX_Size() int {
 	return xxx_messageInfo_DescriptorProto_ReservedRange.Size(m)
@@ -765,8 +765,8 @@ func (m *ExtensionRangeOptions) XXX_Unmarshal(b []byte) error {
 func (m *ExtensionRangeOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ExtensionRangeOptions.Marshal(b, m, deterministic)
 }
-func (dst *ExtensionRangeOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ExtensionRangeOptions.Merge(dst, src)
+func (m *ExtensionRangeOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ExtensionRangeOptions.Merge(m, src)
 }
 func (m *ExtensionRangeOptions) XXX_Size() int {
 	return xxx_messageInfo_ExtensionRangeOptions.Size(m)
@@ -833,8 +833,8 @@ func (m *FieldDescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *FieldDescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FieldDescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *FieldDescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FieldDescriptorProto.Merge(dst, src)
+func (m *FieldDescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FieldDescriptorProto.Merge(m, src)
 }
 func (m *FieldDescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_FieldDescriptorProto.Size(m)
@@ -936,8 +936,8 @@ func (m *OneofDescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *OneofDescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OneofDescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *OneofDescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OneofDescriptorProto.Merge(dst, src)
+func (m *OneofDescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OneofDescriptorProto.Merge(m, src)
 }
 func (m *OneofDescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_OneofDescriptorProto.Size(m)
@@ -991,8 +991,8 @@ func (m *EnumDescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *EnumDescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_EnumDescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *EnumDescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnumDescriptorProto.Merge(dst, src)
+func (m *EnumDescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnumDescriptorProto.Merge(m, src)
 }
 func (m *EnumDescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_EnumDescriptorProto.Size(m)
@@ -1064,8 +1064,8 @@ func (m *EnumDescriptorProto_EnumReservedRange) XXX_Unmarshal(b []byte) error {
 func (m *EnumDescriptorProto_EnumReservedRange) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_EnumDescriptorProto_EnumReservedRange.Marshal(b, m, deterministic)
 }
-func (dst *EnumDescriptorProto_EnumReservedRange) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnumDescriptorProto_EnumReservedRange.Merge(dst, src)
+func (m *EnumDescriptorProto_EnumReservedRange) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnumDescriptorProto_EnumReservedRange.Merge(m, src)
 }
 func (m *EnumDescriptorProto_EnumReservedRange) XXX_Size() int {
 	return xxx_messageInfo_EnumDescriptorProto_EnumReservedRange.Size(m)
@@ -1112,8 +1112,8 @@ func (m *EnumValueDescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *EnumValueDescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_EnumValueDescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *EnumValueDescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnumValueDescriptorProto.Merge(dst, src)
+func (m *EnumValueDescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnumValueDescriptorProto.Merge(m, src)
 }
 func (m *EnumValueDescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_EnumValueDescriptorProto.Size(m)
@@ -1167,8 +1167,8 @@ func (m *ServiceDescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *ServiceDescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ServiceDescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *ServiceDescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ServiceDescriptorProto.Merge(dst, src)
+func (m *ServiceDescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ServiceDescriptorProto.Merge(m, src)
 }
 func (m *ServiceDescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_ServiceDescriptorProto.Size(m)
@@ -1229,8 +1229,8 @@ func (m *MethodDescriptorProto) XXX_Unmarshal(b []byte) error {
 func (m *MethodDescriptorProto) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MethodDescriptorProto.Marshal(b, m, deterministic)
 }
-func (dst *MethodDescriptorProto) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MethodDescriptorProto.Merge(dst, src)
+func (m *MethodDescriptorProto) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MethodDescriptorProto.Merge(m, src)
 }
 func (m *MethodDescriptorProto) XXX_Size() int {
 	return xxx_messageInfo_MethodDescriptorProto.Size(m)
@@ -1389,8 +1389,8 @@ func (m *FileOptions) XXX_Unmarshal(b []byte) error {
 func (m *FileOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FileOptions.Marshal(b, m, deterministic)
 }
-func (dst *FileOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileOptions.Merge(dst, src)
+func (m *FileOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FileOptions.Merge(m, src)
 }
 func (m *FileOptions) XXX_Size() int {
 	return xxx_messageInfo_FileOptions.Size(m)
@@ -1624,8 +1624,8 @@ func (m *MessageOptions) XXX_Unmarshal(b []byte) error {
 func (m *MessageOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MessageOptions.Marshal(b, m, deterministic)
 }
-func (dst *MessageOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MessageOptions.Merge(dst, src)
+func (m *MessageOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MessageOptions.Merge(m, src)
 }
 func (m *MessageOptions) XXX_Size() int {
 	return xxx_messageInfo_MessageOptions.Size(m)
@@ -1763,8 +1763,8 @@ func (m *FieldOptions) XXX_Unmarshal(b []byte) error {
 func (m *FieldOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FieldOptions.Marshal(b, m, deterministic)
 }
-func (dst *FieldOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FieldOptions.Merge(dst, src)
+func (m *FieldOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FieldOptions.Merge(m, src)
 }
 func (m *FieldOptions) XXX_Size() int {
 	return xxx_messageInfo_FieldOptions.Size(m)
@@ -1859,8 +1859,8 @@ func (m *OneofOptions) XXX_Unmarshal(b []byte) error {
 func (m *OneofOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OneofOptions.Marshal(b, m, deterministic)
 }
-func (dst *OneofOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OneofOptions.Merge(dst, src)
+func (m *OneofOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OneofOptions.Merge(m, src)
 }
 func (m *OneofOptions) XXX_Size() int {
 	return xxx_messageInfo_OneofOptions.Size(m)
@@ -1915,8 +1915,8 @@ func (m *EnumOptions) XXX_Unmarshal(b []byte) error {
 func (m *EnumOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_EnumOptions.Marshal(b, m, deterministic)
 }
-func (dst *EnumOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnumOptions.Merge(dst, src)
+func (m *EnumOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnumOptions.Merge(m, src)
 }
 func (m *EnumOptions) XXX_Size() int {
 	return xxx_messageInfo_EnumOptions.Size(m)
@@ -1984,8 +1984,8 @@ func (m *EnumValueOptions) XXX_Unmarshal(b []byte) error {
 func (m *EnumValueOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_EnumValueOptions.Marshal(b, m, deterministic)
 }
-func (dst *EnumValueOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnumValueOptions.Merge(dst, src)
+func (m *EnumValueOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnumValueOptions.Merge(m, src)
 }
 func (m *EnumValueOptions) XXX_Size() int {
 	return xxx_messageInfo_EnumValueOptions.Size(m)
@@ -2046,8 +2046,8 @@ func (m *ServiceOptions) XXX_Unmarshal(b []byte) error {
 func (m *ServiceOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ServiceOptions.Marshal(b, m, deterministic)
 }
-func (dst *ServiceOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ServiceOptions.Merge(dst, src)
+func (m *ServiceOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ServiceOptions.Merge(m, src)
 }
 func (m *ServiceOptions) XXX_Size() int {
 	return xxx_messageInfo_ServiceOptions.Size(m)
@@ -2109,8 +2109,8 @@ func (m *MethodOptions) XXX_Unmarshal(b []byte) error {
 func (m *MethodOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_MethodOptions.Marshal(b, m, deterministic)
 }
-func (dst *MethodOptions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_MethodOptions.Merge(dst, src)
+func (m *MethodOptions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MethodOptions.Merge(m, src)
 }
 func (m *MethodOptions) XXX_Size() int {
 	return xxx_messageInfo_MethodOptions.Size(m)
@@ -2178,8 +2178,8 @@ func (m *UninterpretedOption) XXX_Unmarshal(b []byte) error {
 func (m *UninterpretedOption) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UninterpretedOption.Marshal(b, m, deterministic)
 }
-func (dst *UninterpretedOption) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UninterpretedOption.Merge(dst, src)
+func (m *UninterpretedOption) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UninterpretedOption.Merge(m, src)
 }
 func (m *UninterpretedOption) XXX_Size() int {
 	return xxx_messageInfo_UninterpretedOption.Size(m)
@@ -2264,8 +2264,8 @@ func (m *UninterpretedOption_NamePart) XXX_Unmarshal(b []byte) error {
 func (m *UninterpretedOption_NamePart) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UninterpretedOption_NamePart.Marshal(b, m, deterministic)
 }
-func (dst *UninterpretedOption_NamePart) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UninterpretedOption_NamePart.Merge(dst, src)
+func (m *UninterpretedOption_NamePart) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UninterpretedOption_NamePart.Merge(m, src)
 }
 func (m *UninterpretedOption_NamePart) XXX_Size() int {
 	return xxx_messageInfo_UninterpretedOption_NamePart.Size(m)
@@ -2354,8 +2354,8 @@ func (m *SourceCodeInfo) XXX_Unmarshal(b []byte) error {
 func (m *SourceCodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SourceCodeInfo.Marshal(b, m, deterministic)
 }
-func (dst *SourceCodeInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SourceCodeInfo.Merge(dst, src)
+func (m *SourceCodeInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SourceCodeInfo.Merge(m, src)
 }
 func (m *SourceCodeInfo) XXX_Size() int {
 	return xxx_messageInfo_SourceCodeInfo.Size(m)
@@ -2471,8 +2471,8 @@ func (m *SourceCodeInfo_Location) XXX_Unmarshal(b []byte) error {
 func (m *SourceCodeInfo_Location) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SourceCodeInfo_Location.Marshal(b, m, deterministic)
 }
-func (dst *SourceCodeInfo_Location) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SourceCodeInfo_Location.Merge(dst, src)
+func (m *SourceCodeInfo_Location) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SourceCodeInfo_Location.Merge(m, src)
 }
 func (m *SourceCodeInfo_Location) XXX_Size() int {
 	return xxx_messageInfo_SourceCodeInfo_Location.Size(m)
@@ -2542,8 +2542,8 @@ func (m *GeneratedCodeInfo) XXX_Unmarshal(b []byte) error {
 func (m *GeneratedCodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GeneratedCodeInfo.Marshal(b, m, deterministic)
 }
-func (dst *GeneratedCodeInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GeneratedCodeInfo.Merge(dst, src)
+func (m *GeneratedCodeInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GeneratedCodeInfo.Merge(m, src)
 }
 func (m *GeneratedCodeInfo) XXX_Size() int {
 	return xxx_messageInfo_GeneratedCodeInfo.Size(m)
@@ -2591,8 +2591,8 @@ func (m *GeneratedCodeInfo_Annotation) XXX_Unmarshal(b []byte) error {
 func (m *GeneratedCodeInfo_Annotation) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GeneratedCodeInfo_Annotation.Marshal(b, m, deterministic)
 }
-func (dst *GeneratedCodeInfo_Annotation) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GeneratedCodeInfo_Annotation.Merge(dst, src)
+func (m *GeneratedCodeInfo_Annotation) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GeneratedCodeInfo_Annotation.Merge(m, src)
 }
 func (m *GeneratedCodeInfo_Annotation) XXX_Size() int {
 	return xxx_messageInfo_GeneratedCodeInfo_Annotation.Size(m)

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2420,8 +2420,8 @@ func (g *Generator) generateCommonMethods(mc *msgCtx) {
 	g.P("return xxx_messageInfo_", mc.goName, ".Marshal(b, m, deterministic)")
 	g.P("}")
 
-	g.P("func (dst *", mc.goName, ") XXX_Merge(src ", g.Pkg["proto"], ".Message) {")
-	g.P("xxx_messageInfo_", mc.goName, ".Merge(dst, src)")
+	g.P("func (m *", mc.goName, ") XXX_Merge(src ", g.Pkg["proto"], ".Message) {")
+	g.P("xxx_messageInfo_", mc.goName, ".Merge(m, src)")
 	g.P("}")
 
 	g.P("func (m *", mc.goName, ") XXX_Size() int {") // avoid name clash with "Size" field in some message

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -71,8 +71,8 @@ func (m *DeprecatedRequest) XXX_Unmarshal(b []byte) error {
 func (m *DeprecatedRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DeprecatedRequest.Marshal(b, m, deterministic)
 }
-func (dst *DeprecatedRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeprecatedRequest.Merge(dst, src)
+func (m *DeprecatedRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeprecatedRequest.Merge(m, src)
 }
 func (m *DeprecatedRequest) XXX_Size() int {
 	return xxx_messageInfo_DeprecatedRequest.Size(m)
@@ -104,8 +104,8 @@ func (m *DeprecatedResponse) XXX_Unmarshal(b []byte) error {
 func (m *DeprecatedResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DeprecatedResponse.Marshal(b, m, deterministic)
 }
-func (dst *DeprecatedResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeprecatedResponse.Merge(dst, src)
+func (m *DeprecatedResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeprecatedResponse.Merge(m, src)
 }
 func (m *DeprecatedResponse) XXX_Size() int {
 	return xxx_messageInfo_DeprecatedResponse.Size(m)

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -47,8 +47,8 @@ func (m *BaseMessage) XXX_Unmarshal(b []byte) error {
 func (m *BaseMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BaseMessage.Marshal(b, m, deterministic)
 }
-func (dst *BaseMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BaseMessage.Merge(dst, src)
+func (m *BaseMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BaseMessage.Merge(m, src)
 }
 func (m *BaseMessage) XXX_Size() int {
 	return xxx_messageInfo_BaseMessage.Size(m)
@@ -101,8 +101,8 @@ func (m *OldStyleMessage) XXX_Unmarshal(b []byte) error {
 func (m *OldStyleMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldStyleMessage.Marshal(b, m, deterministic)
 }
-func (dst *OldStyleMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OldStyleMessage.Merge(dst, src)
+func (m *OldStyleMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OldStyleMessage.Merge(m, src)
 }
 func (m *OldStyleMessage) XXX_Size() int {
 	return xxx_messageInfo_OldStyleMessage.Size(m)

--- a/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
+++ b/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
@@ -37,8 +37,8 @@ func (m *ExtraMessage) XXX_Unmarshal(b []byte) error {
 func (m *ExtraMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ExtraMessage.Marshal(b, m, deterministic)
 }
-func (dst *ExtraMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ExtraMessage.Merge(dst, src)
+func (m *ExtraMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ExtraMessage.Merge(m, src)
 }
 func (m *ExtraMessage) XXX_Size() int {
 	return xxx_messageInfo_ExtraMessage.Size(m)

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -40,8 +40,8 @@ func (m *UserMessage) XXX_Unmarshal(b []byte) error {
 func (m *UserMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UserMessage.Marshal(b, m, deterministic)
 }
-func (dst *UserMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UserMessage.Merge(dst, src)
+func (m *UserMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UserMessage.Merge(m, src)
 }
 func (m *UserMessage) XXX_Size() int {
 	return xxx_messageInfo_UserMessage.Size(m)
@@ -94,8 +94,8 @@ func (m *LoudMessage) XXX_Unmarshal(b []byte) error {
 func (m *LoudMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_LoudMessage.Marshal(b, m, deterministic)
 }
-func (dst *LoudMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LoudMessage.Merge(dst, src)
+func (m *LoudMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LoudMessage.Merge(m, src)
 }
 func (m *LoudMessage) XXX_Size() int {
 	return xxx_messageInfo_LoudMessage.Size(m)
@@ -134,8 +134,8 @@ func (m *LoginMessage) XXX_Unmarshal(b []byte) error {
 func (m *LoginMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_LoginMessage.Marshal(b, m, deterministic)
 }
-func (dst *LoginMessage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LoginMessage.Merge(dst, src)
+func (m *LoginMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LoginMessage.Merge(m, src)
 }
 func (m *LoginMessage) XXX_Size() int {
 	return xxx_messageInfo_LoginMessage.Size(m)
@@ -174,8 +174,8 @@ func (m *Detail) XXX_Unmarshal(b []byte) error {
 func (m *Detail) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Detail.Marshal(b, m, deterministic)
 }
-func (dst *Detail) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Detail.Merge(dst, src)
+func (m *Detail) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Detail.Merge(m, src)
 }
 func (m *Detail) XXX_Size() int {
 	return xxx_messageInfo_Detail.Size(m)
@@ -213,8 +213,8 @@ func (m *Announcement) XXX_Unmarshal(b []byte) error {
 func (m *Announcement) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Announcement.Marshal(b, m, deterministic)
 }
-func (dst *Announcement) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Announcement.Merge(dst, src)
+func (m *Announcement) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Announcement.Merge(m, src)
 }
 func (m *Announcement) XXX_Size() int {
 	return xxx_messageInfo_Announcement.Size(m)
@@ -262,8 +262,8 @@ func (m *OldStyleParcel) XXX_Unmarshal(b []byte) error {
 func (m *OldStyleParcel) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldStyleParcel.Marshal(b, m, deterministic)
 }
-func (dst *OldStyleParcel) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OldStyleParcel.Merge(dst, src)
+func (m *OldStyleParcel) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OldStyleParcel.Merge(m, src)
 }
 func (m *OldStyleParcel) XXX_Size() int {
 	return xxx_messageInfo_OldStyleParcel.Size(m)

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -41,8 +41,8 @@ func (m *SimpleRequest) XXX_Unmarshal(b []byte) error {
 func (m *SimpleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleRequest.Marshal(b, m, deterministic)
 }
-func (dst *SimpleRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SimpleRequest.Merge(dst, src)
+func (m *SimpleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SimpleRequest.Merge(m, src)
 }
 func (m *SimpleRequest) XXX_Size() int {
 	return xxx_messageInfo_SimpleRequest.Size(m)
@@ -71,8 +71,8 @@ func (m *SimpleResponse) XXX_Unmarshal(b []byte) error {
 func (m *SimpleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SimpleResponse.Marshal(b, m, deterministic)
 }
-func (dst *SimpleResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SimpleResponse.Merge(dst, src)
+func (m *SimpleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SimpleResponse.Merge(m, src)
 }
 func (m *SimpleResponse) XXX_Size() int {
 	return xxx_messageInfo_SimpleResponse.Size(m)
@@ -101,8 +101,8 @@ func (m *StreamMsg) XXX_Unmarshal(b []byte) error {
 func (m *StreamMsg) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StreamMsg.Marshal(b, m, deterministic)
 }
-func (dst *StreamMsg) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StreamMsg.Merge(dst, src)
+func (m *StreamMsg) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StreamMsg.Merge(m, src)
 }
 func (m *StreamMsg) XXX_Size() int {
 	return xxx_messageInfo_StreamMsg.Size(m)
@@ -131,8 +131,8 @@ func (m *StreamMsg2) XXX_Unmarshal(b []byte) error {
 func (m *StreamMsg2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StreamMsg2.Marshal(b, m, deterministic)
 }
-func (dst *StreamMsg2) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StreamMsg2.Merge(dst, src)
+func (m *StreamMsg2) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StreamMsg2.Merge(m, src)
 }
 func (m *StreamMsg2) XXX_Size() int {
 	return xxx_messageInfo_StreamMsg2.Size(m)

--- a/protoc-gen-go/testdata/import_public/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/a.pb.go
@@ -53,8 +53,8 @@ func (m *Public) XXX_Unmarshal(b []byte) error {
 func (m *Public) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Public.Marshal(b, m, deterministic)
 }
-func (dst *Public) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Public.Merge(dst, src)
+func (m *Public) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Public.Merge(m, src)
 }
 func (m *Public) XXX_Size() int {
 	return xxx_messageInfo_Public.Size(m)

--- a/protoc-gen-go/testdata/import_public/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/b.pb.go
@@ -39,8 +39,8 @@ func (m *Local) XXX_Unmarshal(b []byte) error {
 func (m *Local) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Local.Marshal(b, m, deterministic)
 }
-func (dst *Local) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Local.Merge(dst, src)
+func (m *Local) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Local.Merge(m, src)
 }
 func (m *Local) XXX_Size() int {
 	return xxx_messageInfo_Local.Size(m)

--- a/protoc-gen-go/testdata/import_public/sub/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/a.pb.go
@@ -60,8 +60,8 @@ func (m *M) XXX_Unmarshal(b []byte) error {
 func (m *M) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M.Marshal(b, m, deterministic)
 }
-func (dst *M) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M.Merge(dst, src)
+func (m *M) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M.Merge(m, src)
 }
 func (m *M) XXX_Size() int {
 	return xxx_messageInfo_M.Size(m)

--- a/protoc-gen-go/testdata/import_public/sub/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/b.pb.go
@@ -36,8 +36,8 @@ func (m *M2) XXX_Unmarshal(b []byte) error {
 func (m *M2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M2.Marshal(b, m, deterministic)
 }
-func (dst *M2) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M2.Merge(dst, src)
+func (m *M2) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M2.Merge(m, src)
 }
 func (m *M2) XXX_Size() int {
 	return xxx_messageInfo_M2.Size(m)

--- a/protoc-gen-go/testdata/imports/fmt/m.pb.go
+++ b/protoc-gen-go/testdata/imports/fmt/m.pb.go
@@ -36,8 +36,8 @@ func (m *M) XXX_Unmarshal(b []byte) error {
 func (m *M) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M.Marshal(b, m, deterministic)
 }
-func (dst *M) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M.Merge(dst, src)
+func (m *M) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M.Merge(m, src)
 }
 func (m *M) XXX_Size() int {
 	return xxx_messageInfo_M.Size(m)

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -58,8 +58,8 @@ func (m *M1) XXX_Unmarshal(b []byte) error {
 func (m *M1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M1.Marshal(b, m, deterministic)
 }
-func (dst *M1) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M1.Merge(dst, src)
+func (m *M1) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M1.Merge(m, src)
 }
 func (m *M1) XXX_Size() int {
 	return xxx_messageInfo_M1.Size(m)
@@ -89,8 +89,8 @@ func (m *M1_1) XXX_Unmarshal(b []byte) error {
 func (m *M1_1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M1_1.Marshal(b, m, deterministic)
 }
-func (dst *M1_1) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M1_1.Merge(dst, src)
+func (m *M1_1) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M1_1.Merge(m, src)
 }
 func (m *M1_1) XXX_Size() int {
 	return xxx_messageInfo_M1_1.Size(m)

--- a/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
@@ -36,8 +36,8 @@ func (m *M2) XXX_Unmarshal(b []byte) error {
 func (m *M2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M2.Marshal(b, m, deterministic)
 }
-func (dst *M2) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M2.Merge(dst, src)
+func (m *M2) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M2.Merge(m, src)
 }
 func (m *M2) XXX_Size() int {
 	return xxx_messageInfo_M2.Size(m)

--- a/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
@@ -36,8 +36,8 @@ func (m *M3) XXX_Unmarshal(b []byte) error {
 func (m *M3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M3.Marshal(b, m, deterministic)
 }
-func (dst *M3) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M3.Merge(dst, src)
+func (m *M3) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M3.Merge(m, src)
 }
 func (m *M3) XXX_Size() int {
 	return xxx_messageInfo_M3.Size(m)

--- a/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
@@ -36,8 +36,8 @@ func (m *M4) XXX_Unmarshal(b []byte) error {
 func (m *M4) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M4.Marshal(b, m, deterministic)
 }
-func (dst *M4) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M4.Merge(dst, src)
+func (m *M4) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M4.Merge(m, src)
 }
 func (m *M4) XXX_Size() int {
 	return xxx_messageInfo_M4.Size(m)

--- a/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
@@ -36,8 +36,8 @@ func (m *M1) XXX_Unmarshal(b []byte) error {
 func (m *M1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M1.Marshal(b, m, deterministic)
 }
-func (dst *M1) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M1.Merge(dst, src)
+func (m *M1) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M1.Merge(m, src)
 }
 func (m *M1) XXX_Size() int {
 	return xxx_messageInfo_M1.Size(m)

--- a/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
@@ -36,8 +36,8 @@ func (m *M2) XXX_Unmarshal(b []byte) error {
 func (m *M2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_M2.Marshal(b, m, deterministic)
 }
-func (dst *M2) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_M2.Merge(dst, src)
+func (m *M2) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_M2.Merge(m, src)
 }
 func (m *M2) XXX_Size() int {
 	return xxx_messageInfo_M2.Size(m)

--- a/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
@@ -38,8 +38,8 @@ func (m *A1M1) XXX_Unmarshal(b []byte) error {
 func (m *A1M1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_A1M1.Marshal(b, m, deterministic)
 }
-func (dst *A1M1) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_A1M1.Merge(dst, src)
+func (m *A1M1) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_A1M1.Merge(m, src)
 }
 func (m *A1M1) XXX_Size() int {
 	return xxx_messageInfo_A1M1.Size(m)

--- a/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
@@ -38,8 +38,8 @@ func (m *A1M2) XXX_Unmarshal(b []byte) error {
 func (m *A1M2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_A1M2.Marshal(b, m, deterministic)
 }
-func (dst *A1M2) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_A1M2.Merge(dst, src)
+func (m *A1M2) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_A1M2.Merge(m, src)
 }
 func (m *A1M2) XXX_Size() int {
 	return xxx_messageInfo_A1M2.Size(m)

--- a/protoc-gen-go/testdata/imports/test_import_all.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_all.pb.go
@@ -47,8 +47,8 @@ func (m *All) XXX_Unmarshal(b []byte) error {
 func (m *All) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_All.Marshal(b, m, deterministic)
 }
-func (dst *All) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_All.Merge(dst, src)
+func (m *All) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_All.Merge(m, src)
 }
 func (m *All) XXX_Size() int {
 	return xxx_messageInfo_All.Size(m)

--- a/protoc-gen-go/testdata/multi/multi1.pb.go
+++ b/protoc-gen-go/testdata/multi/multi1.pb.go
@@ -39,8 +39,8 @@ func (m *Multi1) XXX_Unmarshal(b []byte) error {
 func (m *Multi1) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Multi1.Marshal(b, m, deterministic)
 }
-func (dst *Multi1) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Multi1.Merge(dst, src)
+func (m *Multi1) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Multi1.Merge(m, src)
 }
 func (m *Multi1) XXX_Size() int {
 	return xxx_messageInfo_Multi1.Size(m)

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -81,8 +81,8 @@ func (m *Multi2) XXX_Unmarshal(b []byte) error {
 func (m *Multi2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Multi2.Marshal(b, m, deterministic)
 }
-func (dst *Multi2) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Multi2.Merge(dst, src)
+func (m *Multi2) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Multi2.Merge(m, src)
 }
 func (m *Multi2) XXX_Size() int {
 	return xxx_messageInfo_Multi2.Size(m)

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -77,8 +77,8 @@ func (m *Multi3) XXX_Unmarshal(b []byte) error {
 func (m *Multi3) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Multi3.Marshal(b, m, deterministic)
 }
-func (dst *Multi3) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Multi3.Merge(dst, src)
+func (m *Multi3) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Multi3.Merge(m, src)
 }
 func (m *Multi3) XXX_Size() int {
 	return xxx_messageInfo_Multi3.Size(m)

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -224,8 +224,8 @@ func (m *Request) XXX_Unmarshal(b []byte) error {
 func (m *Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Request.Marshal(b, m, deterministic)
 }
-func (dst *Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Request.Merge(dst, src)
+func (m *Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Request.Merge(m, src)
 }
 func (m *Request) XXX_Size() int {
 	return xxx_messageInfo_Request.Size(m)
@@ -322,8 +322,8 @@ func (m *Request_SomeGroup) XXX_Unmarshal(b []byte) error {
 func (m *Request_SomeGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Request_SomeGroup.Marshal(b, m, deterministic)
 }
-func (dst *Request_SomeGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Request_SomeGroup.Merge(dst, src)
+func (m *Request_SomeGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Request_SomeGroup.Merge(m, src)
 }
 func (m *Request_SomeGroup) XXX_Size() int {
 	return xxx_messageInfo_Request_SomeGroup.Size(m)
@@ -370,8 +370,8 @@ func (m *Reply) XXX_Unmarshal(b []byte) error {
 func (m *Reply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Reply.Marshal(b, m, deterministic)
 }
-func (dst *Reply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Reply.Merge(dst, src)
+func (m *Reply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Reply.Merge(m, src)
 }
 func (m *Reply) XXX_Size() int {
 	return xxx_messageInfo_Reply.Size(m)
@@ -417,8 +417,8 @@ func (m *Reply_Entry) XXX_Unmarshal(b []byte) error {
 func (m *Reply_Entry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Reply_Entry.Marshal(b, m, deterministic)
 }
-func (dst *Reply_Entry) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Reply_Entry.Merge(dst, src)
+func (m *Reply_Entry) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Reply_Entry.Merge(m, src)
 }
 func (m *Reply_Entry) XXX_Size() int {
 	return xxx_messageInfo_Reply_Entry.Size(m)
@@ -480,8 +480,8 @@ func (m *OtherBase) XXX_Unmarshal(b []byte) error {
 func (m *OtherBase) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OtherBase.Marshal(b, m, deterministic)
 }
-func (dst *OtherBase) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OtherBase.Merge(dst, src)
+func (m *OtherBase) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OtherBase.Merge(m, src)
 }
 func (m *OtherBase) XXX_Size() int {
 	return xxx_messageInfo_OtherBase.Size(m)
@@ -517,8 +517,8 @@ func (m *ReplyExtensions) XXX_Unmarshal(b []byte) error {
 func (m *ReplyExtensions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ReplyExtensions.Marshal(b, m, deterministic)
 }
-func (dst *ReplyExtensions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReplyExtensions.Merge(dst, src)
+func (m *ReplyExtensions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReplyExtensions.Merge(m, src)
 }
 func (m *ReplyExtensions) XXX_Size() int {
 	return xxx_messageInfo_ReplyExtensions.Size(m)
@@ -575,8 +575,8 @@ func (m *OtherReplyExtensions) XXX_Unmarshal(b []byte) error {
 func (m *OtherReplyExtensions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OtherReplyExtensions.Marshal(b, m, deterministic)
 }
-func (dst *OtherReplyExtensions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OtherReplyExtensions.Merge(dst, src)
+func (m *OtherReplyExtensions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OtherReplyExtensions.Merge(m, src)
 }
 func (m *OtherReplyExtensions) XXX_Size() int {
 	return xxx_messageInfo_OtherReplyExtensions.Size(m)
@@ -628,8 +628,8 @@ func (m *OldReply) XXX_Unmarshal(b []byte) error {
 func (m *OldReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OldReply.Marshal(b, m, deterministic)
 }
-func (dst *OldReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OldReply.Merge(dst, src)
+func (m *OldReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OldReply.Merge(m, src)
 }
 func (m *OldReply) XXX_Size() int {
 	return xxx_messageInfo_OldReply.Size(m)
@@ -673,8 +673,8 @@ func (m *Communique) XXX_Unmarshal(b []byte) error {
 func (m *Communique) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique.Marshal(b, m, deterministic)
 }
-func (dst *Communique) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Communique.Merge(dst, src)
+func (m *Communique) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Communique.Merge(m, src)
 }
 func (m *Communique) XXX_Size() int {
 	return xxx_messageInfo_Communique.Size(m)
@@ -1044,8 +1044,8 @@ func (m *Communique_SomeGroup) XXX_Unmarshal(b []byte) error {
 func (m *Communique_SomeGroup) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique_SomeGroup.Marshal(b, m, deterministic)
 }
-func (dst *Communique_SomeGroup) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Communique_SomeGroup.Merge(dst, src)
+func (m *Communique_SomeGroup) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Communique_SomeGroup.Merge(m, src)
 }
 func (m *Communique_SomeGroup) XXX_Size() int {
 	return xxx_messageInfo_Communique_SomeGroup.Size(m)
@@ -1081,8 +1081,8 @@ func (m *Communique_Delta) XXX_Unmarshal(b []byte) error {
 func (m *Communique_Delta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Communique_Delta.Marshal(b, m, deterministic)
 }
-func (dst *Communique_Delta) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Communique_Delta.Merge(dst, src)
+func (m *Communique_Delta) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Communique_Delta.Merge(m, src)
 }
 func (m *Communique_Delta) XXX_Size() int {
 	return xxx_messageInfo_Communique_Delta.Size(m)

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -72,8 +72,8 @@ func (m *Request) XXX_Unmarshal(b []byte) error {
 func (m *Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Request.Marshal(b, m, deterministic)
 }
-func (dst *Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Request.Merge(dst, src)
+func (m *Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Request.Merge(m, src)
 }
 func (m *Request) XXX_Size() int {
 	return xxx_messageInfo_Request.Size(m)
@@ -139,8 +139,8 @@ func (m *Book) XXX_Unmarshal(b []byte) error {
 func (m *Book) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Book.Marshal(b, m, deterministic)
 }
-func (dst *Book) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Book.Merge(dst, src)
+func (m *Book) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Book.Merge(m, src)
 }
 func (m *Book) XXX_Size() int {
 	return xxx_messageInfo_Book.Size(m)

--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -142,8 +142,8 @@ func (m *Any) XXX_Unmarshal(b []byte) error {
 func (m *Any) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Any.Marshal(b, m, deterministic)
 }
-func (dst *Any) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Any.Merge(dst, src)
+func (m *Any) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Any.Merge(m, src)
 }
 func (m *Any) XXX_Size() int {
 	return xxx_messageInfo_Any.Size(m)

--- a/ptypes/duration/duration.pb.go
+++ b/ptypes/duration/duration.pb.go
@@ -108,8 +108,8 @@ func (m *Duration) XXX_Unmarshal(b []byte) error {
 func (m *Duration) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Duration.Marshal(b, m, deterministic)
 }
-func (dst *Duration) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Duration.Merge(dst, src)
+func (m *Duration) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Duration.Merge(m, src)
 }
 func (m *Duration) XXX_Size() int {
 	return xxx_messageInfo_Duration.Size(m)

--- a/ptypes/empty/empty.pb.go
+++ b/ptypes/empty/empty.pb.go
@@ -46,8 +46,8 @@ func (m *Empty) XXX_Unmarshal(b []byte) error {
 func (m *Empty) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Empty.Marshal(b, m, deterministic)
 }
-func (dst *Empty) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Empty.Merge(dst, src)
+func (m *Empty) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Empty.Merge(m, src)
 }
 func (m *Empty) XXX_Size() int {
 	return xxx_messageInfo_Empty.Size(m)

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -76,8 +76,8 @@ func (m *Struct) XXX_Unmarshal(b []byte) error {
 func (m *Struct) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Struct.Marshal(b, m, deterministic)
 }
-func (dst *Struct) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Struct.Merge(dst, src)
+func (m *Struct) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Struct.Merge(m, src)
 }
 func (m *Struct) XXX_Size() int {
 	return xxx_messageInfo_Struct.Size(m)
@@ -130,8 +130,8 @@ func (m *Value) XXX_Unmarshal(b []byte) error {
 func (m *Value) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Value.Marshal(b, m, deterministic)
 }
-func (dst *Value) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Value.Merge(dst, src)
+func (m *Value) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Value.Merge(m, src)
 }
 func (m *Value) XXX_Size() int {
 	return xxx_messageInfo_Value.Size(m)
@@ -390,8 +390,8 @@ func (m *ListValue) XXX_Unmarshal(b []byte) error {
 func (m *ListValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ListValue.Marshal(b, m, deterministic)
 }
-func (dst *ListValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListValue.Merge(dst, src)
+func (m *ListValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListValue.Merge(m, src)
 }
 func (m *ListValue) XXX_Size() int {
 	return xxx_messageInfo_ListValue.Size(m)

--- a/ptypes/timestamp/timestamp.pb.go
+++ b/ptypes/timestamp/timestamp.pb.go
@@ -124,8 +124,8 @@ func (m *Timestamp) XXX_Unmarshal(b []byte) error {
 func (m *Timestamp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Timestamp.Marshal(b, m, deterministic)
 }
-func (dst *Timestamp) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Timestamp.Merge(dst, src)
+func (m *Timestamp) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Timestamp.Merge(m, src)
 }
 func (m *Timestamp) XXX_Size() int {
 	return xxx_messageInfo_Timestamp.Size(m)

--- a/ptypes/wrappers/wrappers.pb.go
+++ b/ptypes/wrappers/wrappers.pb.go
@@ -42,8 +42,8 @@ func (m *DoubleValue) XXX_Unmarshal(b []byte) error {
 func (m *DoubleValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DoubleValue.Marshal(b, m, deterministic)
 }
-func (dst *DoubleValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DoubleValue.Merge(dst, src)
+func (m *DoubleValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DoubleValue.Merge(m, src)
 }
 func (m *DoubleValue) XXX_Size() int {
 	return xxx_messageInfo_DoubleValue.Size(m)
@@ -85,8 +85,8 @@ func (m *FloatValue) XXX_Unmarshal(b []byte) error {
 func (m *FloatValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FloatValue.Marshal(b, m, deterministic)
 }
-func (dst *FloatValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FloatValue.Merge(dst, src)
+func (m *FloatValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FloatValue.Merge(m, src)
 }
 func (m *FloatValue) XXX_Size() int {
 	return xxx_messageInfo_FloatValue.Size(m)
@@ -128,8 +128,8 @@ func (m *Int64Value) XXX_Unmarshal(b []byte) error {
 func (m *Int64Value) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Int64Value.Marshal(b, m, deterministic)
 }
-func (dst *Int64Value) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Int64Value.Merge(dst, src)
+func (m *Int64Value) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Int64Value.Merge(m, src)
 }
 func (m *Int64Value) XXX_Size() int {
 	return xxx_messageInfo_Int64Value.Size(m)
@@ -171,8 +171,8 @@ func (m *UInt64Value) XXX_Unmarshal(b []byte) error {
 func (m *UInt64Value) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UInt64Value.Marshal(b, m, deterministic)
 }
-func (dst *UInt64Value) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UInt64Value.Merge(dst, src)
+func (m *UInt64Value) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UInt64Value.Merge(m, src)
 }
 func (m *UInt64Value) XXX_Size() int {
 	return xxx_messageInfo_UInt64Value.Size(m)
@@ -214,8 +214,8 @@ func (m *Int32Value) XXX_Unmarshal(b []byte) error {
 func (m *Int32Value) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Int32Value.Marshal(b, m, deterministic)
 }
-func (dst *Int32Value) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Int32Value.Merge(dst, src)
+func (m *Int32Value) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Int32Value.Merge(m, src)
 }
 func (m *Int32Value) XXX_Size() int {
 	return xxx_messageInfo_Int32Value.Size(m)
@@ -257,8 +257,8 @@ func (m *UInt32Value) XXX_Unmarshal(b []byte) error {
 func (m *UInt32Value) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UInt32Value.Marshal(b, m, deterministic)
 }
-func (dst *UInt32Value) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UInt32Value.Merge(dst, src)
+func (m *UInt32Value) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UInt32Value.Merge(m, src)
 }
 func (m *UInt32Value) XXX_Size() int {
 	return xxx_messageInfo_UInt32Value.Size(m)
@@ -300,8 +300,8 @@ func (m *BoolValue) XXX_Unmarshal(b []byte) error {
 func (m *BoolValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BoolValue.Marshal(b, m, deterministic)
 }
-func (dst *BoolValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BoolValue.Merge(dst, src)
+func (m *BoolValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BoolValue.Merge(m, src)
 }
 func (m *BoolValue) XXX_Size() int {
 	return xxx_messageInfo_BoolValue.Size(m)
@@ -343,8 +343,8 @@ func (m *StringValue) XXX_Unmarshal(b []byte) error {
 func (m *StringValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StringValue.Marshal(b, m, deterministic)
 }
-func (dst *StringValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StringValue.Merge(dst, src)
+func (m *StringValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StringValue.Merge(m, src)
 }
 func (m *StringValue) XXX_Size() int {
 	return xxx_messageInfo_StringValue.Size(m)
@@ -386,8 +386,8 @@ func (m *BytesValue) XXX_Unmarshal(b []byte) error {
 func (m *BytesValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BytesValue.Marshal(b, m, deterministic)
 }
-func (dst *BytesValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BytesValue.Merge(dst, src)
+func (m *BytesValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BytesValue.Merge(m, src)
 }
 func (m *BytesValue) XXX_Size() int {
 	return xxx_messageInfo_BytesValue.Size(m)


### PR DESCRIPTION
Change the receiver name for the XXX_Merge message method to 'm' for
consistency with other methods.