### PR TITLE
protoc-gen-go: generate XXX_OneofWrappers instead of XXX_OneofFuncs

### DIFF
--- a/conformance/internal/conformance_proto/conformance.pb.go
+++ b/conformance/internal/conformance_proto/conformance.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type WireFormat int32
 
@@ -202,70 +202,12 @@ func (m *ConformanceRequest) GetRequestedOutputFormat() WireFormat {
 	return WireFormat_UNSPECIFIED
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ConformanceRequest) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ConformanceRequest_OneofMarshaler, _ConformanceRequest_OneofUnmarshaler, _ConformanceRequest_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ConformanceRequest) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ConformanceRequest_ProtobufPayload)(nil),
 		(*ConformanceRequest_JsonPayload)(nil),
 	}
-}
-
-func _ConformanceRequest_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ConformanceRequest)
-	// payload
-	switch x := m.Payload.(type) {
-	case *ConformanceRequest_ProtobufPayload:
-		b.EncodeVarint(1<<3 | proto.WireBytes)
-		b.EncodeRawBytes(x.ProtobufPayload)
-	case *ConformanceRequest_JsonPayload:
-		b.EncodeVarint(2<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.JsonPayload)
-	case nil:
-	default:
-		return fmt.Errorf("ConformanceRequest.Payload has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ConformanceRequest_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ConformanceRequest)
-	switch tag {
-	case 1: // payload.protobuf_payload
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Payload = &ConformanceRequest_ProtobufPayload{x}
-		return true, err
-	case 2: // payload.json_payload
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Payload = &ConformanceRequest_JsonPayload{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ConformanceRequest_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ConformanceRequest)
-	// payload
-	switch x := m.Payload.(type) {
-	case *ConformanceRequest_ProtobufPayload:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProtobufPayload)))
-		n += len(x.ProtobufPayload)
-	case *ConformanceRequest_JsonPayload:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.JsonPayload)))
-		n += len(x.JsonPayload)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // Represents a single test case's output.
@@ -397,9 +339,9 @@ func (m *ConformanceResponse) GetSkipped() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ConformanceResponse) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ConformanceResponse_OneofMarshaler, _ConformanceResponse_OneofUnmarshaler, _ConformanceResponse_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*ConformanceResponse) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*ConformanceResponse_ParseError)(nil),
 		(*ConformanceResponse_SerializeError)(nil),
 		(*ConformanceResponse_RuntimeError)(nil),
@@ -407,120 +349,6 @@ func (*ConformanceResponse) XXX_OneofFuncs() (func(msg proto.Message, b *proto.B
 		(*ConformanceResponse_JsonPayload)(nil),
 		(*ConformanceResponse_Skipped)(nil),
 	}
-}
-
-func _ConformanceResponse_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ConformanceResponse)
-	// result
-	switch x := m.Result.(type) {
-	case *ConformanceResponse_ParseError:
-		b.EncodeVarint(1<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.ParseError)
-	case *ConformanceResponse_SerializeError:
-		b.EncodeVarint(6<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.SerializeError)
-	case *ConformanceResponse_RuntimeError:
-		b.EncodeVarint(2<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.RuntimeError)
-	case *ConformanceResponse_ProtobufPayload:
-		b.EncodeVarint(3<<3 | proto.WireBytes)
-		b.EncodeRawBytes(x.ProtobufPayload)
-	case *ConformanceResponse_JsonPayload:
-		b.EncodeVarint(4<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.JsonPayload)
-	case *ConformanceResponse_Skipped:
-		b.EncodeVarint(5<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Skipped)
-	case nil:
-	default:
-		return fmt.Errorf("ConformanceResponse.Result has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _ConformanceResponse_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ConformanceResponse)
-	switch tag {
-	case 1: // result.parse_error
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Result = &ConformanceResponse_ParseError{x}
-		return true, err
-	case 6: // result.serialize_error
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Result = &ConformanceResponse_SerializeError{x}
-		return true, err
-	case 2: // result.runtime_error
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Result = &ConformanceResponse_RuntimeError{x}
-		return true, err
-	case 3: // result.protobuf_payload
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Result = &ConformanceResponse_ProtobufPayload{x}
-		return true, err
-	case 4: // result.json_payload
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Result = &ConformanceResponse_JsonPayload{x}
-		return true, err
-	case 5: // result.skipped
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Result = &ConformanceResponse_Skipped{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _ConformanceResponse_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ConformanceResponse)
-	// result
-	switch x := m.Result.(type) {
-	case *ConformanceResponse_ParseError:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ParseError)))
-		n += len(x.ParseError)
-	case *ConformanceResponse_SerializeError:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.SerializeError)))
-		n += len(x.SerializeError)
-	case *ConformanceResponse_RuntimeError:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.RuntimeError)))
-		n += len(x.RuntimeError)
-	case *ConformanceResponse_ProtobufPayload:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.ProtobufPayload)))
-		n += len(x.ProtobufPayload)
-	case *ConformanceResponse_JsonPayload:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.JsonPayload)))
-		n += len(x.JsonPayload)
-	case *ConformanceResponse_Skipped:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Skipped)))
-		n += len(x.Skipped)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // This proto includes every type of field in both singular and repeated
@@ -1462,103 +1290,14 @@ func (m *TestAllTypes) GetFIELDName12() int32 {
 	return 0
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TestAllTypes) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TestAllTypes_OneofMarshaler, _TestAllTypes_OneofUnmarshaler, _TestAllTypes_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TestAllTypes) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TestAllTypes_OneofUint32)(nil),
 		(*TestAllTypes_OneofNestedMessage)(nil),
 		(*TestAllTypes_OneofString)(nil),
 		(*TestAllTypes_OneofBytes)(nil),
 	}
-}
-
-func _TestAllTypes_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TestAllTypes)
-	// oneof_field
-	switch x := m.OneofField.(type) {
-	case *TestAllTypes_OneofUint32:
-		b.EncodeVarint(111<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.OneofUint32))
-	case *TestAllTypes_OneofNestedMessage:
-		b.EncodeVarint(112<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.OneofNestedMessage); err != nil {
-			return err
-		}
-	case *TestAllTypes_OneofString:
-		b.EncodeVarint(113<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.OneofString)
-	case *TestAllTypes_OneofBytes:
-		b.EncodeVarint(114<<3 | proto.WireBytes)
-		b.EncodeRawBytes(x.OneofBytes)
-	case nil:
-	default:
-		return fmt.Errorf("TestAllTypes.OneofField has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TestAllTypes_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TestAllTypes)
-	switch tag {
-	case 111: // oneof_field.oneof_uint32
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.OneofField = &TestAllTypes_OneofUint32{uint32(x)}
-		return true, err
-	case 112: // oneof_field.oneof_nested_message
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(TestAllTypes_NestedMessage)
-		err := b.DecodeMessage(msg)
-		m.OneofField = &TestAllTypes_OneofNestedMessage{msg}
-		return true, err
-	case 113: // oneof_field.oneof_string
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.OneofField = &TestAllTypes_OneofString{x}
-		return true, err
-	case 114: // oneof_field.oneof_bytes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.OneofField = &TestAllTypes_OneofBytes{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TestAllTypes_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TestAllTypes)
-	// oneof_field
-	switch x := m.OneofField.(type) {
-	case *TestAllTypes_OneofUint32:
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(x.OneofUint32))
-	case *TestAllTypes_OneofNestedMessage:
-		s := proto.Size(x.OneofNestedMessage)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *TestAllTypes_OneofString:
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.OneofString)))
-		n += len(x.OneofString)
-	case *TestAllTypes_OneofBytes:
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.OneofBytes)))
-		n += len(x.OneofBytes)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type TestAllTypes_NestedMessage struct {

--- a/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/more_test_objects.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Numeral int32
 

--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Widget_Color int32
 
@@ -693,118 +693,15 @@ func (m *MsgWithOneof) GetMsgWithRequired() *MsgWithRequired {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*MsgWithOneof) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _MsgWithOneof_OneofMarshaler, _MsgWithOneof_OneofUnmarshaler, _MsgWithOneof_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*MsgWithOneof) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*MsgWithOneof_Title)(nil),
 		(*MsgWithOneof_Salary)(nil),
 		(*MsgWithOneof_Country)(nil),
 		(*MsgWithOneof_HomeAddress)(nil),
 		(*MsgWithOneof_MsgWithRequired)(nil),
 	}
