### PR TITLE
protoc-gen-go: don't set the json tag on extension fields

### DIFF
--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -908,7 +908,7 @@ var E_Complex_RealExtension = &proto.ExtensionDesc{
 	ExtensionType: (*Complex)(nil),
 	Field:         123,
 	Name:          "jsonpb.Complex.real_extension",
-	Tag:           "bytes,123,opt,name=real_extension,json=realExtension",
+	Tag:           "bytes,123,opt,name=real_extension",
 	Filename:      "test_objects.proto",
 }
 

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -4187,7 +4187,7 @@ var E_RComplex = &proto.ExtensionDesc{
 	ExtensionType: ([]*ComplexExtension)(nil),
 	Field:         201,
 	Name:          "test_proto.r_complex",
-	Tag:           "bytes,201,rep,name=r_complex,json=rComplex",
+	Tag:           "bytes,201,rep,name=r_complex",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4196,7 +4196,7 @@ var E_NoDefaultDouble = &proto.ExtensionDesc{
 	ExtensionType: (*float64)(nil),
 	Field:         101,
 	Name:          "test_proto.no_default_double",
-	Tag:           "fixed64,101,opt,name=no_default_double,json=noDefaultDouble",
+	Tag:           "fixed64,101,opt,name=no_default_double",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4205,7 +4205,7 @@ var E_NoDefaultFloat = &proto.ExtensionDesc{
 	ExtensionType: (*float32)(nil),
 	Field:         102,
 	Name:          "test_proto.no_default_float",
-	Tag:           "fixed32,102,opt,name=no_default_float,json=noDefaultFloat",
+	Tag:           "fixed32,102,opt,name=no_default_float",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4214,7 +4214,7 @@ var E_NoDefaultInt32 = &proto.ExtensionDesc{
 	ExtensionType: (*int32)(nil),
 	Field:         103,
 	Name:          "test_proto.no_default_int32",
-	Tag:           "varint,103,opt,name=no_default_int32,json=noDefaultInt32",
+	Tag:           "varint,103,opt,name=no_default_int32",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4223,7 +4223,7 @@ var E_NoDefaultInt64 = &proto.ExtensionDesc{
 	ExtensionType: (*int64)(nil),
 	Field:         104,
 	Name:          "test_proto.no_default_int64",
-	Tag:           "varint,104,opt,name=no_default_int64,json=noDefaultInt64",
+	Tag:           "varint,104,opt,name=no_default_int64",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4232,7 +4232,7 @@ var E_NoDefaultUint32 = &proto.ExtensionDesc{
 	ExtensionType: (*uint32)(nil),
 	Field:         105,
 	Name:          "test_proto.no_default_uint32",
-	Tag:           "varint,105,opt,name=no_default_uint32,json=noDefaultUint32",
+	Tag:           "varint,105,opt,name=no_default_uint32",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4241,7 +4241,7 @@ var E_NoDefaultUint64 = &proto.ExtensionDesc{
 	ExtensionType: (*uint64)(nil),
 	Field:         106,
 	Name:          "test_proto.no_default_uint64",
-	Tag:           "varint,106,opt,name=no_default_uint64,json=noDefaultUint64",
+	Tag:           "varint,106,opt,name=no_default_uint64",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4250,7 +4250,7 @@ var E_NoDefaultSint32 = &proto.ExtensionDesc{
 	ExtensionType: (*int32)(nil),
 	Field:         107,
 	Name:          "test_proto.no_default_sint32",
-	Tag:           "zigzag32,107,opt,name=no_default_sint32,json=noDefaultSint32",
+	Tag:           "zigzag32,107,opt,name=no_default_sint32",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4259,7 +4259,7 @@ var E_NoDefaultSint64 = &proto.ExtensionDesc{
 	ExtensionType: (*int64)(nil),
 	Field:         108,
 	Name:          "test_proto.no_default_sint64",
-	Tag:           "zigzag64,108,opt,name=no_default_sint64,json=noDefaultSint64",
+	Tag:           "zigzag64,108,opt,name=no_default_sint64",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4268,7 +4268,7 @@ var E_NoDefaultFixed32 = &proto.ExtensionDesc{
 	ExtensionType: (*uint32)(nil),
 	Field:         109,
 	Name:          "test_proto.no_default_fixed32",
-	Tag:           "fixed32,109,opt,name=no_default_fixed32,json=noDefaultFixed32",
+	Tag:           "fixed32,109,opt,name=no_default_fixed32",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4277,7 +4277,7 @@ var E_NoDefaultFixed64 = &proto.ExtensionDesc{
 	ExtensionType: (*uint64)(nil),
 	Field:         110,
 	Name:          "test_proto.no_default_fixed64",
-	Tag:           "fixed64,110,opt,name=no_default_fixed64,json=noDefaultFixed64",
+	Tag:           "fixed64,110,opt,name=no_default_fixed64",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4286,7 +4286,7 @@ var E_NoDefaultSfixed32 = &proto.ExtensionDesc{
 	ExtensionType: (*int32)(nil),
 	Field:         111,
 	Name:          "test_proto.no_default_sfixed32",
-	Tag:           "fixed32,111,opt,name=no_default_sfixed32,json=noDefaultSfixed32",
+	Tag:           "fixed32,111,opt,name=no_default_sfixed32",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4295,7 +4295,7 @@ var E_NoDefaultSfixed64 = &proto.ExtensionDesc{
 	ExtensionType: (*int64)(nil),
 	Field:         112,
 	Name:          "test_proto.no_default_sfixed64",
-	Tag:           "fixed64,112,opt,name=no_default_sfixed64,json=noDefaultSfixed64",
+	Tag:           "fixed64,112,opt,name=no_default_sfixed64",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4304,7 +4304,7 @@ var E_NoDefaultBool = &proto.ExtensionDesc{
 	ExtensionType: (*bool)(nil),
 	Field:         113,
 	Name:          "test_proto.no_default_bool",
-	Tag:           "varint,113,opt,name=no_default_bool,json=noDefaultBool",
+	Tag:           "varint,113,opt,name=no_default_bool",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4313,7 +4313,7 @@ var E_NoDefaultString = &proto.ExtensionDesc{
 	ExtensionType: (*string)(nil),
 	Field:         114,
 	Name:          "test_proto.no_default_string",
-	Tag:           "bytes,114,opt,name=no_default_string,json=noDefaultString",
+	Tag:           "bytes,114,opt,name=no_default_string",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4322,7 +4322,7 @@ var E_NoDefaultBytes = &proto.ExtensionDesc{
 	ExtensionType: ([]byte)(nil),
 	Field:         115,
 	Name:          "test_proto.no_default_bytes",
-	Tag:           "bytes,115,opt,name=no_default_bytes,json=noDefaultBytes",
+	Tag:           "bytes,115,opt,name=no_default_bytes",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4331,7 +4331,7 @@ var E_NoDefaultEnum = &proto.ExtensionDesc{
 	ExtensionType: (*DefaultsMessage_DefaultsEnum)(nil),
 	Field:         116,
 	Name:          "test_proto.no_default_enum",
-	Tag:           "varint,116,opt,name=no_default_enum,json=noDefaultEnum,enum=test_proto.DefaultsMessage_DefaultsEnum",
+	Tag:           "varint,116,opt,name=no_default_enum,enum=test_proto.DefaultsMessage_DefaultsEnum",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4340,7 +4340,7 @@ var E_DefaultDouble = &proto.ExtensionDesc{
 	ExtensionType: (*float64)(nil),
 	Field:         201,
 	Name:          "test_proto.default_double",
-	Tag:           "fixed64,201,opt,name=default_double,json=defaultDouble,def=3.1415",
+	Tag:           "fixed64,201,opt,name=default_double,def=3.1415",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4349,7 +4349,7 @@ var E_DefaultFloat = &proto.ExtensionDesc{
 	ExtensionType: (*float32)(nil),
 	Field:         202,
 	Name:          "test_proto.default_float",
-	Tag:           "fixed32,202,opt,name=default_float,json=defaultFloat,def=3.14",
+	Tag:           "fixed32,202,opt,name=default_float,def=3.14",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4358,7 +4358,7 @@ var E_DefaultInt32 = &proto.ExtensionDesc{
 	ExtensionType: (*int32)(nil),
 	Field:         203,
 	Name:          "test_proto.default_int32",
-	Tag:           "varint,203,opt,name=default_int32,json=defaultInt32,def=42",
+	Tag:           "varint,203,opt,name=default_int32,def=42",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4367,7 +4367,7 @@ var E_DefaultInt64 = &proto.ExtensionDesc{
 	ExtensionType: (*int64)(nil),
 	Field:         204,
 	Name:          "test_proto.default_int64",
-	Tag:           "varint,204,opt,name=default_int64,json=defaultInt64,def=43",
+	Tag:           "varint,204,opt,name=default_int64,def=43",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4376,7 +4376,7 @@ var E_DefaultUint32 = &proto.ExtensionDesc{
 	ExtensionType: (*uint32)(nil),
 	Field:         205,
 	Name:          "test_proto.default_uint32",
-	Tag:           "varint,205,opt,name=default_uint32,json=defaultUint32,def=44",
+	Tag:           "varint,205,opt,name=default_uint32,def=44",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4385,7 +4385,7 @@ var E_DefaultUint64 = &proto.ExtensionDesc{
 	ExtensionType: (*uint64)(nil),
 	Field:         206,
 	Name:          "test_proto.default_uint64",
-	Tag:           "varint,206,opt,name=default_uint64,json=defaultUint64,def=45",
+	Tag:           "varint,206,opt,name=default_uint64,def=45",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4394,7 +4394,7 @@ var E_DefaultSint32 = &proto.ExtensionDesc{
 	ExtensionType: (*int32)(nil),
 	Field:         207,
 	Name:          "test_proto.default_sint32",
-	Tag:           "zigzag32,207,opt,name=default_sint32,json=defaultSint32,def=46",
+	Tag:           "zigzag32,207,opt,name=default_sint32,def=46",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4403,7 +4403,7 @@ var E_DefaultSint64 = &proto.ExtensionDesc{
 	ExtensionType: (*int64)(nil),
 	Field:         208,
 	Name:          "test_proto.default_sint64",
-	Tag:           "zigzag64,208,opt,name=default_sint64,json=defaultSint64,def=47",
+	Tag:           "zigzag64,208,opt,name=default_sint64,def=47",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4412,7 +4412,7 @@ var E_DefaultFixed32 = &proto.ExtensionDesc{
 	ExtensionType: (*uint32)(nil),
 	Field:         209,
 	Name:          "test_proto.default_fixed32",
-	Tag:           "fixed32,209,opt,name=default_fixed32,json=defaultFixed32,def=48",
+	Tag:           "fixed32,209,opt,name=default_fixed32,def=48",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4421,7 +4421,7 @@ var E_DefaultFixed64 = &proto.ExtensionDesc{
 	ExtensionType: (*uint64)(nil),
 	Field:         210,
 	Name:          "test_proto.default_fixed64",
-	Tag:           "fixed64,210,opt,name=default_fixed64,json=defaultFixed64,def=49",
+	Tag:           "fixed64,210,opt,name=default_fixed64,def=49",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4430,7 +4430,7 @@ var E_DefaultSfixed32 = &proto.ExtensionDesc{
 	ExtensionType: (*int32)(nil),
 	Field:         211,
 	Name:          "test_proto.default_sfixed32",
-	Tag:           "fixed32,211,opt,name=default_sfixed32,json=defaultSfixed32,def=50",
+	Tag:           "fixed32,211,opt,name=default_sfixed32,def=50",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4439,7 +4439,7 @@ var E_DefaultSfixed64 = &proto.ExtensionDesc{
 	ExtensionType: (*int64)(nil),
 	Field:         212,
 	Name:          "test_proto.default_sfixed64",
-	Tag:           "fixed64,212,opt,name=default_sfixed64,json=defaultSfixed64,def=51",
+	Tag:           "fixed64,212,opt,name=default_sfixed64,def=51",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4448,7 +4448,7 @@ var E_DefaultBool = &proto.ExtensionDesc{
 	ExtensionType: (*bool)(nil),
 	Field:         213,
 	Name:          "test_proto.default_bool",
-	Tag:           "varint,213,opt,name=default_bool,json=defaultBool,def=1",
+	Tag:           "varint,213,opt,name=default_bool,def=1",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4457,7 +4457,7 @@ var E_DefaultString = &proto.ExtensionDesc{
 	ExtensionType: (*string)(nil),
 	Field:         214,
 	Name:          "test_proto.default_string",
-	Tag:           "bytes,214,opt,name=default_string,json=defaultString,def=Hello, string,def=foo",
+	Tag:           "bytes,214,opt,name=default_string,def=Hello, string,def=foo",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4466,7 +4466,7 @@ var E_DefaultBytes = &proto.ExtensionDesc{
 	ExtensionType: ([]byte)(nil),
 	Field:         215,
 	Name:          "test_proto.default_bytes",
-	Tag:           "bytes,215,opt,name=default_bytes,json=defaultBytes,def=Hello, bytes",
+	Tag:           "bytes,215,opt,name=default_bytes,def=Hello, bytes",
 	Filename:      "test_proto/test.proto",
 }
 
@@ -4475,7 +4475,7 @@ var E_DefaultEnum = &proto.ExtensionDesc{
 	ExtensionType: (*DefaultsMessage_DefaultsEnum)(nil),
 	Field:         216,
 	Name:          "test_proto.default_enum",
-	Tag:           "varint,216,opt,name=default_enum,json=defaultEnum,enum=test_proto.DefaultsMessage_DefaultsEnum,def=1",
+	Tag:           "varint,216,opt,name=default_enum,enum=test_proto.DefaultsMessage_DefaultsEnum,def=1",
 	Filename:      "test_proto/test.proto",
 }
 

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1532,7 +1532,7 @@ func (g *Generator) goTag(message *Descriptor, field *descriptor.FieldDescriptor
 			name = name[i+1:]
 		}
 	}
-	if json := field.GetJsonName(); json != "" && json != name {
+	if json := field.GetJsonName(); field.Extendee == nil && json != "" && json != name {
 		// TODO: escaping might be needed, in which case
 		// perhaps this should be in its own "json" tag.
 		name += ",json=" + json

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -156,7 +156,7 @@ var E_LoginMessage_UserMessage = &proto.ExtensionDesc{
 	ExtensionType: (*UserMessage)(nil),
 	Field:         16,
 	Name:          "extension_user.LoginMessage.user_message",
-	Tag:           "bytes,16,opt,name=user_message,json=userMessage",
+	Tag:           "bytes,16,opt,name=user_message",
 	Filename:      "extension_user/extension_user.proto",
 }
 
@@ -244,7 +244,7 @@ var E_Announcement_LoudExt = &proto.ExtensionDesc{
 	ExtensionType: (*Announcement)(nil),
 	Field:         100,
 	Name:          "extension_user.Announcement.loud_ext",
-	Tag:           "bytes,100,opt,name=loud_ext,json=loudExt",
+	Tag:           "bytes,100,opt,name=loud_ext",
 	Filename:      "extension_user/extension_user.proto",
 }
 
@@ -301,7 +301,7 @@ var E_OldStyleParcel_MessageSetExtension = &proto.ExtensionDesc{
 	ExtensionType: (*OldStyleParcel)(nil),
 	Field:         2001,
 	Name:          "extension_user.OldStyleParcel",
-	Tag:           "bytes,2001,opt,name=message_set_extension,json=messageSetExtension",
+	Tag:           "bytes,2001,opt,name=message_set_extension",
 	Filename:      "extension_user/extension_user.proto",
 }
 
@@ -310,7 +310,7 @@ var E_UserMessage = &proto.ExtensionDesc{
 	ExtensionType: (*UserMessage)(nil),
 	Field:         5,
 	Name:          "extension_user.user_message",
-	Tag:           "bytes,5,opt,name=user_message,json=userMessage",
+	Tag:           "bytes,5,opt,name=user_message",
 	Filename:      "extension_user/extension_user.proto",
 }
 
@@ -319,7 +319,7 @@ var E_ExtraMessage = &proto.ExtensionDesc{
 	ExtensionType: (*extension_extra.ExtraMessage)(nil),
 	Field:         9,
 	Name:          "extension_user.extra_message",
-	Tag:           "bytes,9,opt,name=extra_message,json=extraMessage",
+	Tag:           "bytes,9,opt,name=extra_message",
 	Filename:      "extension_user/extension_user.proto",
 }
 


### PR DESCRIPTION
This tag is not used by jsonpb. Future releases of protoc will stop
including a json_name field in extension descriptors.