### PR TITLE
Fix edge case, where JSONName is equal

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1552,7 +1552,7 @@ func (g *Generator) goTag(message *Descriptor, field *descriptor.FieldDescriptor
 			name = name[i+1:]
 		}
 	}
-	if json := field.GetJsonName(); field.Extendee == nil && json != "" && json != name {
+	if json := field.GetJsonName(); field.Extendee == nil && json != "" {
 		// TODO: escaping might be needed, in which case
 		// perhaps this should be in its own "json" tag.
 		name += ",json=" + json


### PR DESCRIPTION
jsonpb handles json names specially. To keep this handling uniform, it is necessary to write JSONName in any case.

Example:
```
/* json=street_foo needs to be inserted, so that jsonpb.Marshaller.Marshal produced street_foo
   Omitting json means it will produce streetFoo
*/
string street_foo = 9 [json_name="street_foo"];
```