### PR TITLE
protoc-gen-go: add more spaces between methods

### DIFF
--- a/conformance/internal/conformance_proto/conformance.pb.go
+++ b/conformance/internal/conformance_proto/conformance.pb.go
@@ -139,6 +139,7 @@ func (*ConformanceRequest) ProtoMessage()    {}
 func (*ConformanceRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{0}
 }
+
 func (m *ConformanceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConformanceRequest.Unmarshal(m, b)
 }
@@ -288,6 +289,7 @@ func (*ConformanceResponse) ProtoMessage()    {}
 func (*ConformanceResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{1}
 }
+
 func (m *ConformanceResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ConformanceResponse.Unmarshal(m, b)
 }
@@ -650,6 +652,7 @@ func (*TestAllTypes) ProtoMessage()    {}
 func (*TestAllTypes) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{2}
 }
+
 func (m *TestAllTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestAllTypes.Unmarshal(m, b)
 }
@@ -1572,6 +1575,7 @@ func (*TestAllTypes_NestedMessage) ProtoMessage()    {}
 func (*TestAllTypes_NestedMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{2, 0}
 }
+
 func (m *TestAllTypes_NestedMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestAllTypes_NestedMessage.Unmarshal(m, b)
 }
@@ -1617,6 +1621,7 @@ func (*ForeignMessage) ProtoMessage()    {}
 func (*ForeignMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e7c910178d599565, []int{3}
 }
+
 func (m *ForeignMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ForeignMessage.Unmarshal(m, b)
 }

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -61,6 +61,7 @@ func (*Simple3) ProtoMessage()    {}
 func (*Simple3) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6c135db3023e377, []int{0}
 }
+
 func (m *Simple3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Simple3.Unmarshal(m, b)
 }
@@ -99,6 +100,7 @@ func (*SimpleSlice3) ProtoMessage()    {}
 func (*SimpleSlice3) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6c135db3023e377, []int{1}
 }
+
 func (m *SimpleSlice3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleSlice3.Unmarshal(m, b)
 }
@@ -137,6 +139,7 @@ func (*SimpleMap3) ProtoMessage()    {}
 func (*SimpleMap3) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6c135db3023e377, []int{2}
 }
+
 func (m *SimpleMap3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleMap3.Unmarshal(m, b)
 }
@@ -175,6 +178,7 @@ func (*SimpleNull3) ProtoMessage()    {}
 func (*SimpleNull3) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6c135db3023e377, []int{3}
 }
+
 func (m *SimpleNull3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleNull3.Unmarshal(m, b)
 }
@@ -222,6 +226,7 @@ func (*Mappy) ProtoMessage()    {}
 func (*Mappy) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6c135db3023e377, []int{4}
 }
+
 func (m *Mappy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Mappy.Unmarshal(m, b)
 }

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -100,6 +100,7 @@ func (*Simple) ProtoMessage()    {}
 func (*Simple) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{0}
 }
+
 func (m *Simple) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Simple.Unmarshal(m, b)
 }
@@ -270,6 +271,7 @@ func (*NonFinites) ProtoMessage()    {}
 func (*NonFinites) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{1}
 }
+
 func (m *NonFinites) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NonFinites.Unmarshal(m, b)
 }
@@ -354,6 +356,7 @@ func (*Repeats) ProtoMessage()    {}
 func (*Repeats) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{2}
 }
+
 func (m *Repeats) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Repeats.Unmarshal(m, b)
 }
@@ -468,6 +471,7 @@ func (*Widget) ProtoMessage()    {}
 func (*Widget) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{3}
 }
+
 func (m *Widget) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Widget.Unmarshal(m, b)
 }
@@ -542,6 +546,7 @@ func (*Maps) ProtoMessage()    {}
 func (*Maps) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{4}
 }
+
 func (m *Maps) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Maps.Unmarshal(m, b)
 }
@@ -593,6 +598,7 @@ func (*MsgWithOneof) ProtoMessage()    {}
 func (*MsgWithOneof) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{5}
 }
+
 func (m *MsgWithOneof) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithOneof.Unmarshal(m, b)
 }
@@ -933,6 +939,7 @@ func (*KnownTypes) ProtoMessage()    {}
 func (*KnownTypes) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{8}
 }
+
 func (m *KnownTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_KnownTypes.Unmarshal(m, b)
 }
@@ -1070,6 +1077,7 @@ func (*MsgWithRequired) ProtoMessage()    {}
 func (*MsgWithRequired) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{9}
 }
+
 func (m *MsgWithRequired) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequired.Unmarshal(m, b)
 }
@@ -1110,6 +1118,7 @@ func (*MsgWithIndirectRequired) ProtoMessage()    {}
 func (*MsgWithIndirectRequired) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{10}
 }
+
 func (m *MsgWithIndirectRequired) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithIndirectRequired.Unmarshal(m, b)
 }
