### PR TITLE
doc: fix indentation on Any examples

### DIFF
--- a/ptypes/any/any.pb.go
+++ b/ptypes/any/any.pb.go
@@ -45,7 +45,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -55,7 +55,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)

--- a/ptypes/any/any.proto
+++ b/ptypes/any/any.proto
@@ -64,7 +64,7 @@ option objc_class_prefix = "GPB";
 //       foo = any.unpack(Foo.class);
 //     }
 //
-//  Example 3: Pack and unpack a message in Python.
+// Example 3: Pack and unpack a message in Python.
 //
 //     foo = Foo(...)
 //     any = Any()
@@ -74,7 +74,7 @@ option objc_class_prefix = "GPB";
 //       any.Unpack(foo)
 //       ...
 //
-//  Example 4: Pack and unpack a message in Go
+// Example 4: Pack and unpack a message in Go
 //
 //      foo := &pb.Foo{...}
 //      any, err := ptypes.MarshalAny(foo)


### PR DESCRIPTION
Examples 3 and 4 had an extra leading space causing GoDoc to treat them as part of Example 2 rather than distinct snippets

https://i.imgur.com/FSwehb1.png
https://godoc.org/github.com/golang/protobuf/ptypes/any#Any