### PR TITLE
Fix duplicated indent for map

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -587,7 +587,6 @@ func (m *Marshaler) marshalValue(out *errWriter, prop *proto.Properties, v refle
 				out.write("\n")
 				out.write(indent)
 				out.write(m.Indent)
-				out.write(m.Indent)
 			}
 
 			// TODO handle map key prop properly


### PR DESCRIPTION
If a filed value is a map, the format of the print is wrong.

![image](https://user-images.githubusercontent.com/7303612/67751334-e3b14100-fa6b-11e9-968b-79557657800b.png)
