### PR TITLE
protoc-gen-go/grpc: Add null guard for gRPC connection

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -329,11 +329,14 @@ func (g *grpc) generateClientMethod(servName, fullServName, serviceDescVar strin
 	methName := generator.CamelCase(method.GetName())
 	inType := g.typeName(method.GetInputType())
 	outType := g.typeName(method.GetOutputType())
+	statusPkg := string(g.gen.AddImport(statusPkgPath))
+	codePkg := string(g.gen.AddImport(codePkgPath))
 
 	if method.GetOptions().GetDeprecated() {
 		g.P(deprecationComment)
 	}
 	g.P("func (c *", unexport(servName), "Client) ", g.generateClientSignature(servName, method), "{")
+	g.P("if c.cc == nil { return nil, ", statusPkg, `.Errorf(`, codePkg, `.FailedPrecondition, "grpc connection is nil") }`)
 	if !method.GetServerStreaming() && !method.GetClientStreaming() {
 		g.P("out := new(", outType, ")")
 		// TODO: Pass descExpr to Invoke.

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -221,6 +221,9 @@ func NewDeprecatedServiceClient(cc *grpc.ClientConn) DeprecatedServiceClient {
 
 // Deprecated: Do not use.
 func (c *deprecatedServiceClient) DeprecatedCall(ctx context.Context, in *DeprecatedRequest, opts ...grpc.CallOption) (*DeprecatedResponse, error) {
+	if c.cc == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "grpc connection is nil")
+	}
 	out := new(DeprecatedResponse)
 	err := c.cc.Invoke(ctx, "/deprecated.DeprecatedService/DeprecatedCall", in, out, opts...)
 	if err != nil {

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -207,6 +207,9 @@ func NewTestClient(cc *grpc.ClientConn) TestClient {
 }
 
 func (c *testClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error) {
+	if c.cc == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "grpc connection is nil")
+	}
 	out := new(SimpleResponse)
 	err := c.cc.Invoke(ctx, "/grpc.testing.Test/UnaryCall", in, out, opts...)
 	if err != nil {
@@ -216,6 +219,9 @@ func (c *testClient) UnaryCall(ctx context.Context, in *SimpleRequest, opts ...g
 }
 
 func (c *testClient) Downstream(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (Test_DownstreamClient, error) {
+	if c.cc == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "grpc connection is nil")
+	}
 	stream, err := c.cc.NewStream(ctx, &_Test_serviceDesc.Streams[0], "/grpc.testing.Test/Downstream", opts...)
 	if err != nil {
 		return nil, err
@@ -248,6 +254,9 @@ func (x *testDownstreamClient) Recv() (*StreamMsg, error) {
 }
 
 func (c *testClient) Upstream(ctx context.Context, opts ...grpc.CallOption) (Test_UpstreamClient, error) {
+	if c.cc == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "grpc connection is nil")
+	}
 	stream, err := c.cc.NewStream(ctx, &_Test_serviceDesc.Streams[1], "/grpc.testing.Test/Upstream", opts...)
 	if err != nil {
 		return nil, err
@@ -282,6 +291,9 @@ func (x *testUpstreamClient) CloseAndRecv() (*SimpleResponse, error) {
 }
 
 func (c *testClient) Bidi(ctx context.Context, opts ...grpc.CallOption) (Test_BidiClient, error) {
+	if c.cc == nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "grpc connection is nil")
+	}
 	stream, err := c.cc.NewStream(ctx, &_Test_serviceDesc.Streams[2], "/grpc.testing.Test/Bidi", opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Generated code for gRPC Service Client does an RPC call by deferencing a connection pointer (`grpc.ClientConn`) without checking whether it is nil.

In this PR, an error is returned if that connection pointer is nil, so that no _nil pointer dereference_ is thrown (_panic_) due to nil connection.