### PR TITLE
jsonpb: fix a confusing error message

### DIFF
--- a/jsonpb/decode.go
+++ b/jsonpb/decode.go
@@ -474,7 +474,7 @@ func (u *Unmarshaler) unmarshalSingularValue(v protoreflect.Value, in []byte, fd
 		if hasPrefixAndSuffix('"', in, '"') {
 			vd := fd.Enum().Values().ByName(protoreflect.Name(trimQuote(in)))
 			if vd == nil {
-				return v, fmt.Errorf("unknown value %v for enum %s", in, fd.Enum().FullName())
+				return v, fmt.Errorf("unknown value %q for enum %s", in, fd.Enum().FullName())
 			}
 			return protoreflect.ValueOfEnum(vd.Number()), nil
 		}


### PR DESCRIPTION
Because `in` is a []byte, as written this prints a list of integers instead of the unrecognized enum value.