### PR TITLE
all: rely on protodesc.ToFileDescriptorProto

### DIFF
--- a/descriptor/descriptor.go
+++ b/descriptor/descriptor.go
@@ -79,14 +79,9 @@ func deriveRawDescriptor(d protoreflect.Descriptor) ([]byte, []int) {
 	}
 
 	// Obtain the raw file descriptor.
-	var raw []byte
-	switch fd := d.(type) {
-	case interface{ ProtoLegacyRawDesc() []byte }:
-		raw = fd.ProtoLegacyRawDesc()
-	case protoreflect.FileDescriptor:
-		raw, _ = proto.Marshal(protodesc.ToFileDescriptorProto(fd))
-	}
-	file := protoimpl.X.CompressGZIP(raw)
+	fd := d.(protoreflect.FileDescriptor)
+	b, _ := proto.Marshal(protodesc.ToFileDescriptorProto(fd))
+	file := protoimpl.X.CompressGZIP(b)
 
 	// Reverse the indexes, since we populated it in reverse.
 	for i, j := 0, len(idxs)-1; i < j; i, j = i+1, j-1 {

--- a/proto/registry.go
+++ b/proto/registry.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/runtime/protoimpl"
@@ -62,14 +63,7 @@ func FileDescriptor(s filePath) fileDescGZIP {
 	// Find the descriptor in the v2 registry.
 	var b []byte
 	if fd, _ := protoregistry.GlobalFiles.FindFileByPath(s); fd != nil {
-		if fd, ok := fd.(interface{ ProtoLegacyRawDesc() []byte }); ok {
-			b = fd.ProtoLegacyRawDesc()
-		} else {
-			// TODO: Use protodesc.ToFileDescriptorProto to construct
-			// a descriptorpb.FileDescriptorProto and marshal it.
-			// However, doing so causes the proto package to have a dependency
-			// on descriptorpb, leading to cyclic dependency issues.
-		}
+		b, _ = Marshal(protodesc.ToFileDescriptorProto(fd))
 	}
 
 	// Locally cache the raw descriptor form for the file.


### PR DESCRIPTION
Use protodesc.ToFileDescriptorProto to retrieve the raw descriptors
for legacy support instead of the undocumented ProtoLegacyRawDesc method
that we expect the newer module to provide.

This change will cause the legacy proto package to incur a dependency
on the descriptorpb package.