-}
-
-func _MsgWithOneof_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*MsgWithOneof)
-	// union
-	switch x := m.Union.(type) {
-	case *MsgWithOneof_Title:
-		b.EncodeVarint(1<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Title)
-	case *MsgWithOneof_Salary:
-		b.EncodeVarint(2<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.Salary))
-	case *MsgWithOneof_Country:
-		b.EncodeVarint(3<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Country)
-	case *MsgWithOneof_HomeAddress:
-		b.EncodeVarint(4<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.HomeAddress)
-	case *MsgWithOneof_MsgWithRequired:
-		b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.MsgWithRequired); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("MsgWithOneof.Union has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _MsgWithOneof_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*MsgWithOneof)
-	switch tag {
-	case 1: // union.title
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Union = &MsgWithOneof_Title{x}
-		return true, err
-	case 2: // union.salary
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &MsgWithOneof_Salary{int64(x)}
-		return true, err
-	case 3: // union.Country
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Union = &MsgWithOneof_Country{x}
-		return true, err
-	case 4: // union.home_address
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Union = &MsgWithOneof_HomeAddress{x}
-		return true, err
-	case 5: // union.msg_with_required
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(MsgWithRequired)
-		err := b.DecodeMessage(msg)
-		m.Union = &MsgWithOneof_MsgWithRequired{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _MsgWithOneof_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*MsgWithOneof)
-	// union
-	switch x := m.Union.(type) {
-	case *MsgWithOneof_Title:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Title)))
-		n += len(x.Title)
-	case *MsgWithOneof_Salary:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Salary))
-	case *MsgWithOneof_Country:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Country)))
-		n += len(x.Country)
-	case *MsgWithOneof_HomeAddress:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.HomeAddress)))
-		n += len(x.HomeAddress)
-	case *MsgWithOneof_MsgWithRequired:
-		s := proto.Size(x.MsgWithRequired)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type Real struct {

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -940,13 +940,19 @@ func isProto3Zero(v reflect.Value) bool {
 	return false
 }
 
-// ProtoPackageIsVersion2 is referenced from generated protocol buffer files
-// to assert that that code is compatible with this version of the proto package.
-const ProtoPackageIsVersion2 = true
+const (
+	// ProtoPackageIsVersion3 is referenced from generated protocol buffer files
+	// to assert that that code is compatible with this version of the proto package.
+	ProtoPackageIsVersion3 = true
 
-// ProtoPackageIsVersion1 is referenced from generated protocol buffer files
-// to assert that that code is compatible with this version of the proto package.
-const ProtoPackageIsVersion1 = true
+	// ProtoPackageIsVersion2 is referenced from generated protocol buffer files
+	// to assert that that code is compatible with this version of the proto package.
+	ProtoPackageIsVersion2 = true
+
+	// ProtoPackageIsVersion1 is referenced from generated protocol buffer files
+	// to assert that that code is compatible with this version of the proto package.
+	ProtoPackageIsVersion1 = true
+)
 
 // InternalMessageInfo is a type used internally by generated .pb.go files.
 // This type is not intended to be used by non-generated code.

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Message_Humour int32
 
@@ -490,55 +490,11 @@ func (m *TestUTF8) GetMapValue() map[int64]string {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TestUTF8) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TestUTF8_OneofMarshaler, _TestUTF8_OneofUnmarshaler, _TestUTF8_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TestUTF8) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TestUTF8_Field)(nil),
 	}
