### PR TITLE
proto: optimize global (un)marshal lock using RWMutex

### DIFF
--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -106,11 +106,12 @@ func getMarshalInfo(t reflect.Type) *marshalInfo {
 		return u
 	}
 	marshalInfoLock.Lock()
-	// We don't need double check here.
-	// Only a little allocation will be introduced in parallel.
-	u = &marshalInfo{typ: t}
-	marshalInfoMap[t] = u
-	marshalInfoLock.Unlock()
+	defer marshalInfoLock.Unlock()
+	u, ok = marshalInfoMap[t]
+	if !ok {
+		u = &marshalInfo{typ: t}
+		marshalInfoMap[t] = u
+	}
 	return u
 }
 

--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -92,19 +92,24 @@ type marshalElemInfo struct {
 
 var (
 	marshalInfoMap  = map[reflect.Type]*marshalInfo{}
-	marshalInfoLock sync.Mutex
+	marshalInfoLock sync.RWMutex
 )
 
 // getMarshalInfo returns the information to marshal a given type of message.
 // The info it returns may not necessarily initialized.
 // t is the type of the message (NOT the pointer to it).
 func getMarshalInfo(t reflect.Type) *marshalInfo {
-	marshalInfoLock.Lock()
+	marshalInfoLock.RLock()
 	u, ok := marshalInfoMap[t]
-	if !ok {
-		u = &marshalInfo{typ: t}
-		marshalInfoMap[t] = u
+	marshalInfoLock.RUnlock()
+	if ok {
+		return u
 	}
+	marshalInfoLock.Lock()
+	// We don't need double check here.
+	// Only a little allocation will be introduced in parallel.
+	u = &marshalInfo{typ: t}
+	marshalInfoMap[t] = u
 	marshalInfoLock.Unlock()
 	return u
 }

--- a/proto/table_unmarshal.go
+++ b/proto/table_unmarshal.go
@@ -122,12 +122,13 @@ func getUnmarshalInfo(t reflect.Type) *unmarshalInfo {
 	}
 	unmarshalInfoLock.Lock()
 	defer unmarshalInfoLock.Unlock()
-	// We don't need double check here.
-	// Only a little allocation will be introduced in parallel.
-	u = &unmarshalInfo{typ: t}
-	// Note: we just set the type here. The rest of the fields
-	// will be initialized on first use.
-	unmarshalInfoMap[t] = u
+	u, ok = unmarshalInfoMap[t]
+	if !ok {
+		u = &unmarshalInfo{typ: t}
+		// Note: we just set the type here. The rest of the fields
+		// will be initialized on first use.
+		unmarshalInfoMap[t] = u
+	}
 	return u
 }
 


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

Thie PR Use `RWMutex` to optimize `getMarshalInfo` and `getUnmarshalInfo`, for these functions, only n (number of message type) will hit Write, and m(number of message) - n will hit Read, it's the best case to use RWMutex instead of Mutex.

This optimization introduce huge improvement in our scenario.

We have 1000 worker and 1 controller, and work and controller keep heartbeat with gRPC. They also exchange the job info with each other.

The message is like

```proto
message Job {
    uint64 job_id = 1;
    // Some other info
}

message Heartbeat {
    repeated Job jobs = 1;
}
```

About 10000 jobs in every Heartbeat, and the heartbeat QPS in controller is about 1000.

The controller handle the Heartbeat in about 10ms, and the network latency is about 10ms, but the client will use about 30s in maximum to finish a RPC call.

We use golang pprof block profile, and it seems that almost all block is caused by one global Mutex in protobuf package.

![image](https://user-images.githubusercontent.com/9161438/71443720-9c7fbd80-2747-11ea-9a35-1e6806984275.png)

After optimization, in our use case, the rpc call from client will only use about 30ms, as our expected.