@@ -1162,6 +1171,7 @@ func (*MsgWithRequiredBytes) ProtoMessage()    {}
 func (*MsgWithRequiredBytes) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{11}
 }
+
 func (m *MsgWithRequiredBytes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequiredBytes.Unmarshal(m, b)
 }
@@ -1200,6 +1210,7 @@ func (*MsgWithRequiredWKT) ProtoMessage()    {}
 func (*MsgWithRequiredWKT) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e97c739a0ce14cc6, []int{12}
 }
+
 func (m *MsgWithRequiredWKT) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MsgWithRequiredWKT.Unmarshal(m, b)
 }

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -84,6 +84,7 @@ func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c50d9b824d4ac38, []int{0}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Message.Unmarshal(m, b)
 }
@@ -249,6 +250,7 @@ func (*Nested) ProtoMessage()    {}
 func (*Nested) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c50d9b824d4ac38, []int{1}
 }
+
 func (m *Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Nested.Unmarshal(m, b)
 }
@@ -294,6 +296,7 @@ func (*MessageWithMap) ProtoMessage()    {}
 func (*MessageWithMap) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c50d9b824d4ac38, []int{2}
 }
+
 func (m *MessageWithMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageWithMap.Unmarshal(m, b)
 }
@@ -332,6 +335,7 @@ func (*IntMap) ProtoMessage()    {}
 func (*IntMap) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c50d9b824d4ac38, []int{3}
 }
+
 func (m *IntMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_IntMap.Unmarshal(m, b)
 }
@@ -370,6 +374,7 @@ func (*IntMaps) ProtoMessage()    {}
 func (*IntMaps) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c50d9b824d4ac38, []int{4}
 }
+
 func (m *IntMaps) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_IntMaps.Unmarshal(m, b)
 }
@@ -414,6 +419,7 @@ func (*TestUTF8) ProtoMessage()    {}
 func (*TestUTF8) Descriptor() ([]byte, []int) {
 	return fileDescriptor_1c50d9b824d4ac38, []int{5}
 }
+
 func (m *TestUTF8) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestUTF8.Unmarshal(m, b)
 }

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -314,6 +314,7 @@ func (*GoEnum) ProtoMessage()    {}
 func (*GoEnum) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{0}
 }
+
 func (m *GoEnum) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoEnum.Unmarshal(m, b)
 }
@@ -353,6 +354,7 @@ func (*GoTestField) ProtoMessage()    {}
 func (*GoTestField) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{1}
 }
+
 func (m *GoTestField) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestField.Unmarshal(m, b)
 }
@@ -486,6 +488,7 @@ func (*GoTest) ProtoMessage()    {}
 func (*GoTest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{2}
 }
+
 func (m *GoTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest.Unmarshal(m, b)
 }
@@ -1110,6 +1113,7 @@ func (*GoTest_RequiredGroup) ProtoMessage()    {}
 func (*GoTest_RequiredGroup) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{2, 0}
 }
+
 func (m *GoTest_RequiredGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_RequiredGroup.Unmarshal(m, b)
 }
@@ -1148,6 +1152,7 @@ func (*GoTest_RepeatedGroup) ProtoMessage()    {}
 func (*GoTest_RepeatedGroup) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{2, 1}
 }
+
 func (m *GoTest_RepeatedGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_RepeatedGroup.Unmarshal(m, b)
 }
@@ -1186,6 +1191,7 @@ func (*GoTest_OptionalGroup) ProtoMessage()    {}
 func (*GoTest_OptionalGroup) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{2, 2}
 }
+
 func (m *GoTest_OptionalGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTest_OptionalGroup.Unmarshal(m, b)
 }
@@ -1225,6 +1231,7 @@ func (*GoTestRequiredGroupField) ProtoMessage()    {}
 func (*GoTestRequiredGroupField) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{3}
 }
+
 func (m *GoTestRequiredGroupField) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestRequiredGroupField.Unmarshal(m, b)
 }
@@ -1263,6 +1270,7 @@ func (*GoTestRequiredGroupField_Group) ProtoMessage()    {}
 func (*GoTestRequiredGroupField_Group) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{3, 0}
 }
+
 func (m *GoTestRequiredGroupField_Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoTestRequiredGroupField_Group.Unmarshal(m, b)
 }
@@ -1308,6 +1316,7 @@ func (*GoSkipTest) ProtoMessage()    {}
 func (*GoSkipTest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{4}
 }
+
 func (m *GoSkipTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoSkipTest.Unmarshal(m, b)
 }
@@ -1375,6 +1384,7 @@ func (*GoSkipTest_SkipGroup) ProtoMessage()    {}
 func (*GoSkipTest_SkipGroup) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{4, 0}
 }
+
 func (m *GoSkipTest_SkipGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoSkipTest_SkipGroup.Unmarshal(m, b)
 }
@@ -1422,6 +1432,7 @@ func (*NonPackedTest) ProtoMessage()    {}
 func (*NonPackedTest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{5}
 }
