### PR TITLE
Avoid assuming time.Duration is nanoseconds

### DIFF
--- a/ptypes/duration.go
+++ b/ptypes/duration.go
@@ -82,7 +82,7 @@ func Duration(p *durpb.Duration) (time.Duration, error) {
 		return 0, fmt.Errorf("duration: %v is out of range for time.Duration", p)
 	}
 	if p.Nanos != 0 {
-		d += time.Duration(p.Nanos)
+		d += time.Duration(p.Nanos) * time.Nanosecond
 		if (d < 0) != (p.Nanos < 0) {
 			return 0, fmt.Errorf("duration: %v is out of range for time.Duration", p)
 		}


### PR DESCRIPTION
It is spec'd that way, but best practice is to avoid it.