### PR TITLE
use specify json tag by default

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2239,7 +2239,10 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		ns := allocNames(base, "Get"+base)
 		fieldName, fieldGetterName := ns[0], ns[1]
 		typename, wiretype := g.GoType(message, field)
-		jsonName := *field.Name
+		jsonName := field.GetJsonName()
+		if jsonName == "" {
+			jsonName = *field.Name
+		}
 		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
 
 		oneof := field.OneofIndex != nil
@@ -2264,7 +2267,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 			of := oneofField{
 				fieldCommon: fieldCommon{
 					goName:     fname,
-					getterName: "Get"+fname,
+					getterName: "Get" + fname,
 					goType:     dname,
 					tags:       tag,
 					protoName:  odp.GetName(),

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -410,6 +410,8 @@ type Generator struct {
 	ImportPrefix      string            // String to prefix to imported package file names.
 	ImportMap         map[string]string // Mapping from .proto file name to import path
 
+	customJsonTag bool // enable custom json tag
+
 	Pkg map[string]string // The names under which we import support packages
 
 	outputImportPath GoImportPath                   // Package we're generating code for.
@@ -495,6 +497,10 @@ func (g *Generator) CommandLineParameters(parameter string) {
 		case "annotate_code":
 			if v == "true" {
 				g.annotateCode = true
+			}
+		case "custom_json_tag":
+			if v == "true" {
+				g.customJsonTag = true
 			}
 		default:
 			if len(k) > 0 && k[0] == 'M' {
@@ -2239,9 +2245,9 @@ func (g *Generator) generateMessage(message *Descriptor) {
 		ns := allocNames(base, "Get"+base)
 		fieldName, fieldGetterName := ns[0], ns[1]
 		typename, wiretype := g.GoType(message, field)
-		jsonName := field.GetJsonName()
-		if jsonName == "" {
-			jsonName = *field.Name
+		jsonName := *field.Name
+		if g.customJsonTag && field.GetJsonName() != "" {
+			jsonName = field.GetJsonName()
 		}
 		tag := fmt.Sprintf("protobuf:%s json:%q", g.goTag(message, field, wiretype), jsonName+",omitempty")
 


### PR DESCRIPTION
message TestReq {
    string OpenId = 1 ;
    string UserName = 2 [json_name="u_name"];
}

by default, protoc-gen-go will create struct with json tag UserName, just like this:
type TestReq struct {
    OpenId               string   `protobuf:"bytes,1,opt,name=OpenId,proto3" json:"OpenId,omitempty"`
    UserName             string   `protobuf:"bytes,2,opt,name=UserName,json=UserName,proto3" json:"UserName,omitempty"`
    XXX_NoUnkeyedLiteral struct{} `json:"-"`
    XXX_unrecognized     []byte   `json:"-"`
    XXX_sizecache        int32    `json:"-"`
}

but we want to define the json tag of the filed UserName called "u_name", this can be fixed by this commit!

type TestReq struct {
        OpenId               string   `protobuf:"bytes,1,opt,name=OpenId,proto3" json:"OpenId,omitempty"`
        UserName             string   `protobuf:"bytes,2,opt,name=UserName,json=u_name,proto3" json:"u_name,omitempty"`
        XXX_NoUnkeyedLiteral struct{} `json:"-"`
        XXX_unrecognized     []byte   `json:"-"`
        XXX_sizecache        int32    `json:"-"`
}
