### PR TITLE
proposal: protoc-gen-go: Add `OneOfValue()` next to oneof discriminator method.

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1916,6 +1916,7 @@ func (f *oneofField) getter(g *Generator, mc *msgCtx) {
 	// The discriminator type
 	g.P("type ", f.goType, " interface {")
 	g.P(f.goType, "()")
+	g.P("OneOfValue() interface{}")
 	g.P("}")
 	g.P()
 	// The subField types, fulfilling the discriminator type contract
@@ -1927,6 +1928,11 @@ func (f *oneofField) getter(g *Generator, mc *msgCtx) {
 	}
 	for _, sf := range f.subFields {
 		g.P("func (*", sf.oneofTypeName, ") ", f.goType, "() {}")
+		g.P()
+		g.P("func (m *", sf.oneofTypeName, ") OneOfValue() interface{} {")
+		g.P("if m != nil { return m.", sf.goName, " }")
+		g.P("return nil")
+		g.P("}")
 		g.P()
 	}
 	// Getter for the oneof field


### PR DESCRIPTION
Simplifies the access to fields that are common among all oneof subtypes
by means of casting `interface{}` returned by `OneOfValue()` to a more
specific interface containing a common getter method. Avoids the effort
of creating a switch case for each oneof subtype and its specific field.

Example
```
message A {
  oneof B {
    C c = 1;
    D d = 2;
  }
  message C {
    Common common = 1;
    SpecificForC x = 2;
  }
  message D {
    Common common = 1;
    SpecificForD y = 2;
  }
  message Common {
    string name = 1;
  }
  [...]
}
```

I would like to (manually) add a general `GetCommon()` method for `B` in a file next to the `pb.go` file, like this.
```
type getCommoner interface {
  GetCommon() (*A_Common)
}
func (m *A_B) GetCommon() (common *A_Common) {
  if commoner, ok := m.GetB().OneOfValue().(getCommoner); ok {
    common = commoner.GetCommon()
  }
  return
}
```