### PR TITLE
protoc-gen-go: predeclared identifiers in cleanPackageName

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -567,7 +567,8 @@ func RegisterUniquePackageName(pkg string, f *FileDescriptor) string {
 	return string(name)
 }
 
-var isGoKeyword = map[string]bool{
+var isGoKeywordOrPredeclaredIdentifier = map[string]bool{
+	// Keywords
 	"break":       true,
 	"case":        true,
 	"chan":        true,
@@ -593,12 +594,53 @@ var isGoKeyword = map[string]bool{
 	"switch":      true,
 	"type":        true,
 	"var":         true,
+
+	// Predeclared Identifiers
+	"append":     true,
+	"bool":       true,
+	"byte":       true,
+	"cap":        true,
+	"close":      true,
+	"complex":    true,
+	"complex128": true,
+	"complex64":  true,
+	"copy":       true,
+	"delete":     true,
+	"error":      true,
+	"false":      true,
+	"float32":    true,
+	"float64":    true,
+	"imag":       true,
+	"int":        true,
+	"int16":      true,
+	"int32":      true,
+	"int64":      true,
+	"int8":       true,
+	"iota":       true,
+	"len":        true,
+	"make":       true,
+	"new":        true,
+	"nil":        true,
+	"panic":      true,
+	"print":      true,
+	"println":    true,
+	"real":       true,
+	"recover":    true,
+	"rune":       true,
+	"string":     true,
+	"true":       true,
+	"uint":       true,
+	"uint16":     true,
+	"uint32":     true,
+	"uint64":     true,
+	"uint8":      true,
+	"uintptr":    true,
 }
 
 func cleanPackageName(name string) GoPackageName {
 	name = strings.Map(badToUnderscore, name)
-	// Identifier must not be keyword: insert _.
-	if isGoKeyword[name] {
+	// Identifier must not be keyword or predeclared identifier: insert _.
+	if isGoKeywordOrPredeclaredIdentifier[name] {
 		name = "_" + name
 	}
 	// Identifier must not begin with digit: insert _.

--- a/protoc-gen-go/generator/name_test.go
+++ b/protoc-gen-go/generator/name_test.go
@@ -68,6 +68,7 @@ func TestGoPackageOption(t *testing.T) {
 		{"foo", "", "foo", true},
 		{"github.com/golang/bar", "github.com/golang/bar", "bar", true},
 		{"github.com/golang/bar;baz", "github.com/golang/bar", "baz", true},
+		{"github.com/golang/string", "github.com/golang/string", "_string", true},
 	}
 	for _, tc := range tests {
 		d := &FileDescriptor{


### PR DESCRIPTION
Don't generate identifiers that conflict with predeclared identifiers, prepend with "_" instead. This matches the behavior for package names that are Go keywords.

We ran into this issue during https://github.com/envoyproxy/envoy/pull/4556. Code with import statement:

```
import string "github.com/envoyproxy/data-plane-api/api/string"
```

was being generated and would not compile.

The list of predeclared indentifiers was taken from: https://golang.org/ref/spec#Predeclared_identifiers

