### PR TITLE
proto: remove test dependency on experimental packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module github.com/golang/protobuf
 
-require (
-	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd // indirect
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
-	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b
-)
+require google.golang.org/genproto v0.0.0-20180831171423-11092d34479b

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
-golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b h1:lohp5blsw53GBXtLyLNaTXPXS9pJ1tiTw61ZHUoE9Qw=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/proto/extensions_test.go
+++ b/proto/extensions_test.go
@@ -38,11 +38,11 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 	pb "github.com/golang/protobuf/proto/test_proto"
-	"golang.org/x/sync/errgroup"
 )
 
 func TestGetExtensionsWithMissingExtensions(t *testing.T) {
@@ -671,18 +671,22 @@ func TestMarshalRace(t *testing.T) {
 	// GetExtension will decode it lazily. Make sure this does
 	// not race against Marshal.
 
-	var g errgroup.Group
+	wg := sync.WaitGroup{}
+	errs := make(chan error, 3)
 	for n := 3; n > 0; n-- {
-		g.Go(func() error {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			_, err := proto.Marshal(m)
-			return err
-		})
-		g.Go(func() error {
-			_, err := proto.GetExtension(m, pb.E_Ext_More)
-			return err
-		})
+			errs <- err
+		}()
 	}
-	if err := g.Wait(); err != nil {
-		t.Fatal(err)
+	wg.Wait()
+	close(errs)
+
+	for err = range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Removes two go mod dependencies on `golang.org/x/sync` and indirectly on `golang.org/x/net`. These were being used to provide an `errgroup.Group` to collate errors in a test.

This PR provides the same functionality but using `sync.WaitGroup`.