### PR TITLE
protoc-gen-go/grpc: inline errUnimplemented function

### DIFF
--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -196,10 +196,6 @@ var fileDescriptor_f64ba265cd7eae3f = []byte{
 var _ context.Context
 var _ grpc.ClientConn
 
-func errUnimplemented(methodName string) error {
-	return status.Errorf(codes.Unimplemented, "method %s not implemented", methodName)
-}
-
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
@@ -247,7 +243,7 @@ type UnimplementedDeprecatedServiceServer struct {
 }
 
 func (*UnimplementedDeprecatedServiceServer) DeprecatedCall(ctx context.Context, req *DeprecatedRequest) (*DeprecatedResponse, error) {
-	return nil, errUnimplemented("DeprecatedCall")
+	return nil, status.Errorf(codes.Unimplemented, "method DeprecatedCall not implemented")
 }
 
 // Deprecated: Do not use.

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -181,10 +181,6 @@ var fileDescriptor_81ea47a3f88c2082 = []byte{
 var _ context.Context
 var _ grpc.ClientConn
 
-func errUnimplemented(methodName string) error {
-	return status.Errorf(codes.Unimplemented, "method %s not implemented", methodName)
-}
-
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
@@ -332,16 +328,16 @@ type UnimplementedTestServer struct {
 }
 
 func (*UnimplementedTestServer) UnaryCall(ctx context.Context, req *SimpleRequest) (*SimpleResponse, error) {
-	return nil, errUnimplemented("UnaryCall")
+	return nil, status.Errorf(codes.Unimplemented, "method UnaryCall not implemented")
 }
 func (*UnimplementedTestServer) Downstream(req *SimpleRequest, srv Test_DownstreamServer) error {
-	return errUnimplemented("Downstream")
+	return status.Errorf(codes.Unimplemented, "method Downstream not implemented")
 }
 func (*UnimplementedTestServer) Upstream(srv Test_UpstreamServer) error {
-	return errUnimplemented("Upstream")
+	return status.Errorf(codes.Unimplemented, "method Upstream not implemented")
 }
 func (*UnimplementedTestServer) Bidi(srv Test_BidiServer) error {
-	return errUnimplemented("Bidi")
+	return status.Errorf(codes.Unimplemented, "method Bidi not implemented")
 }
 
 func RegisterTestServer(s *grpc.Server, srv TestServer) {


### PR DESCRIPTION
Avoid using an errUnimplemented function, which requires us to
give a name to it, causing possible conflicts.
Instead, just inline it's functionality.

Fixes #817