### PR TITLE
README.md: document how to build a specific version of `protoc-gen-go`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,19 @@ To use this software, you must:
 	https://golang.org/doc/install
   for details or, if you are using gccgo, follow the instructions at
 	https://golang.org/doc/install/gccgo
-- Grab the code from the repository and install the proto package.
+- Grab the code from the repository and install the `proto` package.
   The simplest way is to run `go get -u github.com/golang/protobuf/protoc-gen-go`.
-  The compiler plugin, protoc-gen-go, will be installed in $GOBIN,
-  defaulting to $GOPATH/bin.  It must be in your $PATH for the protocol
-  compiler, protoc, to find it.
+  The compiler plugin, `protoc-gen-go`, will be installed in `$GOPATH/bin`
+  unless `$GOBIN` is set. It must be in your `$PATH` for the protocol
+  compiler, `protoc`, to find it.
+- If you need a particular version of `protoc-gen-go` (e.g., to match your
+  `proto` package version), one option is
+  ```shell
+  GIT_TAG="v1.2.0" # change as needed
+  go get -d -u github.com/golang/protobuf/protoc-gen-go
+  git -C "$(go env GOPATH)"/src/github.com/golang/protobuf checkout $GIT_TAG
+  go install github.com/golang/protobuf/protoc-gen-go
+  ```
 
 This software has two parts: a 'protocol compiler plugin' that
 generates Go source files that, once compiled, can access and manage


### PR DESCRIPTION
If your code is locked to a specific version of `github.com/golang/protobuf` (e.g., 1.2.0), the default suggestion of `go get -u github.com/golang/protobuf/protoc-gen-go` may end up building and installing an incompatible version of `protoc-gen-go` (e.g., as introduced by https://github.com/golang/protobuf/blame/8d0c54c1/proto/proto3_proto/proto3.pb.go#L23).

Provides a workaround for #738.