### PR TITLE
Fix  plugins cover by nil value

### DIFF
--- a/protoc-gen-go/generator/generator.go
+++ b/protoc-gen-go/generator/generator.go
@@ -484,7 +484,7 @@ func (g *Generator) CommandLineParameters(parameter string) {
 			}
 		}
 	}
-	if pluginList != "" {
+	if pluginList != "none" && pluginList != "" {
 		// Amend the set of plugins.
 		enabled := make(map[string]bool)
 		for _, name := range strings.Split(pluginList, "+") {


### PR DESCRIPTION
if plugins was not specified from cli , but specify from third party package import, then empty `nplugins` will cover non-empty `plugins`, this is not correct.
#1349