### PR TITLE
internal/cmd/generate-alias: fix generator for lacking go_package options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.9
 
 require (
 	github.com/google/go-cmp v0.4.0
-	google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967
+	google.golang.org/protobuf v1.20.2-0.20200320194150-9d397869d892
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
+github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
@@ -10,5 +11,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
-google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967 h1:DwkfSP6tZMxKX50J0dBSqEgJvJdFYP1Gvzbjtvkmrug=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
+google.golang.org/protobuf v1.20.2-0.20200320194150-9d397869d892 h1:LQPEPzH8usKk01hUU5qdXb17Tgjr/BLZhHy1h90Vd7U=
+google.golang.org/protobuf v1.20.2-0.20200320194150-9d397869d892/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=


### PR DESCRIPTION
In https://golang.org/cl/219598, we removed patching the well-known types
with an explicit go_package option and instead relied on M flags.
The lack of updated go_package options broke generate-alias since it
appears as if the import public is trying to alias Go identifiers
within the same Go package (thus generating nothing).

We fix generate-alias by replicating the same approach here,
where we construct the M flag mapping and pass it to protoc-gen-go.