### PR TITLE
proto: replace len(b)<=0 with len(b)==0

### DIFF
--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -1948,7 +1948,7 @@ func encodeVarint(b []byte, x uint64) []byte {
 // If there is an error, it returns 0,0.
 func decodeVarint(b []byte) (uint64, int) {
 	var x, y uint64
-	if len(b) <= 0 {
+	if len(b) == 0 {
 		goto bad
 	}
 	x = uint64(b[0])


### PR DESCRIPTION
len never returns negative values, so len(b)==0 states
requirements in a more clear way with less "uncertainty".