+
 func (m *NonPackedTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NonPackedTest.Unmarshal(m, b)
 }
@@ -1460,6 +1471,7 @@ func (*PackedTest) ProtoMessage()    {}
 func (*PackedTest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{6}
 }
+
 func (m *PackedTest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PackedTest.Unmarshal(m, b)
 }
@@ -1499,6 +1511,7 @@ func (*MaxTag) ProtoMessage()    {}
 func (*MaxTag) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{7}
 }
+
 func (m *MaxTag) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MaxTag.Unmarshal(m, b)
 }
@@ -1538,6 +1551,7 @@ func (*OldMessage) ProtoMessage()    {}
 func (*OldMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{8}
 }
+
 func (m *OldMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldMessage.Unmarshal(m, b)
 }
@@ -1583,6 +1597,7 @@ func (*OldMessage_Nested) ProtoMessage()    {}
 func (*OldMessage_Nested) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{8, 0}
 }
+
 func (m *OldMessage_Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldMessage_Nested.Unmarshal(m, b)
 }
@@ -1625,6 +1640,7 @@ func (*NewMessage) ProtoMessage()    {}
 func (*NewMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{9}
 }
+
 func (m *NewMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewMessage.Unmarshal(m, b)
 }
@@ -1671,6 +1687,7 @@ func (*NewMessage_Nested) ProtoMessage()    {}
 func (*NewMessage_Nested) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{9, 0}
 }
+
 func (m *NewMessage_Nested) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NewMessage_Nested.Unmarshal(m, b)
 }
@@ -1718,6 +1735,7 @@ func (*InnerMessage) ProtoMessage()    {}
 func (*InnerMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{10}
 }
+
 func (m *InnerMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InnerMessage.Unmarshal(m, b)
 }
@@ -1844,6 +1862,7 @@ func (*RequiredInnerMessage) ProtoMessage()    {}
 func (*RequiredInnerMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{12}
 }
+
 func (m *RequiredInnerMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RequiredInnerMessage.Unmarshal(m, b)
 }
@@ -2019,6 +2038,7 @@ func (*MyMessage_SomeGroup) ProtoMessage()    {}
 func (*MyMessage_SomeGroup) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{13, 0}
 }
+
 func (m *MyMessage_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MyMessage_SomeGroup.Unmarshal(m, b)
 }
@@ -2058,6 +2078,7 @@ func (*Ext) ProtoMessage()    {}
 func (*Ext) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{14}
 }
+
 func (m *Ext) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Ext.Unmarshal(m, b)
 }
@@ -2132,6 +2153,7 @@ func (*ComplexExtension) ProtoMessage()    {}
 func (*ComplexExtension) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{15}
 }
+
 func (m *ComplexExtension) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ComplexExtension.Unmarshal(m, b)
 }
@@ -2270,6 +2292,7 @@ func (*Empty) ProtoMessage()    {}
 func (*Empty) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{18}
 }
+
 func (m *Empty) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Empty.Unmarshal(m, b)
 }
@@ -2301,6 +2324,7 @@ func (*MessageList) ProtoMessage()    {}
 func (*MessageList) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{19}
 }
+
 func (m *MessageList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageList.Unmarshal(m, b)
 }
@@ -2340,6 +2364,7 @@ func (*MessageList_Message) ProtoMessage()    {}
 func (*MessageList_Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{19, 0}
 }
+
 func (m *MessageList_Message) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageList_Message.Unmarshal(m, b)
 }
@@ -2386,6 +2411,7 @@ func (*Strings) ProtoMessage()    {}
 func (*Strings) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{20}
 }
+
 func (m *Strings) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Strings.Unmarshal(m, b)
 }
@@ -2454,6 +2480,7 @@ func (*Defaults) ProtoMessage()    {}
 func (*Defaults) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{21}
 }
+
 func (m *Defaults) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Defaults.Unmarshal(m, b)
 }
@@ -2639,6 +2666,7 @@ func (*SubDefaults) ProtoMessage()    {}
 func (*SubDefaults) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{22}
 }
+
 func (m *SubDefaults) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SubDefaults.Unmarshal(m, b)
 }
@@ -2679,6 +2707,7 @@ func (*RepeatedEnum) ProtoMessage()    {}
 func (*RepeatedEnum) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{23}
 }
+
 func (m *RepeatedEnum) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RepeatedEnum.Unmarshal(m, b)
 }
@@ -2723,6 +2752,7 @@ func (*MoreRepeated) ProtoMessage()    {}
 func (*MoreRepeated) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{24}
 }
+
 func (m *MoreRepeated) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MoreRepeated.Unmarshal(m, b)
 }
@@ -2803,6 +2833,7 @@ func (*GroupOld) ProtoMessage()    {}
 func (*GroupOld) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{25}
 }
