### PR TITLE
added v2 suffix to go.mod module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module google.golang.org/protobuf
+module google.golang.org/protobuf/v2
 
 go 1.9
 


### PR DESCRIPTION
The v2 suffix was dropped in commit 934520f5b.  Was this intentional?