### PR TITLE
Ability to specify proto_import_prefix for imported .proto file exclusively.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ The following parameters are deprecated and should not be used:
 
 - `import_prefix=xxx` - a prefix that is added onto the beginning of
   all imports.
+- `proto_import_prefix=xxx` - a prefix that is added onto the beggining of
+  only those imports that come from one .proto file including another. Useful if you don't want to use go_package option and want to generate all files under a custom location.
 - `import_path=foo/bar` - used as the package if no input files
   declare `go_package`. If it contains slashes, everything up to the
   rightmost slash is ignored.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The following parameters are deprecated and should not be used:
 - `import_prefix=xxx` - a prefix that is added onto the beginning of
   all imports.
 - `proto_import_prefix=xxx` - a prefix that is added onto the beggining of
-  only those imports that come from one .proto file including another. Useful if you don't want to use go_package option and want to generate all files under a custom location.
+  only those imports that come from one of the .proto file including another. Useful if you don't want to use go_package option and want to generate all files under a custom location.
 - `import_path=foo/bar` - used as the package if no input files
   declare `go_package`. If it contains slashes, everything up to the
   rightmost slash is ignored.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The following parameters are deprecated and should not be used:
 - `import_prefix=xxx` - a prefix that is added onto the beginning of
   all imports.
 - `proto_import_prefix=xxx` - a prefix that is added onto the beggining of
-  only those imports that come from one of the .proto file including another. Useful if you don't want to use go_package option and want to generate all files under a custom location.
+  only those imports that come from one .proto file including another. Useful if you don't want to use go_package option and want to generate all files under a custom location.
 - `import_path=foo/bar` - used as the package if no input files
   declare `go_package`. If it contains slashes, everything up to the
   rightmost slash is ignored.

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -408,6 +408,7 @@ type Generator struct {
 	Param             map[string]string // Command-line parameters.
 	PackageImportPath string            // Go import path of the package we're generating code for
 	ImportPrefix      string            // String to prefix to imported package file names.
+	ProtoImportPrefix string            // String to prefix to imported package file names. This applyies when proto includes another proto file. Not core source code.
 	ImportMap         map[string]string // Mapping from .proto file name to import path
 
 	Pkg map[string]string // The names under which we import support packages
@@ -479,6 +480,11 @@ func (g *Generator) CommandLineParameters(parameter string) {
 		switch k {
 		case "import_prefix":
 			g.ImportPrefix = v
+			if g.ProtoImportPrefix == "" {
+				g.ProtoImportPrefix = v
+			}
+		case "proto_import_prefix":
+			g.ProtoImportPrefix = v
 		case "import_path":
 			g.PackageImportPath = v
 		case "paths":
@@ -1320,7 +1326,7 @@ func (g *Generator) generateImports() {
 	g.P(g.Pkg["math"] + ` "math"`)
 	g.P(g.Pkg["proto"]+" ", GoImportPath(g.ImportPrefix)+"github.com/golang/protobuf/proto")
 	for importPath, packageName := range imports {
-		g.P(packageName, " ", GoImportPath(g.ImportPrefix)+importPath)
+		g.P(packageName, " ", GoImportPath(g.ProtoImportPrefix)+importPath)
 	}
 	g.P(")")
 	g.P()


### PR DESCRIPTION
Currently you can use only import_prefix=xxx/ that gets applyied to core imports like: github.com/golang/protobuf/proto

What this commit is about is that it allows you to specify import for .proto imports only (ie. one .proto file is referencing another) without changing the import prefix of core packages (ie. github.com/golang/protobuf/proto)

This commit does not affect previous functionality. If you set only import_prefix it will still work as before.

This commit is helpful if you want to generate into other folders than $GOPATH/src and dont want to use go_package. If you want to generate into $GOPATH/src/my_project/proto_generated for example
