### PR TITLE
protoc-gen-go: put all imports in one section

### DIFF
--- a/conformance/internal/conformance_proto/conformance.pb.go
+++ b/conformance/internal/conformance_proto/conformance.pb.go
@@ -5,8 +5,6 @@ package conformance
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	duration "github.com/golang/protobuf/ptypes/duration"
@@ -14,6 +12,7 @@ import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	field_mask "google.golang.org/genproto/protobuf/field_mask"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -5,9 +5,8 @@ package jsonpb
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -5,14 +5,13 @@ package jsonpb
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	duration "github.com/golang/protobuf/ptypes/duration"
 	_struct "github.com/golang/protobuf/ptypes/struct"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -5,11 +5,10 @@ package proto3_proto
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	test_proto "github.com/golang/protobuf/proto/test_proto"
 	any "github.com/golang/protobuf/ptypes/any"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -5,9 +5,8 @@ package test_proto
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -5,9 +5,8 @@ package descriptor
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1303,26 +1303,15 @@ func (g *Generator) generateImports() {
 	for importPath := range g.addedImports {
 		imports[importPath] = g.GoPackageName(importPath)
 	}
-	g.P("import (")
-	// Standard library imports.
-	g.P(g.Pkg["fmt"] + ` "fmt"`)
-	g.P(g.Pkg["math"] + ` "math"`)
-	for importPath, packageName := range imports {
-		if !strings.Contains(string(importPath), ".") {
-			g.P(packageName, " ", GoImportPath(g.ImportPrefix)+importPath)
-		}
-	}
-	g.P()
-	// Third-party imports.
-	//
 	// We almost always need a proto import.  Rather than computing when we
 	// do, which is tricky when there's a plugin, just import it and
 	// reference it later. The same argument applies to the fmt and math packages.
+	g.P("import (")
+	g.P(g.Pkg["fmt"] + ` "fmt"`)
+	g.P(g.Pkg["math"] + ` "math"`)
 	g.P(g.Pkg["proto"]+" ", GoImportPath(g.ImportPrefix)+"github.com/golang/protobuf/proto")
 	for importPath, packageName := range imports {
-		if strings.Contains(string(importPath), ".") {
-			g.P(packageName, " ", GoImportPath(g.ImportPrefix)+importPath)
-		}
+		g.P(packageName, " ", GoImportPath(g.ImportPrefix)+importPath)
 	}
 	g.P(")")
 	g.P()

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -7,11 +7,10 @@ package deprecated
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -5,9 +5,8 @@ package extension_base
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
+++ b/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
@@ -5,9 +5,8 @@ package extension_extra
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -5,11 +5,10 @@ package extension_user
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	extension_base "github.com/golang/protobuf/protoc-gen-go/testdata/extension_base"
 	extension_extra "github.com/golang/protobuf/protoc-gen-go/testdata/extension_extra"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -5,11 +5,10 @@ package testing
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/import_public/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/a.pb.go
@@ -5,10 +5,9 @@ package import_public
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	sub "github.com/golang/protobuf/protoc-gen-go/testdata/import_public/sub"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/import_public/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/b.pb.go
@@ -5,10 +5,9 @@ package import_public
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	sub "github.com/golang/protobuf/protoc-gen-go/testdata/import_public/sub"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/import_public/sub/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/a.pb.go
@@ -5,9 +5,8 @@ package sub
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/import_public/sub/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/b.pb.go
@@ -5,9 +5,8 @@ package sub
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/fmt/m.pb.go
+++ b/protoc-gen-go/testdata/imports/fmt/m.pb.go
@@ -5,9 +5,8 @@ package fmt
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -5,9 +5,8 @@ package test_a_1
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
@@ -5,9 +5,8 @@ package test_a_1
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
@@ -5,9 +5,8 @@ package test_a_2
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
@@ -5,9 +5,8 @@ package test_a_2
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
@@ -5,9 +5,8 @@ package beta
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
@@ -5,9 +5,8 @@ package beta
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
@@ -5,10 +5,9 @@ package imports
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	test_a_1 "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_a_1"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
@@ -5,10 +5,9 @@ package imports
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	test_a_1 "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_a_1"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/imports/test_import_all.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_all.pb.go
@@ -5,13 +5,12 @@ package imports
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	fmt1 "github.com/golang/protobuf/protoc-gen-go/testdata/imports/fmt"
 	test_a_1 "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_a_1"
 	test_a_2 "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_a_2"
 	test_b_1 "github.com/golang/protobuf/protoc-gen-go/testdata/imports/test_b_1"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/multi/multi1.pb.go
+++ b/protoc-gen-go/testdata/multi/multi1.pb.go
@@ -5,9 +5,8 @@ package multitest
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -5,9 +5,8 @@ package multitest
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -5,9 +5,8 @@ package multitest
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -7,10 +7,9 @@ package test
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	_ "github.com/golang/protobuf/protoc-gen-go/testdata/multi"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -5,9 +5,8 @@ package proto3
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -5,9 +5,8 @@ package any
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ptypes/duration/duration.pb.go
+++ b/ptypes/duration/duration.pb.go
@@ -5,9 +5,8 @@ package duration
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ptypes/empty/empty.pb.go
+++ b/ptypes/empty/empty.pb.go
@@ -5,9 +5,8 @@ package empty
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -5,9 +5,8 @@ package structpb
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ptypes/timestamp/timestamp.pb.go
+++ b/ptypes/timestamp/timestamp.pb.go
@@ -5,9 +5,8 @@ package timestamp
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ptypes/wrappers/wrappers.pb.go
+++ b/ptypes/wrappers/wrappers.pb.go
@@ -5,9 +5,8 @@ package wrappers
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
Keep plugin imports and non-plugin imports in the same section, but
don't try to split stdlib and non-stdlib imports into different
sections. Consistent with using astutil to insert all imports from a
blank slate.