### PR TITLE
protoc-gen-go: add stability warning to XxxServer and XxxClient

### DIFF
--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -157,6 +157,8 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	g.P(fmt.Sprintf(`// %sClient is the client API for %s service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.`, servName, servName))
+	g.P("//")
+	g.P("// Unstable: When implementing, embed an anonymous ", servName, "Client field from New", servName, "Client for forward compatibility.")
 
 	// Client interface.
 	if deprecated {
@@ -210,6 +212,8 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	// Server interface.
 	serverType := servName + "Server"
 	g.P("// ", serverType, " is the server API for ", servName, " service.")
+	g.P("//")
+	g.P("// Unstable: When implementing, embed an anonymous Unimplemented", serverType, " field for forward compatibility.")
 	if deprecated {
 		g.P("//")
 		g.P(deprecationComment)

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -204,6 +204,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 //
+// Unstable: When implementing, embed an anonymous DeprecatedServiceClient field from NewDeprecatedServiceClient for forward compatibility.
+//
 // Deprecated: Do not use.
 type DeprecatedServiceClient interface {
 	// DeprecatedCall takes a DeprecatedRequest and returns a DeprecatedResponse.
@@ -232,6 +234,8 @@ func (c *deprecatedServiceClient) DeprecatedCall(ctx context.Context, in *Deprec
 }
 
 // DeprecatedServiceServer is the server API for DeprecatedService service.
+//
+// Unstable: When implementing, embed an anonymous UnimplementedDeprecatedServiceServer field for forward compatibility.
 //
 // Deprecated: Do not use.
 type DeprecatedServiceServer interface {

--- a/protoc-gen-go/testdata/grpc/grpc.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc.pb.go
@@ -188,6 +188,8 @@ const _ = grpc.SupportPackageIsVersion4
 // TestClient is the client API for Test service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+//
+// Unstable: When implementing, embed an anonymous TestClient field from NewTestClient for forward compatibility.
 type TestClient interface {
 	UnaryCall(ctx context.Context, in *SimpleRequest, opts ...grpc.CallOption) (*SimpleResponse, error)
 	// This RPC streams from the server only.
@@ -313,6 +315,8 @@ func (x *testBidiClient) Recv() (*StreamMsg2, error) {
 }
 
 // TestServer is the server API for Test service.
+//
+// Unstable: When implementing, embed an anonymous UnimplementedTestServer field for forward compatibility.
 type TestServer interface {
 	UnaryCall(context.Context, *SimpleRequest) (*SimpleResponse, error)
 	// This RPC streams from the server only.

--- a/protoc-gen-go/testdata/grpc/grpc_empty.pb.go
+++ b/protoc-gen-go/testdata/grpc/grpc_empty.pb.go
@@ -47,6 +47,8 @@ const _ = grpc.SupportPackageIsVersion4
 // EmptyServiceClient is the client API for EmptyService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+//
+// Unstable: When implementing, embed an anonymous EmptyServiceClient field from NewEmptyServiceClient for forward compatibility.
 type EmptyServiceClient interface {
 }
 
@@ -59,6 +61,8 @@ func NewEmptyServiceClient(cc *grpc.ClientConn) EmptyServiceClient {
 }
 
 // EmptyServiceServer is the server API for EmptyService service.
+//
+// Unstable: When implementing, embed an anonymous UnimplementedEmptyServiceServer field for forward compatibility.
 type EmptyServiceServer interface {
 }
 


### PR DESCRIPTION
Due to the lack of stability guarantees provided for service Server and
Client interfaces, as hightlighted in grpc/grpc-go#2318 and
grpc/grpc-go#3024, this change adds a godoc line that both warns users
and suggests the canonical workaround.

The structure of the godoc text is styled after an open proposal,
golang/go#34409, thus may need to be changed, but attempts to play well
with the tooling ecosystem, as was done for deprecated with
golang/go#10909.