-}
-
-func _TestUTF8_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TestUTF8)
-	// oneof
-	switch x := m.Oneof.(type) {
-	case *TestUTF8_Field:
-		b.EncodeVarint(3<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Field)
-	case nil:
-	default:
-		return fmt.Errorf("TestUTF8.Oneof has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TestUTF8_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TestUTF8)
-	switch tag {
-	case 3: // oneof.field
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Oneof = &TestUTF8_Field{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TestUTF8_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TestUTF8)
-	// oneof
-	switch x := m.Oneof.(type) {
-	case *TestUTF8_Field:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Field)))
-		n += len(x.Field)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -321,8 +321,11 @@ func (u *marshalInfo) computeMarshalInfo() {
 
 	// get oneof implementers
 	var oneofImplementers []interface{}
-	if m, ok := reflect.Zero(reflect.PtrTo(t)).Interface().(oneofMessage); ok {
+	switch m := reflect.Zero(reflect.PtrTo(t)).Interface().(type) {
+	case oneofFuncsIface:
 		_, _, _, oneofImplementers = m.XXX_OneofFuncs()
+	case oneofWrappersIface:
+		oneofImplementers = m.XXX_OneofWrappers()
 	}
 
 	n := t.NumField()
@@ -484,10 +487,6 @@ func (fi *marshalFieldInfo) computeOneofFieldInfo(f *reflect.StructField, oneofI
 			marshaler: marshaler,
 		}
 	}
-}
-
-type oneofMessage interface {
-	XXX_OneofFuncs() (func(Message, *Buffer) error, func(Message, int, int, *Buffer) (bool, error), func(Message) int, []interface{})
 }
 
 // wiretype returns the wire encoding of the type.

--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -362,46 +362,48 @@ func (u *unmarshalInfo) computeUnmarshalInfo() {
 	}
 
 	// Find any types associated with oneof fields.
-	// TODO: XXX_OneofFuncs returns more info than we need.  Get rid of some of it?
-	fn := reflect.Zero(reflect.PtrTo(t)).MethodByName("XXX_OneofFuncs")
-	if fn.IsValid() {
-		res := fn.Call(nil)[3] // last return value from XXX_OneofFuncs: []interface{}
-		for i := res.Len() - 1; i >= 0; i-- {
-			v := res.Index(i)                             // interface{}
-			tptr := reflect.ValueOf(v.Interface()).Type() // *Msg_X
-			typ := tptr.Elem()                            // Msg_X
+	var oneofImplementers []interface{}
+	switch m := reflect.Zero(reflect.PtrTo(t)).Interface().(type) {
+	case oneofFuncsIface:
+		_, _, _, oneofImplementers = m.XXX_OneofFuncs()
+	case oneofWrappersIface:
+		oneofImplementers = m.XXX_OneofWrappers()
+	}
+	for _, v := range oneofImplementers {
+		tptr := reflect.TypeOf(v) // *Msg_X
+		typ := tptr.Elem()        // Msg_X
 
-			f := typ.Field(0) // oneof implementers have one field
-			baseUnmarshal := fieldUnmarshaler(&f)
-			tags := strings.Split(f.Tag.Get("protobuf"), ",")
-			fieldNum, err := strconv.Atoi(tags[1])
-			if err != nil {
-				panic("protobuf tag field not an integer: " + tags[1])
-			}
-			var name string
-			for _, tag := range tags {
-				if strings.HasPrefix(tag, "name=") {
-					name = strings.TrimPrefix(tag, "name=")
-					break
-				}
-			}
-
-			// Find the oneof field that this struct implements.
-			// Might take O(n^2) to process all of the oneofs, but who cares.
-			for _, of := range oneofFields {
-				if tptr.Implements(of.ityp) {
-					// We have found the corresponding interface for this struct.
-					// That lets us know where this struct should be stored
-					// when we encounter it during unmarshaling.
-					unmarshal := makeUnmarshalOneof(typ, of.ityp, baseUnmarshal)
-					u.setTag(fieldNum, of.field, unmarshal, 0, name)
-				}
+		f := typ.Field(0) // oneof implementers have one field
+		baseUnmarshal := fieldUnmarshaler(&f)
+		tags := strings.Split(f.Tag.Get("protobuf"), ",")
+		fieldNum, err := strconv.Atoi(tags[1])
+		if err != nil {
+			panic("protobuf tag field not an integer: " + tags[1])
+		}
+		var name string
+		for _, tag := range tags {
+			if strings.HasPrefix(tag, "name=") {
+				name = strings.TrimPrefix(tag, "name=")
+				break
 			}
 		}
+
+		// Find the oneof field that this struct implements.
+		// Might take O(n^2) to process all of the oneofs, but who cares.
+		for _, of := range oneofFields {
+			if tptr.Implements(of.ityp) {
+				// We have found the corresponding interface for this struct.
+				// That lets us know where this struct should be stored
+				// when we encounter it during unmarshaling.
+				unmarshal := makeUnmarshalOneof(typ, of.ityp, baseUnmarshal)
+				u.setTag(fieldNum, of.field, unmarshal, 0, name)
+			}
+		}
+
 	}
 
 	// Get extension ranges, if any.
-	fn = reflect.Zero(reflect.PtrTo(t)).MethodByName("ExtensionRangeArray")
+	fn := reflect.Zero(reflect.PtrTo(t)).MethodByName("ExtensionRangeArray")
 	if fn.IsValid() {
 		if !u.extensions.IsValid() && !u.oldExtensions.IsValid() {
 			panic("a message with extensions, but no extensions field in " + t.Name())

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type FOO int32
 
@@ -3396,9 +3396,9 @@ func (m *Oneof) GetValue() int32 {
 	return 0
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Oneof) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Oneof_OneofMarshaler, _Oneof_OneofUnmarshaler, _Oneof_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Oneof) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Oneof_F_Bool)(nil),
 		(*Oneof_F_Int32)(nil),
 		(*Oneof_F_Int64)(nil),
@@ -3418,298 +3418,6 @@ func (*Oneof) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, 
 		(*Oneof_F_Largest_Tag)(nil),
 		(*Oneof_Value)(nil),
 	}
-}
-
-func _Oneof_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Oneof)
-	// union
-	switch x := m.Union.(type) {
-	case *Oneof_F_Bool:
-		t := uint64(0)
-		if x.F_Bool {
-			t = 1
-		}
-		b.EncodeVarint(1<<3 | proto.WireVarint)
-		b.EncodeVarint(t)
-	case *Oneof_F_Int32:
-		b.EncodeVarint(2<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.F_Int32))
-	case *Oneof_F_Int64:
-		b.EncodeVarint(3<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.F_Int64))
-	case *Oneof_F_Fixed32:
-		b.EncodeVarint(4<<3 | proto.WireFixed32)
-		b.EncodeFixed32(uint64(x.F_Fixed32))
-	case *Oneof_F_Fixed64:
-		b.EncodeVarint(5<<3 | proto.WireFixed64)
-		b.EncodeFixed64(uint64(x.F_Fixed64))
-	case *Oneof_F_Uint32:
-		b.EncodeVarint(6<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.F_Uint32))
-	case *Oneof_F_Uint64:
-		b.EncodeVarint(7<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.F_Uint64))
-	case *Oneof_F_Float:
-		b.EncodeVarint(8<<3 | proto.WireFixed32)
-		b.EncodeFixed32(uint64(math.Float32bits(x.F_Float)))
-	case *Oneof_F_Double:
-		b.EncodeVarint(9<<3 | proto.WireFixed64)
-		b.EncodeFixed64(math.Float64bits(x.F_Double))
-	case *Oneof_F_String:
-		b.EncodeVarint(10<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.F_String)
-	case *Oneof_F_Bytes:
-		b.EncodeVarint(11<<3 | proto.WireBytes)
-		b.EncodeRawBytes(x.F_Bytes)
-	case *Oneof_F_Sint32:
-		b.EncodeVarint(12<<3 | proto.WireVarint)
-		b.EncodeZigzag32(uint64(x.F_Sint32))
-	case *Oneof_F_Sint64:
-		b.EncodeVarint(13<<3 | proto.WireVarint)
-		b.EncodeZigzag64(uint64(x.F_Sint64))
-	case *Oneof_F_Enum:
-		b.EncodeVarint(14<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.F_Enum))
-	case *Oneof_F_Message:
-		b.EncodeVarint(15<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.F_Message); err != nil {
-			return err
-		}
-	case *Oneof_FGroup:
-		b.EncodeVarint(16<<3 | proto.WireStartGroup)
-		if err := b.Marshal(x.FGroup); err != nil {
-			return err
-		}
-		b.EncodeVarint(16<<3 | proto.WireEndGroup)
-	case *Oneof_F_Largest_Tag:
-		b.EncodeVarint(536870911<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.F_Largest_Tag))
-	case nil:
-	default:
-		return fmt.Errorf("Oneof.Union has unexpected type %T", x)
-	}
-	// tormato
-	switch x := m.Tormato.(type) {
-	case *Oneof_Value:
-		b.EncodeVarint(100<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.Value))
-	case nil:
-	default:
-		return fmt.Errorf("Oneof.Tormato has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Oneof_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Oneof)
-	switch tag {
-	case 1: // union.F_Bool
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Oneof_F_Bool{x != 0}
-		return true, err
-	case 2: // union.F_Int32
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Oneof_F_Int32{int32(x)}
-		return true, err
-	case 3: // union.F_Int64
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Oneof_F_Int64{int64(x)}
-		return true, err
-	case 4: // union.F_Fixed32
-		if wire != proto.WireFixed32 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed32()
-		m.Union = &Oneof_F_Fixed32{uint32(x)}
-		return true, err
-	case 5: // union.F_Fixed64
-		if wire != proto.WireFixed64 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed64()
-		m.Union = &Oneof_F_Fixed64{x}
-		return true, err
-	case 6: // union.F_Uint32
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Oneof_F_Uint32{uint32(x)}
-		return true, err
-	case 7: // union.F_Uint64
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Oneof_F_Uint64{x}
-		return true, err
-	case 8: // union.F_Float
-		if wire != proto.WireFixed32 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed32()
-		m.Union = &Oneof_F_Float{math.Float32frombits(uint32(x))}
-		return true, err
-	case 9: // union.F_Double
-		if wire != proto.WireFixed64 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed64()
-		m.Union = &Oneof_F_Double{math.Float64frombits(x)}
-		return true, err
-	case 10: // union.F_String
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Union = &Oneof_F_String{x}
-		return true, err
-	case 11: // union.F_Bytes
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Union = &Oneof_F_Bytes{x}
-		return true, err
-	case 12: // union.F_Sint32
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeZigzag32()
-		m.Union = &Oneof_F_Sint32{int32(x)}
-		return true, err
-	case 13: // union.F_Sint64
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeZigzag64()
-		m.Union = &Oneof_F_Sint64{int64(x)}
-		return true, err
-	case 14: // union.F_Enum
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Oneof_F_Enum{MyMessage_Color(x)}
-		return true, err
-	case 15: // union.F_Message
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(GoTestField)
-		err := b.DecodeMessage(msg)
-		m.Union = &Oneof_F_Message{msg}
-		return true, err
-	case 16: // union.f_group
-		if wire != proto.WireStartGroup {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Oneof_F_Group)
-		err := b.DecodeGroup(msg)
-		m.Union = &Oneof_FGroup{msg}
-		return true, err
-	case 536870911: // union.F_Largest_Tag
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Oneof_F_Largest_Tag{int32(x)}
-		return true, err
-	case 100: // tormato.value
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Tormato = &Oneof_Value{int32(x)}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Oneof_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Oneof)
-	// union
-	switch x := m.Union.(type) {
-	case *Oneof_F_Bool:
-		n += 1 // tag and wire
-		n += 1
-	case *Oneof_F_Int32:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.F_Int32))
-	case *Oneof_F_Int64:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.F_Int64))
-	case *Oneof_F_Fixed32:
-		n += 1 // tag and wire
-		n += 4
-	case *Oneof_F_Fixed64:
-		n += 1 // tag and wire
-		n += 8
-	case *Oneof_F_Uint32:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.F_Uint32))
-	case *Oneof_F_Uint64:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.F_Uint64))
-	case *Oneof_F_Float:
-		n += 1 // tag and wire
-		n += 4
-	case *Oneof_F_Double:
-		n += 1 // tag and wire
-		n += 8
-	case *Oneof_F_String:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.F_String)))
-		n += len(x.F_String)
-	case *Oneof_F_Bytes:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.F_Bytes)))
-		n += len(x.F_Bytes)
-	case *Oneof_F_Sint32:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64((uint32(x.F_Sint32) << 1) ^ uint32((int32(x.F_Sint32) >> 31))))
-	case *Oneof_F_Sint64:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(uint64(x.F_Sint64<<1) ^ uint64((int64(x.F_Sint64) >> 63))))
-	case *Oneof_F_Enum:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.F_Enum))
-	case *Oneof_F_Message:
-		s := proto.Size(x.F_Message)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Oneof_FGroup:
-		n += 2 // tag and wire
-		n += proto.Size(x.FGroup)
-		n += 2 // tag and wire
-	case *Oneof_F_Largest_Tag:
-		n += 5 // tag and wire
-		n += proto.SizeVarint(uint64(x.F_Largest_Tag))
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	// tormato
-	switch x := m.Tormato.(type) {
-	case *Oneof_Value:
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(x.Value))
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type Oneof_F_Group struct {
@@ -3889,9 +3597,9 @@ func (m *Communique) GetMsg() *Strings {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Communique) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Communique_OneofMarshaler, _Communique_OneofUnmarshaler, _Communique_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Communique) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Communique_Number)(nil),
 		(*Communique_Name)(nil),
 		(*Communique_Data)(nil),
