### PR TITLE
Add support for unmarshalling Numbers to strings.

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -1063,6 +1063,18 @@ func (u *Unmarshaler) unmarshalValue(target reflect.Value, inputValue json.RawMe
 		inputValue = inputValue[1 : len(inputValue)-1]
 	}
 
+	// Numbers need to be decodeable as string in order to not lose information
+	if targetType.Kind() == reflect.String {
+		var number json.Number
+		dec := json.NewDecoder(strings.NewReader(string(inputValue)))
+		err := dec.Decode(&number)
+		if err == nil {
+			target.SetString(number.String())
+			return nil
+		}
+		// Best effort only
+	}
+
 	// Use the encoding/json for parsing other value types.
 	return json.Unmarshal(inputValue, target.Addr().Interface())
 }

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -841,6 +841,8 @@ var unmarshalingTests = []struct {
 	{"null StringValue", Unmarshaler{}, `{"str":null}`, &pb.KnownTypes{Str: nil}},
 	{"null BytesValue", Unmarshaler{}, `{"bytes":null}`, &pb.KnownTypes{Bytes: nil}},
 
+	{"Big Number", Unmarshaler{}, `{"str":9223372036854775808}`, &pb.KnownTypes{Str: &wpb.StringValue{Value: "9223372036854775808"}}},
+
 	{"required", Unmarshaler{}, `{"str":"hello"}`, &pb.MsgWithRequired{Str: proto.String("hello")}},
 	{"required bytes", Unmarshaler{}, `{"byts": []}`, &pb.MsgWithRequiredBytes{Byts: []byte{}}},
 }


### PR DESCRIPTION
To preserve Number information beyond 64bit, it is necessary to be able
to convert Numbers to strings (as is supported by Go's json
implementation).
Implements #875.