### PR TITLE
proto: support UTF-8 in TextMarshaler

### DIFF
--- a/proto/text_test.go
+++ b/proto/text_test.go
@@ -377,9 +377,8 @@ func TestUseUtf8StringEscaping(t *testing.T) {
 
 	for i, tc := range testCases {
 		var buf bytes.Buffer
-		tm := proto.TextMarshaler{UseUtf8StringEscaping: true}
-		if err := tm.Marshal(&buf, tc.in); err != nil {
-			t.Errorf("proto.MarsalText: %v", err)
+		if err := proto.MarshalTextUtf8(&buf, tc.in); err != nil {
+			t.Errorf("proto.MarsalTextUtf8: %v", err)
 			continue
 		}
 		s := buf.String()


### PR DESCRIPTION
- add a configuration UseUtf8StringEscaping into TextMarshaler.
- add two functions MarshalTextUtf8 and MarshalTextStringUtf8.

Fixes: #572 
