### PR TITLE
Show that oneof is broken

### DIFF
--- a/jsonpb/json_test.go
+++ b/jsonpb/json_test.go
@@ -742,10 +742,20 @@ var unmarshalingTests = []struct {
 	{"oneof NullValue", Unmarshaler{}, `{"nullValue":null}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_NullValue{stpb.NullValue_NULL_VALUE}}},
 
 	// Country wins.
-	{"oneof two fields", Unmarshaler{}, `{"Country":"Australia","title":"some title"}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_Country{"Australia"}}},
+	{
+		"oneof two fields",
+		Unmarshaler{},
+		`{"Country":"Australia","title":"some title"}`,
+		&pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_Country{"Australia"}},
+	},
 
-	// But now homeAddress wins?
-	{"oneof two fields", Unmarshaler{}, `{"Country":"Australia","homeAddress":"USA"}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_HomeAddress{"USA"}}},
+	// But now homeAddress arbitrarily wins?
+	{
+		"oneof two fields",
+		Unmarshaler{},
+		`{"Country":"Australia","homeAddress":"USA"}`,
+		&pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_HomeAddress{"USA"}},
+	},
 
 	{"orig_name input", Unmarshaler{}, `{"o_bool":true}`, &pb2.Simple{OBool: proto.Bool(true)}},
 	{"camelName input", Unmarshaler{}, `{"oBool":true}`, &pb2.Simple{OBool: proto.Bool(true)}},

--- a/jsonpb/json_test.go
+++ b/jsonpb/json_test.go
@@ -740,6 +740,13 @@ var unmarshalingTests = []struct {
 	{"oneof spec name2", Unmarshaler{}, `{"homeAddress":"Australia"}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_HomeAddress{"Australia"}}},
 	{"oneof orig_name2", Unmarshaler{}, `{"home_address":"Australia"}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_HomeAddress{"Australia"}}},
 	{"oneof NullValue", Unmarshaler{}, `{"nullValue":null}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_NullValue{stpb.NullValue_NULL_VALUE}}},
+
+	// Country wins.
+	{"oneof two fields", Unmarshaler{}, `{"Country":"Australia","title":"some title"}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_Country{"Australia"}}},
+
+	// But now homeAddress wins?
+	{"oneof two fields", Unmarshaler{}, `{"Country":"Australia","homeAddress":"USA"}`, &pb2.MsgWithOneof{Union: &pb2.MsgWithOneof_HomeAddress{"USA"}}},
+
 	{"orig_name input", Unmarshaler{}, `{"o_bool":true}`, &pb2.Simple{OBool: proto.Bool(true)}},
 	{"camelName input", Unmarshaler{}, `{"oBool":true}`, &pb2.Simple{OBool: proto.Bool(true)}},
 


### PR DESCRIPTION
If a JSON object has two fields of the same oneof, one field
arbitrarily wins without any error.