### PR TITLE
protoc-gen-go: add blank line after extension method

### DIFF
--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -823,6 +823,7 @@ var extRange_Real = []proto.ExtensionRange{
 func (*Real) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_Real
 }
+
 func (m *Real) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Real.Unmarshal(m, b)
 }
@@ -870,6 +871,7 @@ var extRange_Complex = []proto.ExtensionRange{
 func (*Complex) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_Complex
 }
+
 func (m *Complex) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Complex.Unmarshal(m, b)
 }

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -1784,6 +1784,7 @@ var extRange_OtherMessage = []proto.ExtensionRange{
 func (*OtherMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OtherMessage
 }
+
 func (m *OtherMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherMessage.Unmarshal(m, b)
 }
@@ -1902,6 +1903,7 @@ var extRange_MyMessage = []proto.ExtensionRange{
 func (*MyMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_MyMessage
 }
+
 func (m *MyMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MyMessage.Unmarshal(m, b)
 }
@@ -2190,6 +2192,7 @@ var extRange_DefaultsMessage = []proto.ExtensionRange{
 func (*DefaultsMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_DefaultsMessage
 }
+
 func (m *DefaultsMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DefaultsMessage.Unmarshal(m, b)
 }
@@ -2236,6 +2239,7 @@ var extRange_MyMessageSet = []proto.ExtensionRange{
 func (*MyMessageSet) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_MyMessageSet
 }
+
 func (m *MyMessageSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MyMessageSet.Unmarshal(m, b)
 }

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -761,6 +761,7 @@ var extRange_ExtensionRangeOptions = []proto.ExtensionRange{
 func (*ExtensionRangeOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_ExtensionRangeOptions
 }
+
 func (m *ExtensionRangeOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExtensionRangeOptions.Unmarshal(m, b)
 }
@@ -1385,6 +1386,7 @@ var extRange_FileOptions = []proto.ExtensionRange{
 func (*FileOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_FileOptions
 }
+
 func (m *FileOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FileOptions.Unmarshal(m, b)
 }
@@ -1620,6 +1622,7 @@ var extRange_MessageOptions = []proto.ExtensionRange{
 func (*MessageOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_MessageOptions
 }
+
 func (m *MessageOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageOptions.Unmarshal(m, b)
 }
@@ -1759,6 +1762,7 @@ var extRange_FieldOptions = []proto.ExtensionRange{
 func (*FieldOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_FieldOptions
 }
+
 func (m *FieldOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FieldOptions.Unmarshal(m, b)
 }
@@ -1855,6 +1859,7 @@ var extRange_OneofOptions = []proto.ExtensionRange{
 func (*OneofOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OneofOptions
 }
+
 func (m *OneofOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OneofOptions.Unmarshal(m, b)
 }
@@ -1911,6 +1916,7 @@ var extRange_EnumOptions = []proto.ExtensionRange{
 func (*EnumOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_EnumOptions
 }
+
 func (m *EnumOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumOptions.Unmarshal(m, b)
 }
@@ -1980,6 +1986,7 @@ var extRange_EnumValueOptions = []proto.ExtensionRange{
 func (*EnumValueOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_EnumValueOptions
 }
+
 func (m *EnumValueOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumValueOptions.Unmarshal(m, b)
 }
@@ -2042,6 +2049,7 @@ var extRange_ServiceOptions = []proto.ExtensionRange{
 func (*ServiceOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_ServiceOptions
 }
+
 func (m *ServiceOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ServiceOptions.Unmarshal(m, b)
 }
@@ -2105,6 +2113,7 @@ var extRange_MethodOptions = []proto.ExtensionRange{
 func (*MethodOptions) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_MethodOptions
 }
+
 func (m *MethodOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MethodOptions.Unmarshal(m, b)
 }

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2390,6 +2390,7 @@ func (g *Generator) generateCommonMethods(mc *msgCtx) {
 		g.P("func (*", mc.goName, ") ExtensionRangeArray() []", g.Pkg["proto"], ".ExtensionRange {")
 		g.P("return extRange_", mc.goName)
 		g.P("}")
+		g.P()
 	}
 
 	// TODO: It does not scale to keep adding another method for every

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -43,6 +43,7 @@ var extRange_BaseMessage = []proto.ExtensionRange{
 func (*BaseMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_BaseMessage
 }
+
 func (m *BaseMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BaseMessage.Unmarshal(m, b)
 }
@@ -97,6 +98,7 @@ var extRange_OldStyleMessage = []proto.ExtensionRange{
 func (*OldStyleMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OldStyleMessage
 }
+
 func (m *OldStyleMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldStyleMessage.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -90,6 +90,7 @@ var extRange_LoudMessage = []proto.ExtensionRange{
 func (*LoudMessage) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_LoudMessage
 }
+
 func (m *LoudMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoudMessage.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -366,6 +366,7 @@ var extRange_Reply = []proto.ExtensionRange{
 func (*Reply) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_Reply
 }
+
 func (m *Reply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Reply.Unmarshal(m, b)
 }
@@ -476,6 +477,7 @@ var extRange_OtherBase = []proto.ExtensionRange{
 func (*OtherBase) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OtherBase
 }
+
 func (m *OtherBase) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherBase.Unmarshal(m, b)
 }
@@ -624,6 +626,7 @@ var extRange_OldReply = []proto.ExtensionRange{
 func (*OldReply) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_OldReply
 }
+
 func (m *OldReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldReply.Unmarshal(m, b)
 }


### PR DESCRIPTION
Add a blank line between the ExtensionRangeArray and XXX_Unmarshal methods.