### PR TITLE
protoc-gen-go/generator: removed superfluous case from switch statement

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2264,7 +2264,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 			of := oneofField{
 				fieldCommon: fieldCommon{
 					goName:     fname,
-					getterName: "Get"+fname,
+					getterName: "Get" + fname,
 					goType:     dname,
 					tags:       tag,
 					protoName:  odp.GetName(),

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1997,7 +1997,6 @@ func (g *Generator) generateDefaultConstants(mc *msgCtx, topLevelFields []topLev
 		}
 		kind := "const "
 		switch {
-		case typename == "bool":
 		case typename == "string":
 			def = strconv.Quote(def)
 		case typename == "[]byte":


### PR DESCRIPTION
Removed an unused case, applied go fmt. 