### PR TITLE
jsonpb: Fix marshaling of Duration with negative nanoseconds.

### DIFF
--- a/jsonpb/encode.go
+++ b/jsonpb/encode.go
@@ -176,10 +176,11 @@ func (w *jsonWriter) marshalMessage(m protoreflect.Message, indent, typeURL stri
 		if (s > 0 && ns < 0) || (s < 0 && ns > 0) {
 			return errors.New("signs of seconds and nanos do not match")
 		}
-		if s < 0 {
-			ns = -ns
+		var sign string
+		if s < 0 || ns < 0 {
+			sign, s, ns = "-", -1*s, -1*ns
 		}
-		x := fmt.Sprintf("%d.%09d", s, ns)
+		x := fmt.Sprintf("%s%d.%09d", sign, s, ns)
 		x = strings.TrimSuffix(x, "000")
 		x = strings.TrimSuffix(x, "000")
 		x = strings.TrimSuffix(x, ".000")

--- a/jsonpb/json_test.go
+++ b/jsonpb/json_test.go
@@ -452,6 +452,7 @@ var marshalingTests = []struct {
 	{"Duration", marshaler, &pb2.KnownTypes{Dur: &durpb.Duration{Seconds: 3, Nanos: 1e6}}, `{"dur":"3.001s"}`},
 	{"Duration beyond float64 precision", marshaler, &pb2.KnownTypes{Dur: &durpb.Duration{Seconds: 100000000, Nanos: 1}}, `{"dur":"100000000.000000001s"}`},
 	{"negative Duration", marshaler, &pb2.KnownTypes{Dur: &durpb.Duration{Seconds: -123, Nanos: -456}}, `{"dur":"-123.000000456s"}`},
+	{"Duration negative nanos", marshaler, &pb2.KnownTypes{Dur: &durpb.Duration{Nanos: -1}}, `{"dur":"-0.000000001s"}`},
 	{"Struct", marshaler, &pb2.KnownTypes{St: &stpb.Struct{
 		Fields: map[string]*stpb.Value{
 			"one": {Kind: &stpb.Value_StringValue{"loneliest number"}},


### PR DESCRIPTION
Fixes #1219.