### PR TITLE
generate json tags for oneof fields

### DIFF
--- a/jsonpb/jsonpb_test_proto/test_objects.pb.go
+++ b/jsonpb/jsonpb_test_proto/test_objects.pb.go
@@ -586,7 +586,7 @@ type MsgWithOneof struct {
 	//	*MsgWithOneof_Country
 	//	*MsgWithOneof_HomeAddress
 	//	*MsgWithOneof_MsgWithRequired
-	Union                isMsgWithOneof_Union `protobuf_oneof:"union"`
+	Union                isMsgWithOneof_Union `protobuf_oneof:"union" json:"union"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`
@@ -622,23 +622,23 @@ type isMsgWithOneof_Union interface {
 }
 
 type MsgWithOneof_Title struct {
-	Title string `protobuf:"bytes,1,opt,name=title,oneof"`
+	Title string `protobuf:"bytes,1,opt,name=title,oneof" json:"title"`
 }
 
 type MsgWithOneof_Salary struct {
-	Salary int64 `protobuf:"varint,2,opt,name=salary,oneof"`
+	Salary int64 `protobuf:"varint,2,opt,name=salary,oneof" json:"salary"`
 }
 
 type MsgWithOneof_Country struct {
-	Country string `protobuf:"bytes,3,opt,name=Country,oneof"`
+	Country string `protobuf:"bytes,3,opt,name=Country,oneof" json:"Country"`
 }
 
 type MsgWithOneof_HomeAddress struct {
-	HomeAddress string `protobuf:"bytes,4,opt,name=home_address,json=homeAddress,oneof"`
+	HomeAddress string `protobuf:"bytes,4,opt,name=home_address,json=homeAddress,oneof" json:"home_address"`
 }
 
 type MsgWithOneof_MsgWithRequired struct {
-	MsgWithRequired *MsgWithRequired `protobuf:"bytes,5,opt,name=msg_with_required,json=msgWithRequired,oneof"`
+	MsgWithRequired *MsgWithRequired `protobuf:"bytes,5,opt,name=msg_with_required,json=msgWithRequired,oneof" json:"msg_with_required"`
 }
 
 func (*MsgWithOneof_Title) isMsgWithOneof_Union() {}

--- a/proto/proto3_proto/proto3.pb.go
+++ b/proto/proto3_proto/proto3.pb.go
@@ -405,7 +405,7 @@ type TestUTF8 struct {
 	Vector []string `protobuf:"bytes,2,rep,name=vector,proto3" json:"vector,omitempty"`
 	// Types that are valid to be assigned to Oneof:
 	//	*TestUTF8_Field
-	Oneof                isTestUTF8_Oneof `protobuf_oneof:"oneof"`
+	Oneof                isTestUTF8_Oneof `protobuf_oneof:"oneof" json:"oneof"`
 	MapKey               map[string]int64 `protobuf:"bytes,4,rep,name=map_key,json=mapKey,proto3" json:"map_key,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 	MapValue             map[int64]string `protobuf:"bytes,5,rep,name=map_value,json=mapValue,proto3" json:"map_value,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
@@ -457,7 +457,7 @@ type isTestUTF8_Oneof interface {
 }
 
 type TestUTF8_Field struct {
-	Field string `protobuf:"bytes,3,opt,name=field,proto3,oneof"`
+	Field string `protobuf:"bytes,3,opt,name=field,proto3,oneof" json:"field"`
 }
 
 func (*TestUTF8_Field) isTestUTF8_Oneof() {}

--- a/proto/test_proto/test.pb.go
+++ b/proto/test_proto/test.pb.go
@@ -3106,10 +3106,10 @@ type Oneof struct {
 	//	*Oneof_F_Message
 	//	*Oneof_FGroup
 	//	*Oneof_F_Largest_Tag
-	Union isOneof_Union `protobuf_oneof:"union"`
+	Union isOneof_Union `protobuf_oneof:"union" json:"union"`
 	// Types that are valid to be assigned to Tormato:
 	//	*Oneof_Value
-	Tormato              isOneof_Tormato `protobuf_oneof:"tormato"`
+	Tormato              isOneof_Tormato `protobuf_oneof:"tormato" json:"tormato"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
 	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
@@ -3145,71 +3145,71 @@ type isOneof_Union interface {
 }
 
 type Oneof_F_Bool struct {
-	F_Bool bool `protobuf:"varint,1,opt,name=F_Bool,json=FBool,oneof"`
+	F_Bool bool `protobuf:"varint,1,opt,name=F_Bool,json=FBool,oneof" json:"F_Bool"`
 }
 
 type Oneof_F_Int32 struct {
-	F_Int32 int32 `protobuf:"varint,2,opt,name=F_Int32,json=FInt32,oneof"`
+	F_Int32 int32 `protobuf:"varint,2,opt,name=F_Int32,json=FInt32,oneof" json:"F_Int32"`
 }
 
 type Oneof_F_Int64 struct {
-	F_Int64 int64 `protobuf:"varint,3,opt,name=F_Int64,json=FInt64,oneof"`
+	F_Int64 int64 `protobuf:"varint,3,opt,name=F_Int64,json=FInt64,oneof" json:"F_Int64"`
 }
 
 type Oneof_F_Fixed32 struct {
-	F_Fixed32 uint32 `protobuf:"fixed32,4,opt,name=F_Fixed32,json=FFixed32,oneof"`
+	F_Fixed32 uint32 `protobuf:"fixed32,4,opt,name=F_Fixed32,json=FFixed32,oneof" json:"F_Fixed32"`
 }
 
 type Oneof_F_Fixed64 struct {
-	F_Fixed64 uint64 `protobuf:"fixed64,5,opt,name=F_Fixed64,json=FFixed64,oneof"`
+	F_Fixed64 uint64 `protobuf:"fixed64,5,opt,name=F_Fixed64,json=FFixed64,oneof" json:"F_Fixed64"`
 }
 
 type Oneof_F_Uint32 struct {
-	F_Uint32 uint32 `protobuf:"varint,6,opt,name=F_Uint32,json=FUint32,oneof"`
+	F_Uint32 uint32 `protobuf:"varint,6,opt,name=F_Uint32,json=FUint32,oneof" json:"F_Uint32"`
 }
 
 type Oneof_F_Uint64 struct {
-	F_Uint64 uint64 `protobuf:"varint,7,opt,name=F_Uint64,json=FUint64,oneof"`
+	F_Uint64 uint64 `protobuf:"varint,7,opt,name=F_Uint64,json=FUint64,oneof" json:"F_Uint64"`
 }
 
 type Oneof_F_Float struct {
-	F_Float float32 `protobuf:"fixed32,8,opt,name=F_Float,json=FFloat,oneof"`
+	F_Float float32 `protobuf:"fixed32,8,opt,name=F_Float,json=FFloat,oneof" json:"F_Float"`
 }
 
 type Oneof_F_Double struct {
-	F_Double float64 `protobuf:"fixed64,9,opt,name=F_Double,json=FDouble,oneof"`
+	F_Double float64 `protobuf:"fixed64,9,opt,name=F_Double,json=FDouble,oneof" json:"F_Double"`
 }
 
 type Oneof_F_String struct {
-	F_String string `protobuf:"bytes,10,opt,name=F_String,json=FString,oneof"`
+	F_String string `protobuf:"bytes,10,opt,name=F_String,json=FString,oneof" json:"F_String"`
 }
 
 type Oneof_F_Bytes struct {
-	F_Bytes []byte `protobuf:"bytes,11,opt,name=F_Bytes,json=FBytes,oneof"`
+	F_Bytes []byte `protobuf:"bytes,11,opt,name=F_Bytes,json=FBytes,oneof" json:"F_Bytes"`
 }
 
 type Oneof_F_Sint32 struct {
-	F_Sint32 int32 `protobuf:"zigzag32,12,opt,name=F_Sint32,json=FSint32,oneof"`
+	F_Sint32 int32 `protobuf:"zigzag32,12,opt,name=F_Sint32,json=FSint32,oneof" json:"F_Sint32"`
 }
 
 type Oneof_F_Sint64 struct {
-	F_Sint64 int64 `protobuf:"zigzag64,13,opt,name=F_Sint64,json=FSint64,oneof"`
+	F_Sint64 int64 `protobuf:"zigzag64,13,opt,name=F_Sint64,json=FSint64,oneof" json:"F_Sint64"`
 }
 
 type Oneof_F_Enum struct {
-	F_Enum MyMessage_Color `protobuf:"varint,14,opt,name=F_Enum,json=FEnum,enum=test_proto.MyMessage_Color,oneof"`
+	F_Enum MyMessage_Color `protobuf:"varint,14,opt,name=F_Enum,json=FEnum,enum=test_proto.MyMessage_Color,oneof" json:"F_Enum"`
 }
 
 type Oneof_F_Message struct {
-	F_Message *GoTestField `protobuf:"bytes,15,opt,name=F_Message,json=FMessage,oneof"`
+	F_Message *GoTestField `protobuf:"bytes,15,opt,name=F_Message,json=FMessage,oneof" json:"F_Message"`
 }
 
 type Oneof_FGroup struct {
-	FGroup *Oneof_F_Group `protobuf:"group,16,opt,name=F_Group,json=fGroup,oneof"`
+	FGroup *Oneof_F_Group `protobuf:"group,16,opt,name=F_Group,json=fGroup,oneof" json:"f_group"`
 }
 
 type Oneof_F_Largest_Tag struct {
-	F_Largest_Tag int32 `protobuf:"varint,536870911,opt,name=F_Largest_Tag,json=FLargestTag,oneof"`
+	F_Largest_Tag int32 `protobuf:"varint,536870911,opt,name=F_Largest_Tag,json=FLargestTag,oneof" json:"F_Largest_Tag"`
 }
 
 func (*Oneof_F_Bool) isOneof_Union() {}
@@ -3377,7 +3377,7 @@ type isOneof_Tormato interface {
 }
 
 type Oneof_Value struct {
-	Value int32 `protobuf:"varint,100,opt,name=value,oneof"`
+	Value int32 `protobuf:"varint,100,opt,name=value,oneof" json:"value"`
 }
 
 func (*Oneof_Value) isOneof_Tormato() {}
@@ -3470,7 +3470,7 @@ type Communique struct {
 	//	*Communique_TempC
 	//	*Communique_Col
 	//	*Communique_Msg
-	Union                isCommunique_Union `protobuf_oneof:"union"`
+	Union                isCommunique_Union `protobuf_oneof:"union" json:"union"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -3513,27 +3513,27 @@ type isCommunique_Union interface {
 }
 
 type Communique_Number struct {
-	Number int32 `protobuf:"varint,5,opt,name=number,oneof"`
+	Number int32 `protobuf:"varint,5,opt,name=number,oneof" json:"number"`
 }
 
 type Communique_Name struct {
-	Name string `protobuf:"bytes,6,opt,name=name,oneof"`
+	Name string `protobuf:"bytes,6,opt,name=name,oneof" json:"name"`
 }
 
 type Communique_Data struct {
-	Data []byte `protobuf:"bytes,7,opt,name=data,oneof"`
+	Data []byte `protobuf:"bytes,7,opt,name=data,oneof" json:"data"`
 }
 
 type Communique_TempC struct {
-	TempC float64 `protobuf:"fixed64,8,opt,name=temp_c,json=tempC,oneof"`
+	TempC float64 `protobuf:"fixed64,8,opt,name=temp_c,json=tempC,oneof" json:"temp_c"`
 }
 
 type Communique_Col struct {
-	Col MyMessage_Color `protobuf:"varint,9,opt,name=col,enum=test_proto.MyMessage_Color,oneof"`
+	Col MyMessage_Color `protobuf:"varint,9,opt,name=col,enum=test_proto.MyMessage_Color,oneof" json:"col"`
 }
 
 type Communique_Msg struct {
-	Msg *Strings `protobuf:"bytes,10,opt,name=msg,oneof"`
+	Msg *Strings `protobuf:"bytes,10,opt,name=msg,oneof" json:"msg"`
 }
 
 func (*Communique_Number) isCommunique_Union() {}
@@ -3614,7 +3614,7 @@ type TestUTF8 struct {
 	Vector []string `protobuf:"bytes,2,rep,name=vector" json:"vector,omitempty"`
 	// Types that are valid to be assigned to Oneof:
 	//	*TestUTF8_Field
-	Oneof                isTestUTF8_Oneof `protobuf_oneof:"oneof"`
+	Oneof                isTestUTF8_Oneof `protobuf_oneof:"oneof" json:"oneof"`
 	MapKey               map[string]int64 `protobuf:"bytes,4,rep,name=map_key,json=mapKey" json:"map_key,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	MapValue             map[int64]string `protobuf:"bytes,5,rep,name=map_value,json=mapValue" json:"map_value,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
@@ -3666,7 +3666,7 @@ type isTestUTF8_Oneof interface {
 }
 
 type TestUTF8_Field struct {
-	Field string `protobuf:"bytes,3,opt,name=field,oneof"`
+	Field string `protobuf:"bytes,3,opt,name=field,oneof" json:"field"`
 }
 
 func (*TestUTF8_Field) isTestUTF8_Oneof() {}

--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -2261,10 +2261,11 @@ func (g *Generator) generateMessage(message *Descriptor) {
 
 			dname := "is" + goTypeName + "_" + fname
 			tag := `protobuf_oneof:"` + odp.GetName() + `"`
+			tag += ` json:"` + odp.GetName() + `"`
 			of := oneofField{
 				fieldCommon: fieldCommon{
 					goName:     fname,
-					getterName: "Get"+fname,
+					getterName: "Get" + fname,
 					goType:     dname,
 					tags:       tag,
 					protoName:  odp.GetName(),
@@ -2339,6 +2340,7 @@ func (g *Generator) generateMessage(message *Descriptor) {
 
 			oneofField := oFields[*field.OneofIndex]
 			tag := "protobuf:" + g.goTag(message, field, wiretype)
+			tag += ` json:"` + field.GetName() + `"`
 			sf := oneofSubField{
 				fieldCommon: fieldCommon{
 					goName:     fieldName,

--- a/protoc-gen-go/testdata/deprecated/deprecated.pb.go
+++ b/protoc-gen-go/testdata/deprecated/deprecated.pb.go
@@ -91,7 +91,7 @@ type DeprecatedResponse struct {
 	//
 	// Types that are valid to be assigned to DeprecatedOneof:
 	//	*DeprecatedResponse_DeprecatedOneofField
-	DeprecatedOneof      isDeprecatedResponse_DeprecatedOneof `protobuf_oneof:"deprecated_oneof"`
+	DeprecatedOneof      isDeprecatedResponse_DeprecatedOneof `protobuf_oneof:"deprecated_oneof" json:"deprecated_oneof"`
 	XXX_NoUnkeyedLiteral struct{}                             `json:"-"`
 	XXX_unrecognized     []byte                               `json:"-"`
 	XXX_sizecache        int32                                `json:"-"`
@@ -135,7 +135,7 @@ type isDeprecatedResponse_DeprecatedOneof interface {
 }
 
 type DeprecatedResponse_DeprecatedOneofField struct {
-	DeprecatedOneofField string `protobuf:"bytes,2,opt,name=deprecated_oneof_field,json=deprecatedOneofField,proto3,oneof"`
+	DeprecatedOneofField string `protobuf:"bytes,2,opt,name=deprecated_oneof_field,json=deprecatedOneofField,proto3,oneof" json:"deprecated_oneof_field"`
 }
 
 func (*DeprecatedResponse_DeprecatedOneofField) isDeprecatedResponse_DeprecatedOneof() {}

--- a/protoc-gen-go/testdata/import_public/sub/a.pb.go
+++ b/protoc-gen-go/testdata/import_public/sub/a.pb.go
@@ -137,7 +137,7 @@ type M struct {
 	// Types that are valid to be assigned to OneofField:
 	//	*M_OneofInt32
 	//	*M_OneofInt64
-	OneofField           isM_OneofField `protobuf_oneof:"oneof_field"`
+	OneofField           isM_OneofField `protobuf_oneof:"oneof_field" json:"oneof_field"`
 	Grouping             *M_Grouping    `protobuf:"group,4,opt,name=Grouping,json=grouping" json:"grouping,omitempty"`
 	DefaultField         *string        `protobuf:"bytes,6,opt,name=default_field,json=defaultField,def=def" json:"default_field,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
@@ -184,11 +184,11 @@ type isM_OneofField interface {
 }
 
 type M_OneofInt32 struct {
-	OneofInt32 int32 `protobuf:"varint,2,opt,name=oneof_int32,json=oneofInt32,oneof"`
+	OneofInt32 int32 `protobuf:"varint,2,opt,name=oneof_int32,json=oneofInt32,oneof" json:"oneof_int32"`
 }
 
 type M_OneofInt64 struct {
-	OneofInt64 int64 `protobuf:"varint,3,opt,name=oneof_int64,json=oneofInt64,oneof"`
+	OneofInt64 int64 `protobuf:"varint,3,opt,name=oneof_int64,json=oneofInt64,oneof" json:"oneof_int64"`
 }
 
 func (*M_OneofInt32) isM_OneofField() {}
@@ -281,7 +281,7 @@ type M_Submessage struct {
 	// Types that are valid to be assigned to SubmessageOneofField:
 	//	*M_Submessage_SubmessageOneofInt32
 	//	*M_Submessage_SubmessageOneofInt64
-	SubmessageOneofField isM_Submessage_SubmessageOneofField `protobuf_oneof:"submessage_oneof_field"`
+	SubmessageOneofField isM_Submessage_SubmessageOneofField `protobuf_oneof:"submessage_oneof_field" json:"submessage_oneof_field"`
 	XXX_NoUnkeyedLiteral struct{}                            `json:"-"`
 	XXX_unrecognized     []byte                              `json:"-"`
 	XXX_sizecache        int32                               `json:"-"`
@@ -317,11 +317,11 @@ type isM_Submessage_SubmessageOneofField interface {
 }
 
 type M_Submessage_SubmessageOneofInt32 struct {
-	SubmessageOneofInt32 int32 `protobuf:"varint,1,opt,name=submessage_oneof_int32,json=submessageOneofInt32,oneof"`
+	SubmessageOneofInt32 int32 `protobuf:"varint,1,opt,name=submessage_oneof_int32,json=submessageOneofInt32,oneof" json:"submessage_oneof_int32"`
 }
 
 type M_Submessage_SubmessageOneofInt64 struct {
-	SubmessageOneofInt64 int64 `protobuf:"varint,2,opt,name=submessage_oneof_int64,json=submessageOneofInt64,oneof"`
+	SubmessageOneofInt64 int64 `protobuf:"varint,2,opt,name=submessage_oneof_int64,json=submessageOneofInt64,oneof" json:"submessage_oneof_int64"`
 }
 
 func (*M_Submessage_SubmessageOneofInt32) isM_Submessage_SubmessageOneofField() {}

--- a/protoc-gen-go/testdata/issue780_oneof_conflict/test.pb.go
+++ b/protoc-gen-go/testdata/issue780_oneof_conflict/test.pb.go
@@ -23,7 +23,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 type Foo struct {
 	// Types that are valid to be assigned to Bar:
 	//	*Foo_GetBar
-	Bar                  isFoo_Bar `protobuf_oneof:"bar"`
+	Bar                  isFoo_Bar `protobuf_oneof:"bar" json:"bar"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -59,7 +59,7 @@ type isFoo_Bar interface {
 }
 
 type Foo_GetBar struct {
-	GetBar string `protobuf:"bytes,1,opt,name=get_bar,json=getBar,oneof"`
+	GetBar string `protobuf:"bytes,1,opt,name=get_bar,json=getBar,oneof" json:"get_bar"`
 }
 
 func (*Foo_GetBar) isFoo_Bar() {}

--- a/protoc-gen-go/testdata/my_test/test.pb.go
+++ b/protoc-gen-go/testdata/my_test/test.pb.go
@@ -713,7 +713,7 @@ type Communique struct {
 	//	*Communique_Delta_
 	//	*Communique_Msg
 	//	*Communique_Somegroup
-	Union                isCommunique_Union `protobuf_oneof:"union"`
+	Union                isCommunique_Union `protobuf_oneof:"union" json:"union"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -756,43 +756,43 @@ type isCommunique_Union interface {
 }
 
 type Communique_Number struct {
-	Number int32 `protobuf:"varint,5,opt,name=number,oneof"`
+	Number int32 `protobuf:"varint,5,opt,name=number,oneof" json:"number"`
 }
 
 type Communique_Name struct {
-	Name string `protobuf:"bytes,6,opt,name=name,oneof"`
+	Name string `protobuf:"bytes,6,opt,name=name,oneof" json:"name"`
 }
 
 type Communique_Data struct {
-	Data []byte `protobuf:"bytes,7,opt,name=data,oneof"`
+	Data []byte `protobuf:"bytes,7,opt,name=data,oneof" json:"data"`
 }
 
 type Communique_TempC struct {
-	TempC float64 `protobuf:"fixed64,8,opt,name=temp_c,json=tempC,oneof"`
+	TempC float64 `protobuf:"fixed64,8,opt,name=temp_c,json=tempC,oneof" json:"temp_c"`
 }
 
 type Communique_Height struct {
-	Height float32 `protobuf:"fixed32,9,opt,name=height,oneof"`
+	Height float32 `protobuf:"fixed32,9,opt,name=height,oneof" json:"height"`
 }
 
 type Communique_Today struct {
-	Today Days `protobuf:"varint,10,opt,name=today,enum=my.test.Days,oneof"`
+	Today Days `protobuf:"varint,10,opt,name=today,enum=my.test.Days,oneof" json:"today"`
 }
 
 type Communique_Maybe struct {
-	Maybe bool `protobuf:"varint,11,opt,name=maybe,oneof"`
+	Maybe bool `protobuf:"varint,11,opt,name=maybe,oneof" json:"maybe"`
 }
 
 type Communique_Delta_ struct {
-	Delta int32 `protobuf:"zigzag32,12,opt,name=delta,oneof"`
+	Delta int32 `protobuf:"zigzag32,12,opt,name=delta,oneof" json:"delta"`
 }
 
 type Communique_Msg struct {
-	Msg *Reply `protobuf:"bytes,16,opt,name=msg,oneof"`
+	Msg *Reply `protobuf:"bytes,16,opt,name=msg,oneof" json:"msg"`
 }
 
 type Communique_Somegroup struct {
-	Somegroup *Communique_SomeGroup `protobuf:"group,14,opt,name=SomeGroup,json=somegroup,oneof"`
+	Somegroup *Communique_SomeGroup `protobuf:"group,14,opt,name=SomeGroup,json=somegroup,oneof" json:"somegroup"`
 }
 
 func (*Communique_Number) isCommunique_Union() {}

--- a/ptypes/struct/struct.pb.go
+++ b/ptypes/struct/struct.pb.go
@@ -115,7 +115,7 @@ type Value struct {
 	//	*Value_BoolValue
 	//	*Value_StructValue
 	//	*Value_ListValue
-	Kind                 isValue_Kind `protobuf_oneof:"kind"`
+	Kind                 isValue_Kind `protobuf_oneof:"kind" json:"kind"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -153,27 +153,27 @@ type isValue_Kind interface {
 }
 
 type Value_NullValue struct {
-	NullValue NullValue `protobuf:"varint,1,opt,name=null_value,json=nullValue,proto3,enum=google.protobuf.NullValue,oneof"`
+	NullValue NullValue `protobuf:"varint,1,opt,name=null_value,json=nullValue,proto3,enum=google.protobuf.NullValue,oneof" json:"null_value"`
 }
 
 type Value_NumberValue struct {
-	NumberValue float64 `protobuf:"fixed64,2,opt,name=number_value,json=numberValue,proto3,oneof"`
+	NumberValue float64 `protobuf:"fixed64,2,opt,name=number_value,json=numberValue,proto3,oneof" json:"number_value"`
 }
 
 type Value_StringValue struct {
-	StringValue string `protobuf:"bytes,3,opt,name=string_value,json=stringValue,proto3,oneof"`
+	StringValue string `protobuf:"bytes,3,opt,name=string_value,json=stringValue,proto3,oneof" json:"string_value"`
 }
 
 type Value_BoolValue struct {
-	BoolValue bool `protobuf:"varint,4,opt,name=bool_value,json=boolValue,proto3,oneof"`
+	BoolValue bool `protobuf:"varint,4,opt,name=bool_value,json=boolValue,proto3,oneof" json:"bool_value"`
 }
 
 type Value_StructValue struct {
-	StructValue *Struct `protobuf:"bytes,5,opt,name=struct_value,json=structValue,proto3,oneof"`
+	StructValue *Struct `protobuf:"bytes,5,opt,name=struct_value,json=structValue,proto3,oneof" json:"struct_value"`
 }
 
 type Value_ListValue struct {
-	ListValue *ListValue `protobuf:"bytes,6,opt,name=list_value,json=listValue,proto3,oneof"`
+	ListValue *ListValue `protobuf:"bytes,6,opt,name=list_value,json=listValue,proto3,oneof" json:"list_value"`
 }
 
 func (*Value_NullValue) isValue_Kind() {}


### PR DESCRIPTION
While protoc-gen-go generates JSON tags for most message structure members, it
does not do so when the member represent a oneof construct or when the
structure represent an element of a oneof member.

This means that programs using encoding/json instead of jsonpb will end up
with incoherent names which do not match the name of the Protobuf fields. They
will also be impredictable due to alternate names used to avoid collisions or
syntax errors.

Adding these tags makes the generated code coherent.