+
 func (m *GroupOld) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupOld.Unmarshal(m, b)
 }
@@ -2841,6 +2872,7 @@ func (*GroupOld_G) ProtoMessage()    {}
 func (*GroupOld_G) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{25, 0}
 }
+
 func (m *GroupOld_G) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupOld_G.Unmarshal(m, b)
 }
@@ -2879,6 +2911,7 @@ func (*GroupNew) ProtoMessage()    {}
 func (*GroupNew) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{26}
 }
+
 func (m *GroupNew) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupNew.Unmarshal(m, b)
 }
@@ -2918,6 +2951,7 @@ func (*GroupNew_G) ProtoMessage()    {}
 func (*GroupNew_G) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{26, 0}
 }
+
 func (m *GroupNew_G) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupNew_G.Unmarshal(m, b)
 }
@@ -2964,6 +2998,7 @@ func (*FloatingPoint) ProtoMessage()    {}
 func (*FloatingPoint) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{27}
 }
+
 func (m *FloatingPoint) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FloatingPoint.Unmarshal(m, b)
 }
@@ -3012,6 +3047,7 @@ func (*MessageWithMap) ProtoMessage()    {}
 func (*MessageWithMap) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{28}
 }
+
 func (m *MessageWithMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MessageWithMap.Unmarshal(m, b)
 }
@@ -3092,6 +3128,7 @@ func (*Oneof) ProtoMessage()    {}
 func (*Oneof) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{29}
 }
+
 func (m *Oneof) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Oneof.Unmarshal(m, b)
 }
@@ -3695,6 +3732,7 @@ func (*Oneof_F_Group) ProtoMessage()    {}
 func (*Oneof_F_Group) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{29, 0}
 }
+
 func (m *Oneof_F_Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Oneof_F_Group.Unmarshal(m, b)
 }
@@ -3743,6 +3781,7 @@ func (*Communique) ProtoMessage()    {}
 func (*Communique) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{30}
 }
+
 func (m *Communique) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique.Unmarshal(m, b)
 }
@@ -4003,6 +4042,7 @@ func (*TestUTF8) ProtoMessage()    {}
 func (*TestUTF8) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{31}
 }
+
 func (m *TestUTF8) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TestUTF8.Unmarshal(m, b)
 }

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -359,6 +359,7 @@ func (*FileDescriptorSet) ProtoMessage()    {}
 func (*FileDescriptorSet) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{0}
 }
+
 func (m *FileDescriptorSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FileDescriptorSet.Unmarshal(m, b)
 }
@@ -420,6 +421,7 @@ func (*FileDescriptorProto) ProtoMessage()    {}
 func (*FileDescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{1}
 }
+
 func (m *FileDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FileDescriptorProto.Unmarshal(m, b)
 }
@@ -547,6 +549,7 @@ func (*DescriptorProto) ProtoMessage()    {}
 func (*DescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{2}
 }
+
 func (m *DescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto.Unmarshal(m, b)
 }
@@ -650,6 +653,7 @@ func (*DescriptorProto_ExtensionRange) ProtoMessage()    {}
 func (*DescriptorProto_ExtensionRange) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{2, 0}
 }
+
 func (m *DescriptorProto_ExtensionRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto_ExtensionRange.Unmarshal(m, b)
 }
@@ -706,6 +710,7 @@ func (*DescriptorProto_ReservedRange) ProtoMessage()    {}
 func (*DescriptorProto_ReservedRange) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{2, 1}
 }
+
 func (m *DescriptorProto_ReservedRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DescriptorProto_ReservedRange.Unmarshal(m, b)
 }
@@ -830,6 +835,7 @@ func (*FieldDescriptorProto) ProtoMessage()    {}
 func (*FieldDescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{4}
 }
+
 func (m *FieldDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FieldDescriptorProto.Unmarshal(m, b)
 }
@@ -933,6 +939,7 @@ func (*OneofDescriptorProto) ProtoMessage()    {}
 func (*OneofDescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{5}
 }
+
 func (m *OneofDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OneofDescriptorProto.Unmarshal(m, b)
 }
@@ -988,6 +995,7 @@ func (*EnumDescriptorProto) ProtoMessage()    {}
 func (*EnumDescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{6}
 }
+
 func (m *EnumDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumDescriptorProto.Unmarshal(m, b)
 }
@@ -1061,6 +1069,7 @@ func (*EnumDescriptorProto_EnumReservedRange) ProtoMessage()    {}
 func (*EnumDescriptorProto_EnumReservedRange) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{6, 0}
 }
+
 func (m *EnumDescriptorProto_EnumReservedRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumDescriptorProto_EnumReservedRange.Unmarshal(m, b)
 }
@@ -1109,6 +1118,7 @@ func (*EnumValueDescriptorProto) ProtoMessage()    {}
 func (*EnumValueDescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{7}
 }
+
 func (m *EnumValueDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_EnumValueDescriptorProto.Unmarshal(m, b)
 }
