### PR TITLE
all: deprecate the module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use the "google.golang.org/protobuf" module instead.
 module github.com/golang/protobuf
 
 go 1.9


### PR DESCRIPTION
Use the new deprecation feature to mark this module as deprecated.
See https://golang.org/issue/40357.

Considerations:
* google.golang.org/protobuf/cmd/protoc-gen-go@v1.25.0 and below
used to generate a hard dependency on github.com/golang/protobuf,
which would be frustrating since it would force an explicit dependency
on a deprecated module. However, that is no longer the case in v1.26.0.
* google.golang.org/protobuf and github.com/golang/protobuf have
a cyclic dependency on each other. However, this should not be a problem
since proposal 40357 only marks direct dependencies in the go.mod file,
rather than all transitive dependencies in the go.sum file.