### PR TITLE
proto: deprecate {Unm,M}arshalMessageSet{JSON}

### DIFF
--- a/proto/deprecated.go
+++ b/proto/deprecated.go
@@ -31,8 +31,33 @@
 
 package proto
 
+import "errors"
+
 // Deprecated: do not use.
 type Stats struct{ Emalloc, Dmalloc, Encode, Decode, Chit, Cmiss, Size uint64 }
 
 // Deprecated: do not use.
 func GetStats() Stats { return Stats{} }
+
+// Deprecated: do not use.
+func MarshalMessageSet(interface{}) ([]byte, error) {
+	return nil, errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func UnmarshalMessageSet([]byte, interface{}) error {
+	return errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func MarshalMessageSetJSON(interface{}) ([]byte, error) {
+	return nil, errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func UnmarshalMessageSetJSON([]byte, interface{}) error {
+	return errors.New("proto: not implemented")
+}
+
+// Deprecated: do not use.
+func RegisterMessageSetType(Message, int32, string) {}

--- a/proto/message_set_test.go
+++ b/proto/message_set_test.go
@@ -29,49 +29,60 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-package proto
+package proto_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
+
+	"github.com/golang/protobuf/proto"
+	. "github.com/golang/protobuf/proto/test_proto"
 )
 
 func TestUnmarshalMessageSetWithDuplicate(t *testing.T) {
-	// Check that a repeated message set entry will be concatenated.
-	in := &messageSet{
-		Item: []*_MessageSet_Item{
-			{TypeId: Int32(12345), Message: []byte("hoo")},
-			{TypeId: Int32(12345), Message: []byte("hah")},
-		},
-	}
-	b, err := Marshal(in)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	t.Logf("Marshaled bytes: %q", b)
+	/*
+		Message{
+			Tag{1, StartGroup},
+			Message{
+				Tag{2, Varint}, Uvarint(12345),
+				Tag{3, Bytes}, Bytes("hoo"),
+			},
+			Tag{1, EndGroup},
+			Tag{1, StartGroup},
+			Message{
+				Tag{2, Varint}, Uvarint(12345),
+				Tag{3, Bytes}, Bytes("hah"),
+			},
+			Tag{1, EndGroup},
+		}
+	*/
+	var in []byte
+	fmt.Sscanf("0b10b9601a03686f6f0c0b10b9601a036861680c", "%x", &in)
 
-	var extensions XXX_InternalExtensions
-	if err := UnmarshalMessageSet(b, &extensions); err != nil {
-		t.Fatalf("UnmarshalMessageSet: %v", err)
-	}
-	ext, ok := extensions.p.extensionMap[12345]
-	if !ok {
-		t.Fatalf("Didn't retrieve extension 12345; map is %v", extensions.p.extensionMap)
-	}
-	// Skip wire type/field number and length varints.
-	got := skipVarint(skipVarint(ext.enc))
-	if want := []byte("hoohah"); !bytes.Equal(got, want) {
-		t.Errorf("Combined extension is %q, want %q", got, want)
-	}
-}
+	/*
+		Message{
+			Tag{1, StartGroup},
+			Message{
+				Tag{2, Varint}, Uvarint(12345),
+				Tag{3, Bytes}, Bytes("hoohah"),
+			},
+			Tag{1, EndGroup},
+		}
+	*/
+	var want []byte
+	fmt.Sscanf("0b10b9601a06686f6f6861680c", "%x", &want)
 
-func TestMarshalMessageSetJSON_UnknownType(t *testing.T) {
-	extMap := map[int32]Extension{12345: Extension{}}
-	got, err := MarshalMessageSetJSON(extMap)
-	if err != nil {
-		t.Fatalf("MarshalMessageSetJSON: %v", err)
+	var m MyMessageSet
+	if err := proto.Unmarshal(in, &m); err != nil {
+		t.Fatalf("unexpected Unmarshal error: %v", err)
 	}
-	if want := []byte("{}"); !bytes.Equal(got, want) {
-		t.Errorf("MarshalMessageSetJSON(%v) = %q, want %q", extMap, got, want)
+	got, err := proto.Marshal(&m)
+	if err != nil {
+		t.Fatalf("unexpected Marshal error: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("output mismatch:\ngot  %x\nwant %x", got, want)
 	}
 }

--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -136,7 +136,7 @@ func (u *unmarshalInfo) unmarshal(m pointer, b []byte) error {
 		u.computeUnmarshalInfo()
 	}
 	if u.isMessageSet {
-		return UnmarshalMessageSet(b, m.offset(u.extensions).toExtensions())
+		return unmarshalMessageSet(b, m.offset(u.extensions).toExtensions())
 	}
 	var reqMask uint64 // bitmask of required fields we've seen.
 	var errLater error

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -2247,13 +2247,6 @@ func (*MyMessageSet) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8ca34d01332f1402, []int{17}
 }
 
-func (m *MyMessageSet) MarshalJSON() ([]byte, error) {
-	return proto.MarshalMessageSetJSON(&m.XXX_InternalExtensions)
-}
-func (m *MyMessageSet) UnmarshalJSON(buf []byte) error {
-	return proto.UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)
-}
-
 var extRange_MyMessageSet = []proto.ExtensionRange{
 	{Start: 100, End: 2147483646},
 }

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2370,17 +2370,6 @@ func (g *Generator) generateCommonMethods(mc *msgCtx) {
 
 	// Extension support methods
 	if len(mc.message.ExtensionRange) > 0 {
-		// message_set_wire_format only makes sense when extensions are defined.
-		if opts := mc.message.Options; opts != nil && opts.GetMessageSetWireFormat() {
-			g.P()
-			g.P("func (m *", mc.goName, ") MarshalJSON() ([]byte, error) {")
-			g.P("return ", g.Pkg["proto"], ".MarshalMessageSetJSON(&m.XXX_InternalExtensions)")
-			g.P("}")
-			g.P("func (m *", mc.goName, ") UnmarshalJSON(buf []byte) error {")
-			g.P("return ", g.Pkg["proto"], ".UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)")
-			g.P("}")
-		}
-
 		g.P()
 		g.P("var extRange_", mc.goName, " = []", g.Pkg["proto"], ".ExtensionRange{")
 		for _, r := range mc.message.ExtensionRange {
@@ -2788,10 +2777,8 @@ func (g *Generator) generateExtension(ext *ExtensionDescriptor) {
 	// In addition, the situation for when to apply this special case is implemented
 	// differently in other languages:
 	// https://github.com/google/protobuf/blob/aff10976/src/google/protobuf/text_format.cc#L1560
-	mset := false
 	if extDesc.GetOptions().GetMessageSetWireFormat() && typeName[len(typeName)-1] == "message_set_extension" {
 		typeName = typeName[:len(typeName)-1]
-		mset = true
 	}
 
 	// For text formatting, the package must be exactly what the .proto file declares,
@@ -2813,10 +2800,6 @@ func (g *Generator) generateExtension(ext *ExtensionDescriptor) {
 	g.P()
 
 	g.addInitf("%s.RegisterExtension(%s)", g.Pkg["proto"], ext.DescName())
-	if mset {
-		// Generate a bit more code to register with message_set.go.
-		g.addInitf("%s.RegisterMessageSetType((%s)(nil), %d, %q)", g.Pkg["proto"], fieldType, *field.Number, extName)
-	}
 
 	g.file.addExport(ext, constOrVarSymbol{ccTypeName, "var", ""})
 }

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -84,13 +84,6 @@ func (*OldStyleMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2fbd53bac0b7ca8a, []int{1}
 }
 
-func (m *OldStyleMessage) MarshalJSON() ([]byte, error) {
-	return proto.MarshalMessageSetJSON(&m.XXX_InternalExtensions)
-}
-func (m *OldStyleMessage) UnmarshalJSON(buf []byte) error {
-	return proto.UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)
-}
-
 var extRange_OldStyleMessage = []proto.ExtensionRange{
 	{Start: 100, End: 2147483646},
 }

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -360,7 +360,6 @@ func init() {
 	proto.RegisterExtension(E_Announcement_LoudExt)
 	proto.RegisterType((*Announcement)(nil), "extension_user.Announcement")
 	proto.RegisterExtension(E_OldStyleParcel_MessageSetExtension)
-	proto.RegisterMessageSetType((*OldStyleParcel)(nil), 2001, "extension_user.OldStyleParcel")
 	proto.RegisterType((*OldStyleParcel)(nil), "extension_user.OldStyleParcel")
 	proto.RegisterExtension(E_UserMessage)
 	proto.RegisterExtension(E_ExtraMessage)

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -615,13 +615,6 @@ func (*OldReply) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2c9b60a40d5131b9, []int{5}
 }
 
-func (m *OldReply) MarshalJSON() ([]byte, error) {
-	return proto.MarshalMessageSetJSON(&m.XXX_InternalExtensions)
-}
-func (m *OldReply) UnmarshalJSON(buf []byte) error {
-	return proto.UnmarshalMessageSetJSON(buf, &m.XXX_InternalExtensions)
-}
-
 var extRange_OldReply = []proto.ExtensionRange{
 	{Start: 100, End: 2147483646},
 }


### PR DESCRIPTION
Despite the naming, these are "internal-only" functions that are intended to
only be called from generated code for MessageSets.
Furthermore, MessageSets are themselves a deprecated feature from proto1 days,
such that descriptor.proto even warns against their use since the initial
open-source release of protocol buffers in 2008. Within Google,
there are no direct usages of these functions, and all existing
usages of MessageSets go through the new table-driven implementation.

In addition to deprecating the {Unm,M}arshalMessageSet{JSON} top-level functions,
also modify the generator to stop emitting MarshalJSON and UnmarshalJSON methods
for messages sets. The UnmarshalJSON method is not implemented and the
MarshalJSON method does not seem to be called anywhere in Google (verified by
making the method panic and doing a global test). The jsonpb package continues
to work with MessageSets.

I should note that when the table-driven implementation was open sourced
in late 2017 (see 8cc9e46429bfb16289d40d30b2ee3f4923b47345), it accidentally
removed generation of the Marshal and Unmarshal method. However, no one seemed
to have noticed that those methods were no longer generated.