@@ -1164,6 +1174,7 @@ func (*ServiceDescriptorProto) ProtoMessage()    {}
 func (*ServiceDescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{8}
 }
+
 func (m *ServiceDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ServiceDescriptorProto.Unmarshal(m, b)
 }
@@ -1226,6 +1237,7 @@ func (*MethodDescriptorProto) ProtoMessage()    {}
 func (*MethodDescriptorProto) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{9}
 }
+
 func (m *MethodDescriptorProto) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_MethodDescriptorProto.Unmarshal(m, b)
 }
@@ -2183,6 +2195,7 @@ func (*UninterpretedOption) ProtoMessage()    {}
 func (*UninterpretedOption) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{18}
 }
+
 func (m *UninterpretedOption) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UninterpretedOption.Unmarshal(m, b)
 }
@@ -2269,6 +2282,7 @@ func (*UninterpretedOption_NamePart) ProtoMessage()    {}
 func (*UninterpretedOption_NamePart) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{18, 0}
 }
+
 func (m *UninterpretedOption_NamePart) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UninterpretedOption_NamePart.Unmarshal(m, b)
 }
@@ -2359,6 +2373,7 @@ func (*SourceCodeInfo) ProtoMessage()    {}
 func (*SourceCodeInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{19}
 }
+
 func (m *SourceCodeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SourceCodeInfo.Unmarshal(m, b)
 }
@@ -2476,6 +2491,7 @@ func (*SourceCodeInfo_Location) ProtoMessage()    {}
 func (*SourceCodeInfo_Location) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{19, 0}
 }
+
 func (m *SourceCodeInfo_Location) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SourceCodeInfo_Location.Unmarshal(m, b)
 }
@@ -2547,6 +2563,7 @@ func (*GeneratedCodeInfo) ProtoMessage()    {}
 func (*GeneratedCodeInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{20}
 }
+
 func (m *GeneratedCodeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GeneratedCodeInfo.Unmarshal(m, b)
 }
@@ -2596,6 +2613,7 @@ func (*GeneratedCodeInfo_Annotation) ProtoMessage()    {}
 func (*GeneratedCodeInfo_Annotation) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e5baabe45344a177, []int{20, 0}
 }
+
 func (m *GeneratedCodeInfo_Annotation) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GeneratedCodeInfo_Annotation.Unmarshal(m, b)
 }

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2361,10 +2361,12 @@ func (g *Generator) generateCommonMethods(mc *msgCtx) {
 	g.P("func (*", mc.goName, ") Descriptor() ([]byte, []int) {")
 	g.P("return ", g.file.VarName(), ", []int{", strings.Join(indexes, ", "), "}")
 	g.P("}")
+	g.P()
 	// TODO: Revisit the decision to use a XXX_WellKnownType method
 	// if we change proto.MessageName to work with multiple equivalents.
 	if mc.message.file.GetPackage() == "google.protobuf" && wellKnownTypes[mc.message.GetName()] {
 		g.P("func (*", mc.goName, `) XXX_WellKnownType() string { return "`, mc.message.GetName(), `" }`)
+		g.P()
 	}
 
 	// Extension support methods

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -67,6 +67,7 @@ func (*DeprecatedRequest) ProtoMessage()    {}
 func (*DeprecatedRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_f64ba265cd7eae3f, []int{0}
 }
+
 func (m *DeprecatedRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedRequest.Unmarshal(m, b)
 }
@@ -100,6 +101,7 @@ func (*DeprecatedResponse) ProtoMessage()    {}
 func (*DeprecatedResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_f64ba265cd7eae3f, []int{1}
 }
+
 func (m *DeprecatedResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeprecatedResponse.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
+++ b/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
@@ -33,6 +33,7 @@ func (*ExtraMessage) ProtoMessage()    {}
 func (*ExtraMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_fce75f5a63502cd5, []int{0}
 }
+
 func (m *ExtraMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExtraMessage.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -36,6 +36,7 @@ func (*UserMessage) ProtoMessage()    {}
 func (*UserMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_359ba8abf543ca10, []int{0}
 }
+
 func (m *UserMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UserMessage.Unmarshal(m, b)
 }
@@ -131,6 +132,7 @@ func (*LoginMessage) ProtoMessage()    {}
 func (*LoginMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_359ba8abf543ca10, []int{2}
 }
+
 func (m *LoginMessage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoginMessage.Unmarshal(m, b)
 }
@@ -171,6 +173,7 @@ func (*Detail) ProtoMessage()    {}
 func (*Detail) Descriptor() ([]byte, []int) {
 	return fileDescriptor_359ba8abf543ca10, []int{3}
 }
+
 func (m *Detail) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Detail.Unmarshal(m, b)
 }
@@ -210,6 +213,7 @@ func (*Announcement) ProtoMessage()    {}
 func (*Announcement) Descriptor() ([]byte, []int) {
 	return fileDescriptor_359ba8abf543ca10, []int{4}
 }
+
 func (m *Announcement) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Announcement.Unmarshal(m, b)
 }
@@ -259,6 +263,7 @@ func (*OldStyleParcel) ProtoMessage()    {}
 func (*OldStyleParcel) Descriptor() ([]byte, []int) {
 	return fileDescriptor_359ba8abf543ca10, []int{5}
 }
+
 func (m *OldStyleParcel) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OldStyleParcel.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -37,6 +37,7 @@ func (*SimpleRequest) ProtoMessage()    {}
 func (*SimpleRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81ea47a3f88c2082, []int{0}
 }
+
 func (m *SimpleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleRequest.Unmarshal(m, b)
 }
@@ -67,6 +68,7 @@ func (*SimpleResponse) ProtoMessage()    {}
 func (*SimpleResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81ea47a3f88c2082, []int{1}
 }
+
 func (m *SimpleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SimpleResponse.Unmarshal(m, b)
 }
@@ -97,6 +99,7 @@ func (*StreamMsg) ProtoMessage()    {}
 func (*StreamMsg) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81ea47a3f88c2082, []int{2}
 }
