### PR TITLE
Fix typos in comments, tests and function names

### DIFF
--- a/jsonpb/jsonpb_test.go
+++ b/jsonpb/jsonpb_test.go
@@ -584,10 +584,10 @@ func TestMarshalJSONPBMarshaler(t *testing.T) {
 	msg := dynamicMessage{RawJson: rawJson}
 	str, err := new(Marshaler).MarshalToString(&msg)
 	if err != nil {
-		t.Errorf("an unexpected error occurred when marshalling JSONPBMarshaler: %v", err)
+		t.Errorf("an unexpected error occurred when marshaling JSONPBMarshaler: %v", err)
 	}
 	if str != rawJson {
-		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, rawJson)
+		t.Errorf("marshaling JSON produced incorrect output: got %s, wanted %s", str, rawJson)
 	}
 }
 
@@ -595,17 +595,17 @@ func TestMarshalAnyJSONPBMarshaler(t *testing.T) {
 	msg := dynamicMessage{RawJson: `{ "foo": "bar", "baz": [0, 1, 2, 3] }`}
 	a, err := ptypes.MarshalAny(&msg)
 	if err != nil {
-		t.Errorf("an unexpected error occurred when marshalling to Any: %v", err)
+		t.Errorf("an unexpected error occurred when marshaling to Any: %v", err)
 	}
 	str, err := new(Marshaler).MarshalToString(a)
 	if err != nil {
-		t.Errorf("an unexpected error occurred when marshalling Any to JSON: %v", err)
+		t.Errorf("an unexpected error occurred when marshaling Any to JSON: %v", err)
 	}
 	// after custom marshaling, it's round-tripped through JSON decoding/encoding already,
 	// so the keys are sorted, whitespace is compacted, and "@type" key has been added
 	expected := `{"@type":"type.googleapis.com/` + dynamicMessageName + `","baz":[0,1,2,3],"foo":"bar"}`
 	if str != expected {
-		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
+		t.Errorf("marshaling JSON produced incorrect output: got %s, wanted %s", str, expected)
 	}
 
 	// Do it again, but this time with indentation:
@@ -613,7 +613,7 @@ func TestMarshalAnyJSONPBMarshaler(t *testing.T) {
 	marshaler := Marshaler{Indent: "  "}
 	str, err = marshaler.MarshalToString(a)
 	if err != nil {
-		t.Errorf("an unexpected error occurred when marshalling Any to JSON: %v", err)
+		t.Errorf("an unexpected error occurred when marshaling Any to JSON: %v", err)
 	}
 	// same as expected above, but pretty-printed w/ indentation
 	expected = `{
@@ -627,7 +627,7 @@ func TestMarshalAnyJSONPBMarshaler(t *testing.T) {
   "foo": "bar"
 }`
 	if str != expected {
-		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", str, expected)
+		t.Errorf("marshaling JSON produced incorrect output: got %s, wanted %s", str, expected)
 	}
 }
 
@@ -636,11 +636,11 @@ func TestMarshalWithCustomValidation(t *testing.T) {
 
 	js, err := new(Marshaler).MarshalToString(&msg)
 	if err != nil {
-		t.Errorf("an unexpected error occurred when marshalling to json: %v", err)
+		t.Errorf("an unexpected error occurred when marshaling to json: %v", err)
 	}
 	err = Unmarshal(strings.NewReader(js), &msg)
 	if err != nil {
-		t.Errorf("an unexpected error occurred when unmarshalling from json: %v", err)
+		t.Errorf("an unexpected error occurred when unmarshaling from json: %v", err)
 	}
 }
 
@@ -883,7 +883,7 @@ func TestUnmarshaling(t *testing.T) {
 
 		err := tt.unmarshaler.Unmarshal(strings.NewReader(tt.json), p)
 		if err != nil {
-			t.Errorf("unmarshalling %s: %v", tt.desc, err)
+			t.Errorf("unmarshaling %s: %v", tt.desc, err)
 			continue
 		}
 
@@ -1017,7 +1017,7 @@ func TestAnyWithCustomResolver(t *testing.T) {
 	}
 	wanted := `{"@type":"https://foobar.com/some.random.MessageKind","oBool":true,"oInt64":"1020304","oString":"foobar","oBytes":"AQIDBA=="}`
 	if js != wanted {
-		t.Errorf("marshalling JSON produced incorrect output: got %s, wanted %s", js, wanted)
+		t.Errorf("marshaling JSON produced incorrect output: got %s, wanted %s", js, wanted)
 	}
 
 	u := Unmarshaler{AnyResolver: resolver}
@@ -1032,7 +1032,7 @@ func TestAnyWithCustomResolver(t *testing.T) {
 		t.Errorf("custom resolver was invoked with wrong URL: got %q, wanted %q", resolvedTypeUrls[1], "https://foobar.com/some.random.MessageKind")
 	}
 	if !proto.Equal(any, roundTrip) {
-		t.Errorf("message contents not set correctly after unmarshalling JSON: got %s, wanted %s", roundTrip, any)
+		t.Errorf("message contents not set correctly after unmarshaling JSON: got %s, wanted %s", roundTrip, any)
 	}
 }
 
@@ -1043,7 +1043,7 @@ func TestUnmarshalJSONPBUnmarshaler(t *testing.T) {
 		t.Errorf("an unexpected error occurred when parsing into JSONPBUnmarshaler: %v", err)
 	}
 	if msg.RawJson != rawJson {
-		t.Errorf("message contents not set correctly after unmarshalling JSON: got %s, wanted %s", msg.RawJson, rawJson)
+		t.Errorf("message contents not set correctly after unmarshaling JSON: got %s, wanted %s", msg.RawJson, rawJson)
 	}
 }
 
