### PR TITLE
proto: make DebugPrint print unknown field

### DIFF
--- a/proto/buffer.go
+++ b/proto/buffer.go
@@ -132,7 +132,7 @@ func (m *unknownFields) ProtoMessage()  { panic("not implemented") }
 func (*Buffer) DebugPrint(s string, b []byte) {
 	m := MessageReflect(new(unknownFields))
 	m.SetUnknown(b)
-	b, _ = prototext.MarshalOptions{AllowPartial: true, Indent: "\t"}.Marshal(m.Interface())
+	b, _ = prototext.MarshalOptions{AllowPartial: true, Indent: "\t", EmitUnknown: true}.Marshal(m.Interface())
 	fmt.Printf("==== %s ====\n%s==== %s ====\n", s, b, s)
 }
 


### PR DESCRIPTION
In `DebugPrint` method, byte slice `b` was set into Message's unknown fields, but the `MarshalOptions` 's field `EmitUnknown` use default value `false`. Actually, the method will print nothing about parameter `b`.