+
 func (m *StreamMsg) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg.Unmarshal(m, b)
 }
@@ -127,6 +130,7 @@ func (*StreamMsg2) ProtoMessage()    {}
 func (*StreamMsg2) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81ea47a3f88c2082, []int{3}
 }
+
 func (m *StreamMsg2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StreamMsg2.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/import_public/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/a.pb.go
@@ -49,6 +49,7 @@ func (*Public) ProtoMessage()    {}
 func (*Public) Descriptor() ([]byte, []int) {
 	return fileDescriptor_73b7577c95fa6b70, []int{0}
 }
+
 func (m *Public) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Public.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/import_public/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/b.pb.go
@@ -35,6 +35,7 @@ func (*Local) ProtoMessage()    {}
 func (*Local) Descriptor() ([]byte, []int) {
 	return fileDescriptor_84995586b3d09710, []int{0}
 }
+
 func (m *Local) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Local.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/import_public/sub/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/a.pb.go
@@ -56,6 +56,7 @@ func (*M) ProtoMessage()    {}
 func (*M) Descriptor() ([]byte, []int) {
 	return fileDescriptor_382f7805394b5c4e, []int{0}
 }
+
 func (m *M) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/import_public/sub/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/b.pb.go
@@ -32,6 +32,7 @@ func (*M2) ProtoMessage()    {}
 func (*M2) Descriptor() ([]byte, []int) {
 	return fileDescriptor_fc66afda3d7c2232, []int{0}
 }
+
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/fmt/m.pb.go
+++ b/protoc-gen-go/testdata/imports/fmt/m.pb.go
@@ -32,6 +32,7 @@ func (*M) ProtoMessage()    {}
 func (*M) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72c126fcd452e392, []int{0}
 }
+
 func (m *M) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -54,6 +54,7 @@ func (*M1) ProtoMessage()    {}
 func (*M1) Descriptor() ([]byte, []int) {
 	return fileDescriptor_c1091de3fa870a14, []int{0}
 }
+
 func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
 }
@@ -85,6 +86,7 @@ func (*M1_1) ProtoMessage()    {}
 func (*M1_1) Descriptor() ([]byte, []int) {
 	return fileDescriptor_c1091de3fa870a14, []int{1}
 }
+
 func (m *M1_1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1_1.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
@@ -32,6 +32,7 @@ func (*M2) ProtoMessage()    {}
 func (*M2) Descriptor() ([]byte, []int) {
 	return fileDescriptor_20cf27515c0d621c, []int{0}
 }
+
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
@@ -32,6 +32,7 @@ func (*M3) ProtoMessage()    {}
 func (*M3) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ff9d8f834875c9c5, []int{0}
 }
