### PR TITLE
table unmarshal fix

### DIFF
--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -320,6 +320,9 @@ func (u *unmarshalInfo) computeUnmarshalInfo() {
 		}
 
 		tags := f.Tag.Get("protobuf")
+		if tags == "" {
+			continue
+		}
 		tagArray := strings.Split(tags, ",")
 		if len(tagArray) < 2 {
 			panic("protobuf tag not enough fields in " + t.Name() + "." + f.Name + ": " + tags)


### PR DESCRIPTION
Change-Id: I7b2d8e79edf41d4d6085ac3c43a9646b527ee197
In table_marshal.go file,
tags := strings.Split(f.Tag.Get("protobuf"), ",") if tags[0] == "" { return } 
but in table_unmarshal.go, don't consider this condition.

when i use protobuf:"" to ignore some field, serialization is normal, but it will fail when deserialized.