### PR TITLE
jsonpb: add option to marshal int64 types as unqouted numbers

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -77,6 +77,11 @@ type Marshaler struct {
 	// Whether to use the original (.proto) name for fields.
 	OrigName bool
 
+	// Skips qouting uint64, int64, and fixed64 types as strings. Default
+	// behavior is to quote per protobuf spec
+	// Ref: https://developers.google.com/protocol-buffers/docs/proto3#json
+	SkipQouteInt64 bool
+
 	// A custom URL resolver to use when marshaling Any messages to JSON.
 	// If unset, the default resolution strategy is to extract the
 	// fully-qualified type name from the type URL and pass that to
@@ -647,6 +652,7 @@ func (m *Marshaler) marshalValue(out *errWriter, prop *proto.Properties, v refle
 		return err
 	}
 	needToQuote := string(b[0]) != `"` && (v.Kind() == reflect.Int64 || v.Kind() == reflect.Uint64)
+	needToQuote = needToQuote && !m.SkipQouteInt64
 	if needToQuote {
 		out.write(`"`)
 	}

--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -530,6 +530,7 @@ var marshalingTests = []struct {
 
 	{"required", marshaler, &pb.MsgWithRequired{Str: proto.String("hello")}, `{"str":"hello"}`},
 	{"required bytes", marshaler, &pb.MsgWithRequiredBytes{Byts: []byte{}}, `{"byts":""}`},
+	{"int64 as number", Marshaler{SkipQouteInt64: true}, &pb.KnownTypes{I64: &wpb.Int64Value{Value: -3}}, `{"i64":-3}`},
 }
 
 func TestMarshaling(t *testing.T) {


### PR DESCRIPTION
Case: These changes make it easier for the majority of non-jsonpb json libs unmarshal types into they contracted type ( in the .proto ). While the flag allows marshaling against the protobuf spec, I believe these changes should be considered for the additional control that it provides services.

My understanding of why protobuf does this in the first place is from: https://stackoverflow.com/questions/53911502/jsonpb-why-decode-int64-to-json-the-result-is-string-like-int64-str-10-str

For cases where services are using non-jsonpb un/marshalers its useful to return these as actual numbers. We can't always control how consumers use our service, and it seems like a big part of using jsonpb to marshal is that the output json can just be unmarshaled unaware of it coming from protobuf