### PR TITLE
protoc-gen-go: allow specifying additional internal fields tags

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -409,6 +409,7 @@ type Generator struct {
 	PackageImportPath string            // Go import path of the package we're generating code for
 	ImportPrefix      string            // String to prefix to imported package file names.
 	ImportMap         map[string]string // Mapping from .proto file name to import path
+	InternalTags      string            // String with additional internal field tags.
 
 	Pkg map[string]string // The names under which we import support packages
 
@@ -460,6 +461,72 @@ func (g *Generator) Fail(msgs ...string) {
 	os.Exit(1)
 }
 
+func ValidateFieldTags(tag string) bool {
+	// This is code is from https://godoc.org/golang.org/x/tools/go/analysis/passes/structtag
+	n := 0
+	for ; tag != ""; n++ {
+		if n > 0 && tag != "" && tag[0] != ' ' {
+			// More restrictive than reflect, but catches likely mistakes
+			// like `x:"foo",y:"bar"`, which parses as `x:"foo" ,y:"bar"` with second key ",y".
+			return false
+		}
+		// Skip leading space.
+		i := 0
+		for i < len(tag) && tag[i] == ' ' {
+			i++
+		}
+		tag = tag[i:]
+		if tag == "" {
+			break
+		}
+
+		// Scan to colon. A space, a quote or a control character is a syntax error.
+		// Strictly speaking, control chars include the range [0x7f, 0x9f], not just
+		// [0x00, 0x1f], but in practice, we ignore the multi-byte control characters
+		// as it is simpler to inspect the tag's bytes than the tag's runes.
+		i = 0
+		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
+			i++
+		}
+		if i == 0 {
+			return false
+		}
+		if i+1 >= len(tag) || tag[i] != ':' {
+			return false
+		}
+		if tag[i+1] != '"' {
+			return false
+		}
+		// key := tag[:i] (not needed)
+		tag = tag[i+1:]
+
+		// Scan quoted string to find value.
+		i = 1
+		for i < len(tag) && tag[i] != '"' {
+			if tag[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		if i >= len(tag) {
+			return false
+		}
+		qvalue := tag[:i+1]
+		tag = tag[i+1:]
+
+		value, err := strconv.Unquote(qvalue)
+		if err != nil {
+			return false
+		}
+
+		// No spaces are allows inside the value.
+		if strings.IndexByte(value, ' ') >= 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // CommandLineParameters breaks the comma-separated list of key=value pairs
 // in the parameter (a member of the request protobuf) into a key/value map.
 // It then sets file name mappings defined by those entries.
@@ -496,6 +563,11 @@ func (g *Generator) CommandLineParameters(parameter string) {
 			if v == "true" {
 				g.annotateCode = true
 			}
+		case "internal_tags":
+			if !ValidateFieldTags(v) {
+				g.Fail(fmt.Sprintf("Invalid internal field tags `%s`", v))
+			}
+			g.InternalTags = v
 		default:
 			if len(k) > 0 && k[0] == 'M' {
 				g.ImportMap[k[1:]] = v
@@ -2049,16 +2121,20 @@ func (g *Generator) generateDefaultConstants(mc *msgCtx, topLevelFields []topLev
 
 // generateInternalStructFields just adds the XXX_<something> fields to the message struct.
 func (g *Generator) generateInternalStructFields(mc *msgCtx, topLevelFields []topLevelField) {
-	g.P("XXX_NoUnkeyedLiteral\tstruct{} `json:\"-\"`") // prevent unkeyed struct literals
+	fieldTags := "json:\"-\""
+	if g.InternalTags != "" {
+		fieldTags += " " + g.InternalTags
+	}
+	g.P(fmt.Sprintf("XXX_NoUnkeyedLiteral\tstruct{} `%s`", fieldTags)) // prevent unkeyed struct literals
 	if len(mc.message.ExtensionRange) > 0 {
 		messageset := ""
 		if opts := mc.message.Options; opts != nil && opts.GetMessageSetWireFormat() {
 			messageset = "protobuf_messageset:\"1\" "
 		}
-		g.P(g.Pkg["proto"], ".XXX_InternalExtensions `", messageset, "json:\"-\"`")
+		g.P(g.Pkg["proto"], ".XXX_InternalExtensions `", messageset, fmt.Sprintf("%s`", fieldTags))
 	}
-	g.P("XXX_unrecognized\t[]byte `json:\"-\"`")
-	g.P("XXX_sizecache\tint32 `json:\"-\"`")
+	g.P(fmt.Sprintf("XXX_unrecognized\t[]byte `%s`", fieldTags))
+	g.P(fmt.Sprintf("XXX_sizecache\tint32 `%s`", fieldTags))
 
 }
 
@@ -2264,7 +2340,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 			of := oneofField{
 				fieldCommon: fieldCommon{
 					goName:     fname,
-					getterName: "Get"+fname,
+					getterName: "Get" + fname,
 					goType:     dname,
 					tags:       tag,
 					protoName:  odp.GetName(),


### PR DESCRIPTION
Add a new plugin option `internal_tags` to allow specifying additional
field tags. The `json:"-"` tag is maintained and the new tags will simply
be appended.