### PR TITLE
proto: replace exprs with matching consts from math pkg

### DIFF
--- a/proto/size2_test.go
+++ b/proto/size2_test.go
@@ -32,6 +32,7 @@
 package proto
 
 import (
+	"math"
 	"testing"
 )
 
@@ -51,8 +52,8 @@ func TestVarintSize(t *testing.T) {
 		{128, 2},
 		{16383, 2},
 		{16384, 3},
-		{1<<63 - 1, 9},
-		{1 << 63, 10},
+		{math.MaxInt64, 9},
+		{math.MaxInt64 + 1, 10},
 	}
 	for _, tc := range testCases {
 		size := SizeVarint(tc.n)

--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -448,7 +448,7 @@ func (fi *marshalFieldInfo) computeMarshalFieldInfo(f *reflect.StructField) {
 
 func (fi *marshalFieldInfo) computeOneofFieldInfo(f *reflect.StructField, oneofImplementers []interface{}) {
 	fi.field = toField(f)
-	fi.wiretag = 1<<31 - 1 // Use a large tag number, make oneofs sorted at the end. This tag will not appear on the wire.
+	fi.wiretag = math.MaxInt32 // Use a large tag number, make oneofs sorted at the end. This tag will not appear on the wire.
 	fi.isPointer = true
 	fi.sizer, fi.marshaler = makeOneOfMarshaler(fi, f)
 	fi.oneofElems = make(map[reflect.Type]*marshalElemInfo)


### PR DESCRIPTION
Use named constants from math package instead of expressions
that evaluate to the same value.