### PR TITLE
proto: remove commented-out code

### DIFF
--- a/proto/decode.go
+++ b/proto/decode.go
@@ -186,7 +186,6 @@ func (p *Buffer) DecodeVarint() (x uint64, err error) {
 	if b&0x80 == 0 {
 		goto done
 	}
-	// x -= 0x80 << 63 // Always zero.
 
 	return 0, errOverflow
 


### PR DESCRIPTION
The "return 0, errOverflow" already tells that x is always zero.
If there is a mistake, this code path should be fixed,
otherwise code that is disabled does not add any value.