### PR TITLE
proto.ExtensionDescs silently drops some extensions

### DIFF
--- a/proto/extensions.go
+++ b/proto/extensions.go
@@ -287,9 +287,8 @@ func ExtensionDescs(m Message) ([]*ExtensionDesc, error) {
 	mr.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
 		if fd.IsExtension() {
 			xt := fd.(protoreflect.ExtensionTypeDescriptor)
-			if xd, ok := xt.Type().(*ExtensionDesc); ok {
-				extDescs[fd.Number()] = xd
-			}
+			xd, _ := xt.Type().(*ExtensionDesc)
+			extDescs[fd.Number()] = xd
 		}
 		return true
 	})


### PR DESCRIPTION
The `ExtensionDescs` is spec'ed to return "unknown extensions". The implementation will return unknown extensions from the `[]byte` unrecognized fields, but it just ignores unknown extensions that are actually in the extension map.

This fixes that so it correctly returns _all_ extensions, including all unknown ones.