### PR TITLE
protoreflect: typo

### DIFF
--- a/reflect/protoreflect/type.go
+++ b/reflect/protoreflect/type.go
@@ -48,7 +48,7 @@ type Descriptor interface {
 	// Support for this functionality is optional and may return nil.
 	Parent() Descriptor
 
-	// Index returns the the index of this descriptor within its parent.
+	// Index returns the index of this descriptor within its parent.
 	// It returns 0 if the descriptor does not have a parent or if the parent
 	// is unknown.
 	Index() int


### PR DESCRIPTION
s/the the/the/