### PR TITLE
add embedded proto.Message support

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -554,6 +554,12 @@ func (m *Marshaler) marshalValue(out *errWriter, prop *proto.Properties, v refle
 		return m.marshalObject(out, v.Addr().Interface().(proto.Message), indent+m.Indent, "")
 	}
 
+	if v.Kind() == reflect.Interface {
+		if p, ok := v.Interface().(proto.Message); ok && !reflect.ValueOf(p).IsNil() {
+			return m.marshalObject(out, p, indent+m.Indent, "")
+		}
+	}
+
 	// Handle maps.
 	// Since Go randomizes map iteration, we sort keys for stable output.
 	if v.Kind() == reflect.Map {


### PR DESCRIPTION
If I want to parse a struct with proto.Message interface to json, like

type Example struct {
    code          int32                  `json:"code"`
    msg           string                 `json:"msg"`
    embedded proto.Message `json:"data"`
}
for now, field embedded will be treated as an interface and jsonpb will fallback to use json.Marshal.
It will use the json tag generated by proto-gen-go, which is omitempty by default.
All field with `0` value and false value will be omitted, and all set parameters to jsonpb.Marshaler or grpc-gateway.JSONPbMarshaler won't take any effect, like EmitDefaults, Intent, OrigName...

If there are so many proto files to deal with and it impossible to modify all generated tag of them.
And I think the best way to deal with this situation is to make jsonpb support this embedded struct.