### PR TITLE
add Number method to enum

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1419,6 +1419,11 @@ func (g *Generator) generateEnum(enum *EnumDescriptor) {
 	g.P("}")
 	g.P()
 
+	g.P("func (x ", ccTypeName, ") Number() int32 {")
+	g.P("return ", "int32(x)")
+	g.P("}")
+	g.P()
+
 	if !enum.proto3() {
 		g.P("func (x *", ccTypeName, ") UnmarshalJSON(data []byte) error {")
 		g.P("value, err := ", g.Pkg["proto"], ".UnmarshalJSONEnum(", ccTypeName, `_value, data, "`, ccTypeName, `")`)


### PR DESCRIPTION
related issue: https://github.com/protocolbuffers/protobuf/issues/6104#issuecomment-502423539

if enum has `Number` method. Though we define `ErrorCode ` in different proto files. We could solve the problem like this:

```golang
type ProtoEnum interface {
	fmt.Stringer
	Number() int32
	EnumDescriptor() ([]byte, []int)
}

func Errorf(v ProtoEnum) error {
   // now we could get the code and message desc.
}
```