@@ -3899,121 +3607,6 @@ func (*Communique) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) er
 		(*Communique_Col)(nil),
 		(*Communique_Msg)(nil),
 	}
-}
-
-func _Communique_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Communique)
-	// union
-	switch x := m.Union.(type) {
-	case *Communique_Number:
-		b.EncodeVarint(5<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.Number))
-	case *Communique_Name:
-		b.EncodeVarint(6<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Name)
-	case *Communique_Data:
-		b.EncodeVarint(7<<3 | proto.WireBytes)
-		b.EncodeRawBytes(x.Data)
-	case *Communique_TempC:
-		b.EncodeVarint(8<<3 | proto.WireFixed64)
-		b.EncodeFixed64(math.Float64bits(x.TempC))
-	case *Communique_Col:
-		b.EncodeVarint(9<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.Col))
-	case *Communique_Msg:
-		b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Msg); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Communique.Union has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Communique_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Communique)
-	switch tag {
-	case 5: // union.number
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Communique_Number{int32(x)}
-		return true, err
-	case 6: // union.name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Union = &Communique_Name{x}
-		return true, err
-	case 7: // union.data
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Union = &Communique_Data{x}
-		return true, err
-	case 8: // union.temp_c
-		if wire != proto.WireFixed64 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed64()
-		m.Union = &Communique_TempC{math.Float64frombits(x)}
-		return true, err
-	case 9: // union.col
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Communique_Col{MyMessage_Color(x)}
-		return true, err
-	case 10: // union.msg
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Strings)
-		err := b.DecodeMessage(msg)
-		m.Union = &Communique_Msg{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Communique_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Communique)
-	// union
-	switch x := m.Union.(type) {
-	case *Communique_Number:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Number))
-	case *Communique_Name:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Name)))
-		n += len(x.Name)
-	case *Communique_Data:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Data)))
-		n += len(x.Data)
-	case *Communique_TempC:
-		n += 1 // tag and wire
-		n += 8
-	case *Communique_Col:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Col))
-	case *Communique_Msg:
-		s := proto.Size(x.Msg)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type TestUTF8 struct {
@@ -4106,55 +3699,11 @@ func (m *TestUTF8) GetMapValue() map[int64]string {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*TestUTF8) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _TestUTF8_OneofMarshaler, _TestUTF8_OneofUnmarshaler, _TestUTF8_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*TestUTF8) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*TestUTF8_Field)(nil),
 	}
