### PR TITLE
protoc-gen-go/grpc: Add null guard for gRPC connection

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -329,11 +329,14 @@ func (g *grpc) generateClientMethod(servName, fullServName, serviceDescVar strin
 	methName := generator.CamelCase(method.GetName())
 	inType := g.typeName(method.GetInputType())
 	outType := g.typeName(method.GetOutputType())
+	statusPkg := string(g.gen.AddImport(statusPkgPath))
+	codePkg := string(g.gen.AddImport(codePkgPath))
 
 	if method.GetOptions().GetDeprecated() {
 		g.P(deprecationComment)
 	}
 	g.P("func (c *", unexport(servName), "Client) ", g.generateClientSignature(servName, method), "{")
+	g.P("if c.cc == nil { return nil, ", statusPkg, `.Errorf(`, codePkg, `.FailedPrecondition, "grpc connection is nil") }`)
 	if !method.GetServerStreaming() && !method.GetClientStreaming() {
 		g.P("out := new(", outType, ")")
 		// TODO: Pass descExpr to Invoke.


### PR DESCRIPTION
Generated code for gRPC Service Client does an RPC call by deferencing a connection pointer (`grpc.ClientConn`) without checking whether it is nil.

In this PR, an error is returned if that connection pointer is nil, so that no _nil pointer dereference_ is thrown (_panic_) due to nil connection.