@@ -1077,7 +1077,7 @@ func TestUnmarshalAnyJSONPBUnmarshaler(t *testing.T) {
 	}
 
 	if !proto.Equal(&got, &want) {
-		t.Errorf("message contents not set correctly after unmarshalling JSON: got %v, wanted %v", got, want)
+		t.Errorf("message contents not set correctly after unmarshaling JSON: got %v, wanted %v", got, want)
 	}
 }
 

--- a/proto/all_test.go
+++ b/proto/all_test.go
@@ -1502,7 +1502,7 @@ func TestJSON(t *testing.T) {
 		t.Fatalf("got %s, want %s", received, m)
 	}
 
-	// Test unmarshalling of JSON with symbolic enum name.
+	// Test unmarshaling of JSON with symbolic enum name.
 	const old = `{"count":4,"pet":["bunny","kitty"],"inner":{"host":"cauchy"},"bikeshed":"GREEN"}`
 	received.Reset()
 	if err := json.Unmarshal([]byte(old), received); err != nil {

--- a/proto/encode_test.go
+++ b/proto/encode_test.go
@@ -73,8 +73,8 @@ func BenchmarkAny(b *testing.B) {
 	}
 }
 
-// BenchmarkEmpy measures the overhead of doing the minimal possible encode.
-func BenchmarkEmpy(b *testing.B) {
+// BenchmarkEmpty measures the overhead of doing the minimal possible encode.
+func BenchmarkEmpty(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		raw, err := proto.Marshal(&tpb.Message{})
 		if err != nil {

--- a/proto/extensions_test.go
+++ b/proto/extensions_test.go
@@ -590,7 +590,7 @@ func TestUnmarshalRepeatingNonRepeatedExtension(t *testing.T) {
 		var want pb.ComplexExtension
 
 		// Generate a serialized representation of a repeated extension
-		// by catenating bytes together.
+		// by concatenating bytes together.
 		for i, e := range test.ext {
 			// Merge to create the wanted proto.
 			proto.Merge(&want, e)

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -393,7 +393,7 @@ func (p *Buffer) Bytes() []byte { return p.buf }
 // than relying on this API.
 //
 // If deterministic serialization is requested, map entries will be sorted
-// by keys in lexographical order. This is an implementation detail and
+// by keys in lexicographical order. This is an implementation detail and
 // subject to change.
 func (p *Buffer) SetDeterministic(deterministic bool) {
 	p.deterministic = deterministic

--- a/proto/map_test.go
+++ b/proto/map_test.go
@@ -32,7 +32,7 @@ func TestMap(t *testing.T) {
 	}
 }
 
-func marshalled() []byte {
+func marshaled() []byte {
 	m := &ppb.IntMaps{}
 	for i := 0; i < 1000; i++ {
 		m.Maps = append(m.Maps, &ppb.IntMap{
@@ -47,7 +47,7 @@ func marshalled() []byte {
 }
 
 func BenchmarkConcurrentMapUnmarshal(b *testing.B) {
-	in := marshalled()
+	in := marshaled()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			var out ppb.IntMaps
@@ -59,7 +59,7 @@ func BenchmarkConcurrentMapUnmarshal(b *testing.B) {
 }
 
 func BenchmarkSequentialMapUnmarshal(b *testing.B) {
-	in := marshalled()
+	in := marshaled()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var out ppb.IntMaps

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2062,7 +2062,7 @@ func (g *Generator) generateInternalStructFields(mc *msgCtx, topLevelFields []to
 
 }
 
-// generateOneofFuncs adds all the utility functions for oneof, including marshalling, unmarshalling and sizer.
+// generateOneofFuncs adds all the utility functions for oneof, including marshaling, unmarshaling and sizer.
 func (g *Generator) generateOneofFuncs(mc *msgCtx, topLevelFields []topLevelField) {
 	ofields := []*oneofField{}
 	for _, f := range topLevelFields {

--- a/protoc-gen-go/generator/internal/remap/remap.go
+++ b/protoc-gen-go/generator/internal/remap/remap.go
@@ -47,7 +47,7 @@ type Location struct {
 }
 
 // A Map represents a mapping between token locations in an input source text
-// and locations in the correspnding output text.
+// and locations in the corresponding output text.
 type Map map[Location]Location
 
 // Find reports whether the specified span is recorded by m, and if so returns

--- a/protoc-gen-go/grpc/grpc.go
+++ b/protoc-gen-go/grpc/grpc.go
@@ -226,7 +226,7 @@ func (g *grpc) generateService(file *generator.FileDescriptor, service *pb.Servi
 	g.P("}")
 	g.P()
 
-	// Server Unimplemented struct for forward compatability.
+	// Server Unimplemented struct for forward compatibility.
 	if deprecated {
 		g.P(deprecationComment)
 	}

--- a/protoc-gen-go/testdata/import_public_test.go
+++ b/protoc-gen-go/testdata/import_public_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func TestImportPublicLink(t *testing.T) {
-	// mainpb.[ME] should be interchangable with subpb.[ME].
+	// mainpb.[ME] should be interchangeable with subpb.[ME].
 	var _ mainpb.M = subpb.M{}
 	var _ mainpb.E = subpb.E(0)
 	_ = &mainpb.Public{


### PR DESCRIPTION
Golang code usually used `marshal` instead of `marshall`.