+
 func (m *M3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M3.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
@@ -32,6 +32,7 @@ func (*M4) ProtoMessage()    {}
 func (*M4) Descriptor() ([]byte, []int) {
 	return fileDescriptor_fdd24f82f6c5a786, []int{0}
 }
+
 func (m *M4) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M4.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
@@ -32,6 +32,7 @@ func (*M1) ProtoMessage()    {}
 func (*M1) Descriptor() ([]byte, []int) {
 	return fileDescriptor_7f49573d035512a8, []int{0}
 }
+
 func (m *M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M1.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
@@ -32,6 +32,7 @@ func (*M2) ProtoMessage()    {}
 func (*M2) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a1becddceeb586f2, []int{0}
 }
+
 func (m *M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_M2.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
@@ -34,6 +34,7 @@ func (*A1M1) ProtoMessage()    {}
 func (*A1M1) Descriptor() ([]byte, []int) {
 	return fileDescriptor_3b904a47327455f3, []int{0}
 }
+
 func (m *A1M1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M1.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
@@ -34,6 +34,7 @@ func (*A1M2) ProtoMessage()    {}
 func (*A1M2) Descriptor() ([]byte, []int) {
 	return fileDescriptor_bdb27b114687957d, []int{0}
 }
+
 func (m *A1M2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_A1M2.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/imports/test_import_all.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_all.pb.go
@@ -43,6 +43,7 @@ func (*All) ProtoMessage()    {}
 func (*All) Descriptor() ([]byte, []int) {
 	return fileDescriptor_324466f0afc16f77, []int{0}
 }
+
 func (m *All) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_All.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/multi/multi1.pb.go
+++ b/protoc-gen-go/testdata/multi/multi1.pb.go
@@ -35,6 +35,7 @@ func (*Multi1) ProtoMessage()    {}
 func (*Multi1) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e0bffc140cd1b1d9, []int{0}
 }
+
 func (m *Multi1) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi1.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -77,6 +77,7 @@ func (*Multi2) ProtoMessage()    {}
 func (*Multi2) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a2aebe588a0b2853, []int{0}
 }
+
 func (m *Multi2) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi2.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -73,6 +73,7 @@ func (*Multi3) ProtoMessage()    {}
 func (*Multi3) Descriptor() ([]byte, []int) {
 	return fileDescriptor_580398fc0bbeeaa7, []int{0}
 }
+
 func (m *Multi3) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Multi3.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -220,6 +220,7 @@ func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{0}
 }
+
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
 }
@@ -318,6 +319,7 @@ func (*Request_SomeGroup) ProtoMessage()    {}
 func (*Request_SomeGroup) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{0, 0}
 }
+
 func (m *Request_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request_SomeGroup.Unmarshal(m, b)
 }
@@ -414,6 +416,7 @@ func (*Reply_Entry) ProtoMessage()    {}
 func (*Reply_Entry) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{1, 0}
 }
+
 func (m *Reply_Entry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Reply_Entry.Unmarshal(m, b)
 }
@@ -515,6 +518,7 @@ func (*ReplyExtensions) ProtoMessage()    {}
 func (*ReplyExtensions) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{3}
 }
+
 func (m *ReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReplyExtensions.Unmarshal(m, b)
 }
@@ -573,6 +577,7 @@ func (*OtherReplyExtensions) ProtoMessage()    {}
 func (*OtherReplyExtensions) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{4}
 }
+
 func (m *OtherReplyExtensions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OtherReplyExtensions.Unmarshal(m, b)
 }
@@ -672,6 +677,7 @@ func (*Communique) ProtoMessage()    {}
 func (*Communique) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{6}
 }
+
 func (m *Communique) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique.Unmarshal(m, b)
 }
@@ -1043,6 +1049,7 @@ func (*Communique_SomeGroup) ProtoMessage()    {}
 func (*Communique_SomeGroup) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{6, 0}
 }
+
 func (m *Communique_SomeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_SomeGroup.Unmarshal(m, b)
 }
@@ -1080,6 +1087,7 @@ func (*Communique_Delta) ProtoMessage()    {}
 func (*Communique_Delta) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{6, 1}
 }
+
 func (m *Communique_Delta) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Communique_Delta.Unmarshal(m, b)
 }

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -68,6 +68,7 @@ func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ab04eb4084a521db, []int{0}
 }
+
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
 }
@@ -135,6 +136,7 @@ func (*Book) ProtoMessage()    {}
 func (*Book) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ab04eb4084a521db, []int{1}
 }
+
 func (m *Book) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Book.Unmarshal(m, b)
 }

--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -137,7 +137,9 @@ func (*Any) ProtoMessage()    {}
 func (*Any) Descriptor() ([]byte, []int) {
 	return fileDescriptor_b53526c13ae22eb4, []int{0}
 }
+
 func (*Any) XXX_WellKnownType() string { return "Any" }
+
 func (m *Any) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Any.Unmarshal(m, b)
 }

--- a/ptypes/duration/duration.pb.go
+++ b/ptypes/duration/duration.pb.go
@@ -103,7 +103,9 @@ func (*Duration) ProtoMessage()    {}
 func (*Duration) Descriptor() ([]byte, []int) {
 	return fileDescriptor_23597b2ebd7ac6c5, []int{0}
 }
+
 func (*Duration) XXX_WellKnownType() string { return "Duration" }
+
 func (m *Duration) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Duration.Unmarshal(m, b)
 }

--- a/ptypes/empty/empty.pb.go
+++ b/ptypes/empty/empty.pb.go
@@ -41,7 +41,9 @@ func (*Empty) ProtoMessage()    {}
 func (*Empty) Descriptor() ([]byte, []int) {
 	return fileDescriptor_900544acb223d5b8, []int{0}
 }
+
 func (*Empty) XXX_WellKnownType() string { return "Empty" }