-}
-
-func _TestUTF8_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*TestUTF8)
-	// oneof
-	switch x := m.Oneof.(type) {
-	case *TestUTF8_Field:
-		b.EncodeVarint(3<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Field)
-	case nil:
-	default:
-		return fmt.Errorf("TestUTF8.Oneof has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _TestUTF8_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*TestUTF8)
-	switch tag {
-	case 3: // oneof.field
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Oneof = &TestUTF8_Field{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _TestUTF8_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*TestUTF8)
-	// oneof
-	switch x := m.Oneof.(type) {
-	case *TestUTF8_Field:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Field)))
-		n += len(x.Field)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 var E_Greeting = &proto.ExtensionDesc{

--- a/protoc-gen-go/descriptor/descriptor.pb.go
+++ b/protoc-gen-go/descriptor/descriptor.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type FieldDescriptorProto_Type int32
 

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -68,7 +68,7 @@ import (
 // It is incremented whenever an incompatibility between the generated code and
 // proto package is introduced; the generated code references
 // a constant, proto.ProtoPackageIsVersionN (where N is generatedCodeVersion).
-const generatedCodeVersion = 2
+const generatedCodeVersion = 3
 
 // A Plugin provides functionality to add to the output during Go code generation,
 // such as to produce RPC stubs.
@@ -1872,212 +1872,10 @@ type oneofSubField struct {
 	deprecated    string                               // Deprecation comment, if any.
 }
 
-// wireTypeName returns a textual wire type, needed for oneof sub fields in generated code.
-func (f *oneofSubField) wireTypeName() string {
-	switch f.protoType {
-	case descriptor.FieldDescriptorProto_TYPE_FIXED64,
-		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
-		descriptor.FieldDescriptorProto_TYPE_DOUBLE:
-		return "WireFixed64"
-	case descriptor.FieldDescriptorProto_TYPE_FIXED32,
-		descriptor.FieldDescriptorProto_TYPE_SFIXED32,
-		descriptor.FieldDescriptorProto_TYPE_FLOAT:
-		return "WireFixed32"
-	case descriptor.FieldDescriptorProto_TYPE_GROUP:
-		return "WireStartGroup"
-	case descriptor.FieldDescriptorProto_TYPE_MESSAGE,
-		descriptor.FieldDescriptorProto_TYPE_STRING,
-		descriptor.FieldDescriptorProto_TYPE_BYTES:
-		return "WireBytes"
-	default: // All others are Varints
-		return "WireVarint"
-	}
-}
-
 // typedNil prints a nil casted to the pointer to this field.
-// - for XXX_OneofFuncs
+// - for XXX_OneofWrappers
 func (f *oneofSubField) typedNil(g *Generator) {
 	g.P("(*", f.oneofTypeName, ")(nil),")
-}
-
-// marshalCase prints the case matching this oneof subfield in the marshalling code.
-func (f *oneofSubField) marshalCase(g *Generator) {
-	g.P("case *", f.oneofTypeName, ":")
-	wire := f.wireTypeName()
-	var pre, post string
-	val := "x." + f.goName // overridden for TYPE_BOOL
-	switch f.protoType {
-	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
-		pre = "b.EncodeFixed64(" + g.Pkg["math"] + ".Float64bits("
-		post = "))"
-	case descriptor.FieldDescriptorProto_TYPE_FLOAT:
-		pre = "b.EncodeFixed32(uint64(" + g.Pkg["math"] + ".Float32bits("
-		post = ")))"
-	case descriptor.FieldDescriptorProto_TYPE_INT64, descriptor.FieldDescriptorProto_TYPE_UINT64:
-		pre, post = "b.EncodeVarint(uint64(", "))"
-	case descriptor.FieldDescriptorProto_TYPE_INT32, descriptor.FieldDescriptorProto_TYPE_UINT32, descriptor.FieldDescriptorProto_TYPE_ENUM:
-		pre, post = "b.EncodeVarint(uint64(", "))"
-	case descriptor.FieldDescriptorProto_TYPE_FIXED64, descriptor.FieldDescriptorProto_TYPE_SFIXED64:
-		pre, post = "b.EncodeFixed64(uint64(", "))"
-	case descriptor.FieldDescriptorProto_TYPE_FIXED32, descriptor.FieldDescriptorProto_TYPE_SFIXED32:
-		pre, post = "b.EncodeFixed32(uint64(", "))"
-	case descriptor.FieldDescriptorProto_TYPE_BOOL:
-		g.P("t := uint64(0)")
-		g.P("if ", val, " { t = 1 }")
-		val = "t"
-		pre, post = "b.EncodeVarint(", ")"
-	case descriptor.FieldDescriptorProto_TYPE_STRING:
-		pre, post = "b.EncodeStringBytes(", ")"
-	case descriptor.FieldDescriptorProto_TYPE_GROUP:
-		pre, post = "b.Marshal(", ")"
-	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-		pre, post = "b.EncodeMessage(", ")"
-	case descriptor.FieldDescriptorProto_TYPE_BYTES:
-		pre, post = "b.EncodeRawBytes(", ")"
-	case descriptor.FieldDescriptorProto_TYPE_SINT32:
-		pre, post = "b.EncodeZigzag32(uint64(", "))"
-	case descriptor.FieldDescriptorProto_TYPE_SINT64:
-		pre, post = "b.EncodeZigzag64(uint64(", "))"
-	default:
-		g.Fail("unhandled oneof field type ", f.protoType.String())
-	}
-	g.P("b.EncodeVarint(", f.fieldNumber, "<<3|", g.Pkg["proto"], ".", wire, ")")
-	if t := f.protoType; t != descriptor.FieldDescriptorProto_TYPE_GROUP && t != descriptor.FieldDescriptorProto_TYPE_MESSAGE {
-		g.P(pre, val, post)
-	} else {
-		g.P("if err := ", pre, val, post, "; err != nil {")
-		g.P("return err")
-		g.P("}")
-	}
-	if f.protoType == descriptor.FieldDescriptorProto_TYPE_GROUP {
-		g.P("b.EncodeVarint(", f.fieldNumber, "<<3|", g.Pkg["proto"], ".WireEndGroup)")
-	}
-}
-
-// unmarshalCase prints the case matching this oneof subfield in the unmarshalling code.
-func (f *oneofSubField) unmarshalCase(g *Generator, origOneofName string, oneofName string) {
-	g.P("case ", f.fieldNumber, ": // ", origOneofName, ".", f.getProtoName())
-	g.P("if wire != ", g.Pkg["proto"], ".", f.wireTypeName(), " {")
-	g.P("return true, ", g.Pkg["proto"], ".ErrInternalBadWireType")
-	g.P("}")
-	lhs := "x, err" // overridden for TYPE_MESSAGE and TYPE_GROUP
-	var dec, cast, cast2 string
-	switch f.protoType {
-	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
-		dec, cast = "b.DecodeFixed64()", g.Pkg["math"]+".Float64frombits"
-	case descriptor.FieldDescriptorProto_TYPE_FLOAT:
-		dec, cast, cast2 = "b.DecodeFixed32()", "uint32", g.Pkg["math"]+".Float32frombits"
-	case descriptor.FieldDescriptorProto_TYPE_INT64:
-		dec, cast = "b.DecodeVarint()", "int64"
-	case descriptor.FieldDescriptorProto_TYPE_UINT64:
-		dec = "b.DecodeVarint()"
-	case descriptor.FieldDescriptorProto_TYPE_INT32:
-		dec, cast = "b.DecodeVarint()", "int32"
-	case descriptor.FieldDescriptorProto_TYPE_FIXED64:
-		dec = "b.DecodeFixed64()"
-	case descriptor.FieldDescriptorProto_TYPE_FIXED32:
-		dec, cast = "b.DecodeFixed32()", "uint32"
-	case descriptor.FieldDescriptorProto_TYPE_BOOL:
-		dec = "b.DecodeVarint()"
-		// handled specially below
-	case descriptor.FieldDescriptorProto_TYPE_STRING:
-		dec = "b.DecodeStringBytes()"
-	case descriptor.FieldDescriptorProto_TYPE_GROUP:
-		g.P("msg := new(", f.goType[1:], ")") // drop star
-		lhs = "err"
-		dec = "b.DecodeGroup(msg)"
-		// handled specially below
-	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-		g.P("msg := new(", f.goType[1:], ")") // drop star
-		lhs = "err"
-		dec = "b.DecodeMessage(msg)"
-		// handled specially below
-	case descriptor.FieldDescriptorProto_TYPE_BYTES:
-		dec = "b.DecodeRawBytes(true)"
-	case descriptor.FieldDescriptorProto_TYPE_UINT32:
-		dec, cast = "b.DecodeVarint()", "uint32"
-	case descriptor.FieldDescriptorProto_TYPE_ENUM:
-		dec, cast = "b.DecodeVarint()", f.goType
-	case descriptor.FieldDescriptorProto_TYPE_SFIXED32:
-		dec, cast = "b.DecodeFixed32()", "int32"
-	case descriptor.FieldDescriptorProto_TYPE_SFIXED64:
-		dec, cast = "b.DecodeFixed64()", "int64"
-	case descriptor.FieldDescriptorProto_TYPE_SINT32:
-		dec, cast = "b.DecodeZigzag32()", "int32"
-	case descriptor.FieldDescriptorProto_TYPE_SINT64:
-		dec, cast = "b.DecodeZigzag64()", "int64"
-	default:
-		g.Fail("unhandled oneof field type ", f.protoType.String())
-	}
-	g.P(lhs, " := ", dec)
-	val := "x"
-	if cast != "" {
-		val = cast + "(" + val + ")"
-	}
-	if cast2 != "" {
-		val = cast2 + "(" + val + ")"
-	}
-	switch f.protoType {
-	case descriptor.FieldDescriptorProto_TYPE_BOOL:
-		val += " != 0"
-	case descriptor.FieldDescriptorProto_TYPE_GROUP,
-		descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-		val = "msg"
-	}
-	g.P("m.", oneofName, " = &", f.oneofTypeName, "{", val, "}")
-	g.P("return true, err")
-}
-
-// sizerCase prints the case matching this oneof subfield in the sizer code.
-func (f *oneofSubField) sizerCase(g *Generator) {
-	g.P("case *", f.oneofTypeName, ":")
-	val := "x." + f.goName
-	var varint, fixed string
-	switch f.protoType {
-	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
-		fixed = "8"
-	case descriptor.FieldDescriptorProto_TYPE_FLOAT:
-		fixed = "4"
-	case descriptor.FieldDescriptorProto_TYPE_INT64, descriptor.FieldDescriptorProto_TYPE_UINT64, descriptor.FieldDescriptorProto_TYPE_INT32, descriptor.FieldDescriptorProto_TYPE_UINT32, descriptor.FieldDescriptorProto_TYPE_ENUM:
-		varint = val
-	case descriptor.FieldDescriptorProto_TYPE_FIXED64, descriptor.FieldDescriptorProto_TYPE_SFIXED64:
-		fixed = "8"
-	case descriptor.FieldDescriptorProto_TYPE_FIXED32, descriptor.FieldDescriptorProto_TYPE_SFIXED32:
-		fixed = "4"
-	case descriptor.FieldDescriptorProto_TYPE_BOOL:
-		fixed = "1"
-	case descriptor.FieldDescriptorProto_TYPE_STRING:
-		fixed = "len(" + val + ")"
-		varint = fixed
-	case descriptor.FieldDescriptorProto_TYPE_GROUP:
-		fixed = g.Pkg["proto"] + ".Size(" + val + ")"
-	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-		g.P("s := ", g.Pkg["proto"], ".Size(", val, ")")
-		fixed = "s"
-		varint = fixed
-	case descriptor.FieldDescriptorProto_TYPE_BYTES:
-		fixed = "len(" + val + ")"
-		varint = fixed
-	case descriptor.FieldDescriptorProto_TYPE_SINT32:
-		varint = "(uint32(" + val + ") << 1) ^ uint32((int32(" + val + ") >> 31))"
-	case descriptor.FieldDescriptorProto_TYPE_SINT64:
-		varint = "uint64(" + val + " << 1) ^ uint64((int64(" + val + ") >> 63))"
-	default:
-		g.Fail("unhandled oneof field type ", f.protoType.String())
-	}
-	// Tag and wire varint is known statically,
-	// so don't generate code for that part of the size computation.
-	tagAndWireSize := proto.SizeVarint(uint64(f.fieldNumber << 3)) // wire doesn't affect varint size
-	g.P("n += ", tagAndWireSize, " // tag and wire")
-	if varint != "" {
-		g.P("n += ", g.Pkg["proto"], ".SizeVarint(uint64(", varint, "))")
-	}
-	if fixed != "" {
-		g.P("n += ", fixed)
-	}
-	if f.protoType == descriptor.FieldDescriptorProto_TYPE_GROUP {
-		g.P("n += ", tagAndWireSize, " // tag and wire")
-	}
 }
 
 // getProtoDef returns the default value explicitly stated in the proto file, e.g "yoshi" or "5".
@@ -2275,76 +2073,17 @@ func (g *Generator) generateOneofFuncs(mc *msgCtx, topLevelFields []topLevelFiel
 	if len(ofields) == 0 {
 		return
 	}
-	enc := "_" + mc.goName + "_OneofMarshaler"
-	dec := "_" + mc.goName + "_OneofUnmarshaler"
-	size := "_" + mc.goName + "_OneofSizer"
-	encSig := "(msg " + g.Pkg["proto"] + ".Message, b *" + g.Pkg["proto"] + ".Buffer) error"
-	decSig := "(msg " + g.Pkg["proto"] + ".Message, tag, wire int, b *" + g.Pkg["proto"] + ".Buffer) (bool, error)"
-	sizeSig := "(msg " + g.Pkg["proto"] + ".Message) (n int)"
 
 	// OneofFuncs
-	g.P("// XXX_OneofFuncs is for the internal use of the proto package.")
-	g.P("func (*", mc.goName, ") XXX_OneofFuncs() (func", encSig, ", func", decSig, ", func", sizeSig, ", []interface{}) {")
-	g.P("return ", enc, ", ", dec, ", ", size, ", []interface{}{")
+	g.P("// XXX_OneofWrappers is for the internal use of the proto package.")
+	g.P("func (*", mc.goName, ") XXX_OneofWrappers() []interface{} {")
+	g.P("return []interface{}{")
 	for _, of := range ofields {
 		for _, sf := range of.subFields {
 			sf.typedNil(g)
 		}
 	}
 	g.P("}")
-	g.P("}")
-	g.P()
-
-	// marshaler
-	g.P("func ", enc, encSig, " {")
-	g.P("m := msg.(*", mc.goName, ")")
-	for _, of := range ofields {
-		g.P("// ", of.getProtoName())
-		g.P("switch x := m.", of.goName, ".(type) {")
-		for _, sf := range of.subFields {
-			// also fills in field.wire
-			sf.marshalCase(g)
-		}
-		g.P("case nil:")
-		g.P("default:")
-		g.P(" return ", g.Pkg["fmt"], `.Errorf("`, mc.goName, ".", of.goName, ` has unexpected type %T", x)`)
-		g.P("}")
-	}
-	g.P("return nil")
-	g.P("}")
-	g.P()
-
-	// unmarshaler
-	g.P("func ", dec, decSig, " {")
-	g.P("m := msg.(*", mc.goName, ")")
-	g.P("switch tag {")
-	for _, of := range ofields {
-		for _, sf := range of.subFields {
-			sf.unmarshalCase(g, of.getProtoName(), of.goName)
-		}
-	}
-	g.P("default:")
-	g.P("return false, nil")
-	g.P("}")
-	g.P("}")
-	g.P()
-
-	// sizer
-	g.P("func ", size, sizeSig, " {")
-	g.P("m := msg.(*", mc.goName, ")")
-	for _, of := range ofields {
-		g.P("// ", of.getProtoName())
-		g.P("switch x := m.", of.goName, ".(type) {")
-		for _, sf := range of.subFields {
-			// also fills in field.wire
-			sf.sizerCase(g)
-		}
-		g.P("case nil:")
-		g.P("default:")
-		g.P("panic(", g.Pkg["fmt"], ".Sprintf(\"proto: unexpected type %T in oneof\", x))")
-		g.P("}")
-	}
-	g.P("return n")
 	g.P("}")
 	g.P()
 }

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // DeprecatedEnum contains deprecated values.
 type DeprecatedEnum int32 // Deprecated: Do not use.
@@ -153,55 +153,11 @@ func (m *DeprecatedResponse) GetDeprecatedOneofField() string {
 	return ""
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*DeprecatedResponse) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _DeprecatedResponse_OneofMarshaler, _DeprecatedResponse_OneofUnmarshaler, _DeprecatedResponse_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*DeprecatedResponse) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*DeprecatedResponse_DeprecatedOneofField)(nil),
 	}
