### PR TITLE
Log parsing errors using log pkg

### DIFF
--- a/proto/properties.go
+++ b/proto/properties.go
@@ -38,7 +38,6 @@ package proto
 import (
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"

--- a/proto/properties.go
+++ b/proto/properties.go
@@ -194,7 +194,7 @@ func (p *Properties) Parse(s string) {
 	// "bytes,49,opt,name=foo,def=hello!"
 	fields := strings.Split(s, ",") // breaks def=, but handled below.
 	if len(fields) < 2 {
-		fmt.Fprintf(os.Stderr, "proto: tag has too few fields: %q\n", s)
+		log.Printf("proto: tag has too few fields: %q", s)
 		return
 	}
 
@@ -214,7 +214,7 @@ func (p *Properties) Parse(s string) {
 		p.WireType = WireBytes
 		// no numeric converter for non-numeric types
 	default:
-		fmt.Fprintf(os.Stderr, "proto: tag has unknown wire type: %q\n", s)
+		log.Printf("proto: tag has unknown wire type: %q", s)
 		return
 	}
 


### PR DESCRIPTION
Re-opening #829 per conversation with @neild https://github.com/golang/protobuf/pull/829#issuecomment-492840829

Convert prints to `os.Stderr` to Go's `log.Printf` to remain consistent with the rest of the codebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golang/protobuf/851)
<!-- Reviewable:end -->
