### PR TITLE
Removed import prefix to default import of golang/protobuf/proto

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -1300,7 +1300,7 @@ func (g *Generator) generateImports() {
 	g.P("import (")
 	g.P(g.Pkg["fmt"] + ` "fmt"`)
 	g.P(g.Pkg["math"] + ` "math"`)
-	g.P(g.Pkg["proto"]+" ", GoImportPath(g.ImportPrefix)+"github.com/golang/protobuf/proto")
+	g.P(g.Pkg["proto"]+" ", "github.com/golang/protobuf/proto")
 	for importPath, packageName := range imports {
 		g.P(packageName, " ", GoImportPath(g.ImportPrefix)+importPath)
 	}


### PR DESCRIPTION
The existing code creates immediately broken code when trying to setup go module prefix.

Say I have a go module named `example.com/proto` in my repository which coincides with the local directory `/git/website/src/proto`.

My proto file:
```proto
syntax = "proto3";

import "proto/bar.proto";

package foo;

message Foo{
  bar.Bar b = 1;
}
```

I compile this file with:

```bash
protoc --proto_path=/git/website/src/--go_out=import_prefix=example.com/proto/ ./src/proto/messages/foo.proto
```

I get this set of `.pb.go` imports which are partially correct and partially broken.

```go
package messages

import (
	bar "example.com/proto/bar"
	proto "example.com/proto/github.com/golang/protobuf/proto" 
	fmt "fmt"
	math "math"
)
...
```

This fixes that. I can't imagine a reason to prefix `github.com/golang/protobuf/proto`.

PTAL!

Sam