### PR TITLE
proto: convert integer to rune before converting to string

### DIFF
--- a/proto/text_decode.go
+++ b/proto/text_decode.go
@@ -765,7 +765,7 @@ func unescape(s string) (ch string, tail string, err error) {
 		if i > utf8.MaxRune {
 			return "", "", fmt.Errorf(`\%c%s is not a valid Unicode code point`, r, ss)
 		}
-		return string(i), s, nil
+		return string(rune(i)), s, nil
 	}
 	return "", "", fmt.Errorf(`unknown escape \%c`, r)
 }


### PR DESCRIPTION
Go 1.15 introduced a new `go vet` warning (https://golang.org/doc/go1.15#vet) for conversions of the form `string(x)` where `x` is an integer type other than `rune` or `byte`. This warning is enabled by default when running `go test`. As a consequence, running `go test github.com/golang/protobuf/proto` results in a build failure prior to this commit.

Fixes #1209.