-}
-
-func _DeprecatedResponse_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*DeprecatedResponse)
-	// deprecated_oneof
-	switch x := m.DeprecatedOneof.(type) {
-	case *DeprecatedResponse_DeprecatedOneofField:
-		b.EncodeVarint(2<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.DeprecatedOneofField)
-	case nil:
-	default:
-		return fmt.Errorf("DeprecatedResponse.DeprecatedOneof has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _DeprecatedResponse_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*DeprecatedResponse)
-	switch tag {
-	case 2: // deprecated_oneof.deprecated_oneof_field
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.DeprecatedOneof = &DeprecatedResponse_DeprecatedOneofField{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _DeprecatedResponse_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*DeprecatedResponse)
-	// deprecated_oneof
-	switch x := m.DeprecatedOneof.(type) {
-	case *DeprecatedResponse_DeprecatedOneofField:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.DeprecatedOneofField)))
-		n += len(x.DeprecatedOneofField)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 func init() {

--- a/protoc-gen-go/testdata/extension_base/extension_base.pb.go
+++ b/protoc-gen-go/testdata/extension_base/extension_base.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type BaseMessage struct {
 	Height                       *int32   `protobuf:"varint,1,opt,name=height" json:"height,omitempty"`

--- a/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
+++ b/protoc-gen-go/testdata/extension_extra/extension_extra.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type ExtraMessage struct {
 	Width                *int32   `protobuf:"varint,1,opt,name=width" json:"width,omitempty"`

--- a/protoc-gen-go/testdata/extension_user/extension_user.pb.go
+++ b/protoc-gen-go/testdata/extension_user/extension_user.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type UserMessage struct {
 	Name                 *string  `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type SimpleRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/protoc-gen-go/testdata/import_public/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/a.pb.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 const Default_M_DefaultField = sub.Default_M_DefaultField
 

--- a/protoc-gen-go/testdata/import_public/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/b.pb.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Local struct {
 	M                    *sub.M   `protobuf:"bytes,1,opt,name=m" json:"m,omitempty"`

--- a/protoc-gen-go/testdata/import_public/importing/importing.pb.go
+++ b/protoc-gen-go/testdata/import_public/importing/importing.pb.go
@@ -20,7 +20,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M struct {
 	// Message type defined in a file publicly imported by a file we import.

--- a/protoc-gen-go/testdata/import_public/sub/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/a.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type E int32
 
@@ -230,68 +230,12 @@ func (m *M) GetDefaultField() string {
 	return Default_M_DefaultField
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*M) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _M_OneofMarshaler, _M_OneofUnmarshaler, _M_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*M) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*M_OneofInt32)(nil),
 		(*M_OneofInt64)(nil),
 	}
-}
-
-func _M_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*M)
-	// oneof_field
-	switch x := m.OneofField.(type) {
-	case *M_OneofInt32:
-		b.EncodeVarint(2<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.OneofInt32))
-	case *M_OneofInt64:
-		b.EncodeVarint(3<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.OneofInt64))
-	case nil:
-	default:
-		return fmt.Errorf("M.OneofField has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _M_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*M)
-	switch tag {
-	case 2: // oneof_field.oneof_int32
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.OneofField = &M_OneofInt32{int32(x)}
-		return true, err
-	case 3: // oneof_field.oneof_int64
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.OneofField = &M_OneofInt64{int64(x)}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _M_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*M)
-	// oneof_field
-	switch x := m.OneofField.(type) {
-	case *M_OneofInt32:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.OneofInt32))
-	case *M_OneofInt64:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.OneofInt64))
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type M_Grouping struct {
@@ -405,68 +349,12 @@ func (m *M_Submessage) GetSubmessageOneofInt64() int64 {
 	return 0
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*M_Submessage) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _M_Submessage_OneofMarshaler, _M_Submessage_OneofUnmarshaler, _M_Submessage_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*M_Submessage) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*M_Submessage_SubmessageOneofInt32)(nil),
 		(*M_Submessage_SubmessageOneofInt64)(nil),
 	}
-}
-
-func _M_Submessage_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*M_Submessage)
-	// submessage_oneof_field
-	switch x := m.SubmessageOneofField.(type) {
-	case *M_Submessage_SubmessageOneofInt32:
-		b.EncodeVarint(1<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.SubmessageOneofInt32))
-	case *M_Submessage_SubmessageOneofInt64:
-		b.EncodeVarint(2<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.SubmessageOneofInt64))
-	case nil:
-	default:
-		return fmt.Errorf("M_Submessage.SubmessageOneofField has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _M_Submessage_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*M_Submessage)
-	switch tag {
-	case 1: // submessage_oneof_field.submessage_oneof_int32
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.SubmessageOneofField = &M_Submessage_SubmessageOneofInt32{int32(x)}
-		return true, err
-	case 2: // submessage_oneof_field.submessage_oneof_int64
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.SubmessageOneofField = &M_Submessage_SubmessageOneofInt64{int64(x)}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _M_Submessage_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*M_Submessage)
-	// submessage_oneof_field
-	switch x := m.SubmessageOneofField.(type) {
-	case *M_Submessage_SubmessageOneofInt32:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.SubmessageOneofInt32))
-	case *M_Submessage_SubmessageOneofInt64:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.SubmessageOneofInt64))
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 var E_ExtensionField = &proto.ExtensionDesc{

--- a/protoc-gen-go/testdata/import_public/sub/b.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/b.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M2 struct {
 	XXX_NoUnkeyedLiteral         struct{} `json:"-"`

--- a/protoc-gen-go/testdata/imports/fmt/m.pb.go
+++ b/protoc-gen-go/testdata/imports/fmt/m.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m1.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type E1 int32
 

--- a/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_1/m2.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M2 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m3.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M3 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
+++ b/protoc-gen-go/testdata/imports/test_a_2/m4.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M4 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m1.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M1 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_b_1/m2.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type M2 struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`

--- a/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m1.pb.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type A1M1 struct {
 	F                    *test_a_1.M1 `protobuf:"bytes,1,opt,name=f,proto3" json:"f,omitempty"`

--- a/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_a1m2.pb.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type A1M2 struct {
 	F                    *test_a_1.M2 `protobuf:"bytes,1,opt,name=f,proto3" json:"f,omitempty"`

--- a/protoc-gen-go/testdata/imports/test_import_all.pb.go
+++ b/protoc-gen-go/testdata/imports/test_import_all.pb.go
@@ -22,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type All struct {
 	Am1                  *test_a_1.M1 `protobuf:"bytes,1,opt,name=am1,proto3" json:"am1,omitempty"`

--- a/protoc-gen-go/testdata/multi/multi1.pb.go
+++ b/protoc-gen-go/testdata/multi/multi1.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Multi1 struct {
 	Multi2               *Multi2         `protobuf:"bytes,1,req,name=multi2" json:"multi2,omitempty"`

--- a/protoc-gen-go/testdata/multi/multi2.pb.go
+++ b/protoc-gen-go/testdata/multi/multi2.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Multi2_Color int32
 

--- a/protoc-gen-go/testdata/multi/multi3.pb.go
+++ b/protoc-gen-go/testdata/multi/multi3.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Multi3_HatType int32
 

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -21,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type HatType int32
 
@@ -892,9 +892,9 @@ func (m *Communique) GetSomegroup() *Communique_SomeGroup {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Communique) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Communique_OneofMarshaler, _Communique_OneofUnmarshaler, _Communique_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Communique) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Communique_Number)(nil),
 		(*Communique_Name)(nil),
 		(*Communique_Data)(nil),
@@ -906,182 +906,6 @@ func (*Communique) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) er
 		(*Communique_Msg)(nil),
 		(*Communique_Somegroup)(nil),
 	}
-}
-
-func _Communique_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Communique)
-	// union
-	switch x := m.Union.(type) {
-	case *Communique_Number:
-		b.EncodeVarint(5<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.Number))
-	case *Communique_Name:
-		b.EncodeVarint(6<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Name)
-	case *Communique_Data:
-		b.EncodeVarint(7<<3 | proto.WireBytes)
-		b.EncodeRawBytes(x.Data)
-	case *Communique_TempC:
-		b.EncodeVarint(8<<3 | proto.WireFixed64)
-		b.EncodeFixed64(math.Float64bits(x.TempC))
-	case *Communique_Height:
-		b.EncodeVarint(9<<3 | proto.WireFixed32)
-		b.EncodeFixed32(uint64(math.Float32bits(x.Height)))
-	case *Communique_Today:
-		b.EncodeVarint(10<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.Today))
-	case *Communique_Maybe:
-		t := uint64(0)
-		if x.Maybe {
-			t = 1
-		}
-		b.EncodeVarint(11<<3 | proto.WireVarint)
-		b.EncodeVarint(t)
-	case *Communique_Delta_:
-		b.EncodeVarint(12<<3 | proto.WireVarint)
-		b.EncodeZigzag32(uint64(x.Delta))
-	case *Communique_Msg:
-		b.EncodeVarint(16<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Msg); err != nil {
-			return err
-		}
-	case *Communique_Somegroup:
-		b.EncodeVarint(14<<3 | proto.WireStartGroup)
-		if err := b.Marshal(x.Somegroup); err != nil {
-			return err
-		}
-		b.EncodeVarint(14<<3 | proto.WireEndGroup)
-	case nil:
-	default:
-		return fmt.Errorf("Communique.Union has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Communique_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Communique)
-	switch tag {
-	case 5: // union.number
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Communique_Number{int32(x)}
-		return true, err
-	case 6: // union.name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Union = &Communique_Name{x}
-		return true, err
-	case 7: // union.data
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeRawBytes(true)
-		m.Union = &Communique_Data{x}
-		return true, err
-	case 8: // union.temp_c
-		if wire != proto.WireFixed64 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed64()
-		m.Union = &Communique_TempC{math.Float64frombits(x)}
-		return true, err
-	case 9: // union.height
-		if wire != proto.WireFixed32 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed32()
-		m.Union = &Communique_Height{math.Float32frombits(uint32(x))}
-		return true, err
-	case 10: // union.today
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Communique_Today{Days(x)}
-		return true, err
-	case 11: // union.maybe
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Union = &Communique_Maybe{x != 0}
-		return true, err
-	case 12: // union.delta
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeZigzag32()
-		m.Union = &Communique_Delta_{int32(x)}
-		return true, err
-	case 16: // union.msg
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Reply)
-		err := b.DecodeMessage(msg)
-		m.Union = &Communique_Msg{msg}
-		return true, err
-	case 14: // union.somegroup
-		if wire != proto.WireStartGroup {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Communique_SomeGroup)
-		err := b.DecodeGroup(msg)
-		m.Union = &Communique_Somegroup{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Communique_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Communique)
-	// union
-	switch x := m.Union.(type) {
-	case *Communique_Number:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Number))
-	case *Communique_Name:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Name)))
-		n += len(x.Name)
-	case *Communique_Data:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Data)))
-		n += len(x.Data)
-	case *Communique_TempC:
-		n += 1 // tag and wire
-		n += 8
-	case *Communique_Height:
-		n += 1 // tag and wire
-		n += 4
-	case *Communique_Today:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Today))
-	case *Communique_Maybe:
-		n += 1 // tag and wire
-		n += 1
-	case *Communique_Delta_:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64((uint32(x.Delta) << 1) ^ uint32((int32(x.Delta) >> 31))))
-	case *Communique_Msg:
-		s := proto.Size(x.Msg)
-		n += 2 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Communique_Somegroup:
-		n += 1 // tag and wire
-		n += proto.Size(x.Somegroup)
-		n += 1 // tag and wire
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 type Communique_SomeGroup struct {

--- a/protoc-gen-go/testdata/proto3/proto3.pb.go
+++ b/protoc-gen-go/testdata/proto3/proto3.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Request_Flavour int32
 

--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // `Any` contains an arbitrary serialized protocol buffer message along with a
 // URL that describes the type of the serialized message.

--- a/ptypes/duration/duration.pb.go
+++ b/ptypes/duration/duration.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A Duration represents a signed, fixed-length span of time represented
 // as a count of seconds and fractions of seconds at nanosecond

--- a/ptypes/empty/empty.pb.go
+++ b/ptypes/empty/empty.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A generic empty message that you can re-use to avoid defining duplicated
 // empty messages in your APIs. A typical example is to use it as the request

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // `NullValue` is a singleton enumeration to represent the null value for the
 // `Value` type union.
@@ -237,9 +237,9 @@ func (m *Value) GetListValue() *ListValue {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Value) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Value_OneofMarshaler, _Value_OneofUnmarshaler, _Value_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Value) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Value_NullValue)(nil),
 		(*Value_NumberValue)(nil),
 		(*Value_StringValue)(nil),