+
 func (m *Empty) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Empty.Unmarshal(m, b)
 }

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -71,7 +71,9 @@ func (*Struct) ProtoMessage()    {}
 func (*Struct) Descriptor() ([]byte, []int) {
 	return fileDescriptor_df322afd6c9fb402, []int{0}
 }
+
 func (*Struct) XXX_WellKnownType() string { return "Struct" }
+
 func (m *Struct) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Struct.Unmarshal(m, b)
 }
@@ -125,7 +127,9 @@ func (*Value) ProtoMessage()    {}
 func (*Value) Descriptor() ([]byte, []int) {
 	return fileDescriptor_df322afd6c9fb402, []int{1}
 }
+
 func (*Value) XXX_WellKnownType() string { return "Value" }
+
 func (m *Value) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Value.Unmarshal(m, b)
 }
@@ -385,7 +389,9 @@ func (*ListValue) ProtoMessage()    {}
 func (*ListValue) Descriptor() ([]byte, []int) {
 	return fileDescriptor_df322afd6c9fb402, []int{2}
 }
+
 func (*ListValue) XXX_WellKnownType() string { return "ListValue" }
+
 func (m *ListValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListValue.Unmarshal(m, b)
 }

--- a/ptypes/timestamp/timestamp.pb.go
+++ b/ptypes/timestamp/timestamp.pb.go
@@ -119,7 +119,9 @@ func (*Timestamp) ProtoMessage()    {}
 func (*Timestamp) Descriptor() ([]byte, []int) {
 	return fileDescriptor_292007bbfe81227e, []int{0}
 }
+
 func (*Timestamp) XXX_WellKnownType() string { return "Timestamp" }
+
 func (m *Timestamp) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Timestamp.Unmarshal(m, b)
 }

--- a/ptypes/wrappers/wrappers.pb.go
+++ b/ptypes/wrappers/wrappers.pb.go
@@ -37,7 +37,9 @@ func (*DoubleValue) ProtoMessage()    {}
 func (*DoubleValue) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{0}
 }
+
 func (*DoubleValue) XXX_WellKnownType() string { return "DoubleValue" }
+
 func (m *DoubleValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DoubleValue.Unmarshal(m, b)
 }
@@ -80,7 +82,9 @@ func (*FloatValue) ProtoMessage()    {}
 func (*FloatValue) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{1}
 }
+
 func (*FloatValue) XXX_WellKnownType() string { return "FloatValue" }
+
 func (m *FloatValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FloatValue.Unmarshal(m, b)
 }
@@ -123,7 +127,9 @@ func (*Int64Value) ProtoMessage()    {}
 func (*Int64Value) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{2}
 }
+
 func (*Int64Value) XXX_WellKnownType() string { return "Int64Value" }
+
 func (m *Int64Value) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Int64Value.Unmarshal(m, b)
 }
@@ -166,7 +172,9 @@ func (*UInt64Value) ProtoMessage()    {}
 func (*UInt64Value) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{3}
 }
+
 func (*UInt64Value) XXX_WellKnownType() string { return "UInt64Value" }
+
 func (m *UInt64Value) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UInt64Value.Unmarshal(m, b)
 }
@@ -209,7 +217,9 @@ func (*Int32Value) ProtoMessage()    {}
 func (*Int32Value) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{4}
 }
+
 func (*Int32Value) XXX_WellKnownType() string { return "Int32Value" }
+
 func (m *Int32Value) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Int32Value.Unmarshal(m, b)
 }
@@ -252,7 +262,9 @@ func (*UInt32Value) ProtoMessage()    {}
 func (*UInt32Value) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{5}
 }
+
 func (*UInt32Value) XXX_WellKnownType() string { return "UInt32Value" }
+
 func (m *UInt32Value) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UInt32Value.Unmarshal(m, b)
 }
@@ -295,7 +307,9 @@ func (*BoolValue) ProtoMessage()    {}
 func (*BoolValue) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{6}
 }
+
 func (*BoolValue) XXX_WellKnownType() string { return "BoolValue" }
+
 func (m *BoolValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BoolValue.Unmarshal(m, b)
 }
@@ -338,7 +352,9 @@ func (*StringValue) ProtoMessage()    {}
 func (*StringValue) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{7}
 }
+
 func (*StringValue) XXX_WellKnownType() string { return "StringValue" }
+
 func (m *StringValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StringValue.Unmarshal(m, b)
 }
@@ -381,7 +397,9 @@ func (*BytesValue) ProtoMessage()    {}
 func (*BytesValue) Descriptor() ([]byte, []int) {
 	return fileDescriptor_5377b62bda767935, []int{8}
 }
+
 func (*BytesValue) XXX_WellKnownType() string { return "BytesValue" }
+
 func (m *BytesValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BytesValue.Unmarshal(m, b)
 }


### PR DESCRIPTION
Add a blank line after the Descriptor and XXX_WellKnownType methods.