### PR TITLE
proto: remove panic behavior when registering a duplicate enum

### DIFF
--- a/proto/properties.go
+++ b/proto/properties.go
@@ -439,14 +439,14 @@ func getPropertiesLocked(t reflect.Type) *StructProperties {
 
 // A global registry of enum types.
 // The generated code will register the generated maps by calling RegisterEnum.
-
 var enumValueMaps = make(map[string]map[string]int32)
 
 // RegisterEnum is called from the generated code to install the enum descriptor
 // maps into the global table to aid parsing text format protocol buffers.
 func RegisterEnum(typeName string, unusedNameMap map[int32]string, valueMap map[string]int32) {
 	if _, ok := enumValueMaps[typeName]; ok {
-		panic("proto: duplicate enum registered: " + typeName)
+		log.Printf("proto: duplicate enum registered: %s", typeName)
+		return
 	}
 	enumValueMaps[typeName] = valueMap
 }


### PR DESCRIPTION
This change unifies the behavior when trying to register an already registered type. Instead of panic'ing, a warning is printed and the registration is not altered. 

This solves issues with duplicate registration of enums caused by switching to golang's modules. Prior to modules, packages would vendor protobuf, and registration of common types (like MapBox's vector tile format, for example) happened in the context of the vendored protobuf. When switching on modules, this is no longer the case and pulling in aforementioned packages as dependencies results in broken runtime behavior.

I have been thinking about multiple approaches here, among them:
 * being able to pass in a registration context to `Register*` functions. While certainly interesting, the implications are significant as any code relying on the registered entities would have to be made aware of the original registration context. Probably solvable with the code generator, but it seems like this approach requires further discussion.
 * refactor `Register*` functions to return an `error`  and adjusting the code generator to support a flag for specifying error handling strategies for the case of `Register*` returning an error. Together with something along the lines of `Err{Type/Enum/File}AlreadyRegistered`, this seems like a reasonable way forward.
 * introduce `var EnforceUniqueRegistration = false` in package `proto`. This looked promising at first, but an env var would be needed to be able to adjust the behavior, as calling code would not be able to alter the value prior to `init` of package `proto` being run at startup.

With that, the approach presented here seems to be easy enough and falls in line with existing policies for handling duplicate registration of types.