@@ -247,129 +247,6 @@ func (*Value) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, 
 		(*Value_StructValue)(nil),
 		(*Value_ListValue)(nil),
 	}
-}
-
-func _Value_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Value)
-	// kind
-	switch x := m.Kind.(type) {
-	case *Value_NullValue:
-		b.EncodeVarint(1<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.NullValue))
-	case *Value_NumberValue:
-		b.EncodeVarint(2<<3 | proto.WireFixed64)
-		b.EncodeFixed64(math.Float64bits(x.NumberValue))
-	case *Value_StringValue:
-		b.EncodeVarint(3<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.StringValue)
-	case *Value_BoolValue:
-		t := uint64(0)
-		if x.BoolValue {
-			t = 1
-		}
-		b.EncodeVarint(4<<3 | proto.WireVarint)
-		b.EncodeVarint(t)
-	case *Value_StructValue:
-		b.EncodeVarint(5<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.StructValue); err != nil {
-			return err
-		}
-	case *Value_ListValue:
-		b.EncodeVarint(6<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ListValue); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Value.Kind has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Value_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Value)
-	switch tag {
-	case 1: // kind.null_value
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Kind = &Value_NullValue{NullValue(x)}
-		return true, err
-	case 2: // kind.number_value
-		if wire != proto.WireFixed64 {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeFixed64()
-		m.Kind = &Value_NumberValue{math.Float64frombits(x)}
-		return true, err
-	case 3: // kind.string_value
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Kind = &Value_StringValue{x}
-		return true, err
-	case 4: // kind.bool_value
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Kind = &Value_BoolValue{x != 0}
-		return true, err
-	case 5: // kind.struct_value
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Struct)
-		err := b.DecodeMessage(msg)
-		m.Kind = &Value_StructValue{msg}
-		return true, err
-	case 6: // kind.list_value
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(ListValue)
-		err := b.DecodeMessage(msg)
-		m.Kind = &Value_ListValue{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Value_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Value)
-	// kind
-	switch x := m.Kind.(type) {
-	case *Value_NullValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.NullValue))
-	case *Value_NumberValue:
-		n += 1 // tag and wire
-		n += 8
-	case *Value_StringValue:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.StringValue)))
-		n += len(x.StringValue)
-	case *Value_BoolValue:
-		n += 1 // tag and wire
-		n += 1
-	case *Value_StructValue:
-		s := proto.Size(x.StructValue)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Value_ListValue:
-		s := proto.Size(x.ListValue)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
 }
 
 // `ListValue` is a wrapper around a repeated field of values.

--- a/ptypes/timestamp/timestamp.pb.go
+++ b/ptypes/timestamp/timestamp.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A Timestamp represents a point in time independent of any time zone
 // or calendar, represented as seconds and fractions of seconds at

--- a/ptypes/wrappers/wrappers.pb.go
+++ b/ptypes/wrappers/wrappers.pb.go
@@ -18,7 +18,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Wrapper message for `double`.
 //


### PR DESCRIPTION
The marshaler, unmarshaler, and sizer functions are unused ever since
the underlying implementation was switched to be table-driven.
Change the function to only return the wrapper structs.

This change:
* enables generated protos to drop dependencies on certain proto types
* reduces the size of generated protos
* simplifies the implementation of oneofs in protoc-gen-go

Updates #708